### PR TITLE
Fix graph edge rendering race artifacts and deduplicate edge keys

### DIFF
--- a/frontend/src/components/GraphCanvas.tsx
+++ b/frontend/src/components/GraphCanvas.tsx
@@ -14,6 +14,7 @@ import { useApp } from "@/contexts/AppContext";
 import { apiClient } from "@/lib/api";
 import { normalizeChangeStatus } from "@/lib/changeStatus";
 import { logClientError } from "@/lib/errorFeedback";
+import { buildGraphEdges } from "@/lib/graphEdges";
 import { normalizeAndAlignTiles } from "@/lib/graphLayout";
 import {
   buildTileBodyText,
@@ -583,34 +584,10 @@ export default function GraphCanvas() {
     tileHeights,
   ]);
 
-  const edges = useMemo(() => {
-    const highlightEnabled = Boolean(focusedNodeId);
-    return tiles.flatMap((tile) =>
-      tile.link_from_tile.map((sourceId) => {
-        const isActive =
-          !highlightEnabled ||
-          sourceId === focusedNodeId ||
-          tile.id === focusedNodeId;
-        const strokeColor = highlightEnabled
-          ? isActive
-            ? "#3b82f6"
-            : "#94a3b8"
-          : "#0f172a";
-        return {
-          id: `e-${sourceId}-${tile.id}`,
-          source: sourceId,
-          target: tile.id,
-          style: {
-            stroke: strokeColor,
-            strokeWidth: highlightEnabled ? (isActive ? 2.5 : 1) : 2,
-            opacity: highlightEnabled ? (isActive ? 1 : 0.25) : 1,
-            strokeLinecap: "round",
-            strokeLinejoin: "round",
-          },
-        };
-      })
-    );
-  }, [tiles, focusedNodeId]);
+  const edges = useMemo(
+    () => buildGraphEdges(tiles, focusedNodeId),
+    [tiles, focusedNodeId]
+  );
 
   const handleNodeDragStop = useCallback(
     async (_event: unknown, node: Node) => {

--- a/frontend/src/lib/__tests__/graphEdges.test.ts
+++ b/frontend/src/lib/__tests__/graphEdges.test.ts
@@ -1,0 +1,66 @@
+import { buildGraphEdges } from "@/lib/graphEdges";
+import { Tile } from "@/types";
+
+const makeTile = (overrides: Partial<Tile>): Tile => ({
+  id: "tile",
+  title: "Title",
+  text: "Text",
+  meta_information: {},
+  column: 0,
+  row: 0,
+  deletable: false,
+  link_from_tile: [],
+  ...overrides,
+});
+
+describe("graphEdges", () => {
+  it("deduplicates edges by source-target pair", () => {
+    const tiles: Tile[] = [
+      makeTile({ id: "law_tile" }),
+      makeTile({
+        id: "regulation_1",
+        link_from_tile: ["law_tile", "law_tile"],
+      }),
+    ];
+
+    const edges = buildGraphEdges(tiles, null);
+
+    expect(edges).toHaveLength(1);
+    expect(edges[0]?.id).toBe("e-law_tile-regulation_1");
+    expect(edges[0]?.source).toBe("law_tile");
+    expect(edges[0]?.target).toBe("regulation_1");
+  });
+
+  it("drops edges when source or target node is missing", () => {
+    const tiles: Tile[] = [
+      makeTile({
+        id: "regulation_1",
+        link_from_tile: ["ghost_source"],
+      }),
+    ];
+
+    const edges = buildGraphEdges(tiles, null);
+
+    expect(edges).toHaveLength(0);
+  });
+
+  it("applies highlight styles to active and dimmed edges", () => {
+    const tiles: Tile[] = [
+      makeTile({ id: "law_tile" }),
+      makeTile({ id: "regulation_1", link_from_tile: ["law_tile"] }),
+      makeTile({ id: "regulation_2", link_from_tile: ["law_tile"] }),
+      makeTile({ id: "process_1", link_from_tile: ["regulation_1"] }),
+    ];
+
+    const edges = buildGraphEdges(tiles, "regulation_1");
+    const byId = new Map(edges.map((edge) => [edge.id, edge]));
+    const activeIncoming = byId.get("e-law_tile-regulation_1");
+    const activeOutgoing = byId.get("e-regulation_1-process_1");
+    const dimmed = byId.get("e-law_tile-regulation_2");
+
+    expect(activeIncoming?.style?.stroke).toBe("#3b82f6");
+    expect(activeOutgoing?.style?.stroke).toBe("#3b82f6");
+    expect(dimmed?.style?.stroke).toBe("#94a3b8");
+    expect(dimmed?.style?.opacity).toBe(0.25);
+  });
+});

--- a/frontend/src/lib/graphEdges.ts
+++ b/frontend/src/lib/graphEdges.ts
@@ -1,0 +1,51 @@
+import { Edge } from "@xyflow/react";
+
+import { Tile } from "@/types";
+
+const ACTIVE_EDGE_STROKE = "#3b82f6";
+const DIMMED_EDGE_STROKE = "#94a3b8";
+const DEFAULT_EDGE_STROKE = "#0f172a";
+
+export const buildGraphEdges = (
+  tiles: Tile[],
+  focusedNodeId: string | null
+): Edge[] => {
+  const highlightEnabled = Boolean(focusedNodeId);
+  const nodeIdSet = new Set(tiles.map((tile) => tile.id));
+  const seenEdgeIds = new Set<string>();
+  const edges: Edge[] = [];
+
+  tiles.forEach((tile) => {
+    tile.link_from_tile.forEach((sourceId) => {
+      if (!nodeIdSet.has(sourceId) || !nodeIdSet.has(tile.id)) {
+        return;
+      }
+      const edgeId = `e-${sourceId}-${tile.id}`;
+      if (seenEdgeIds.has(edgeId)) {
+        return;
+      }
+      seenEdgeIds.add(edgeId);
+      const isActive =
+        !highlightEnabled || sourceId === focusedNodeId || tile.id === focusedNodeId;
+      const strokeColor = highlightEnabled
+        ? isActive
+          ? ACTIVE_EDGE_STROKE
+          : DIMMED_EDGE_STROKE
+        : DEFAULT_EDGE_STROKE;
+      edges.push({
+        id: edgeId,
+        source: sourceId,
+        target: tile.id,
+        style: {
+          stroke: strokeColor,
+          strokeWidth: highlightEnabled ? (isActive ? 2.5 : 1) : 2,
+          opacity: highlightEnabled ? (isActive ? 1 : 0.25) : 1,
+          strokeLinecap: "round",
+          strokeLinejoin: "round",
+        },
+      });
+    });
+  });
+
+  return edges;
+};


### PR DESCRIPTION
- refactored graph edge construction into frontend/src/lib/graphEdges.ts to centralize edge logic
- added defensive edge guards: drop edges with missing source/target nodes and deduplicate by source-target id
- updated GraphCanvas to consume the new helper, reducing inline complexity
- added unit tests in frontend/src/lib/__tests__/graphEdges.test.ts for deduplication, missing-node filtering, and highlight styling

Closes #16 