### PR TITLE
Align run-all with CCC start and support proposed-only laws

### DIFF
--- a/backend/core/prompts.py
+++ b/backend/core/prompts.py
@@ -545,6 +545,8 @@ PROMPT_TEMPLATES: Dict[str, str] = {
         Gesetzesvorschlag. Leiten Sie daraus ab, was der Gesetzgeber erreichen moechte. 
         Geben Sie strikt JSON zurueck im Format: {{\"title\": \"...\", \"blurb\": \"...\", \"summary\": \"...\"}}.
 
+        {law_mode_context}
+
         Der 'title' soll ein kurzer Titel sein (max. 12 Woerter), der 'blurb' soll genau ein Satz sein. Fuer die 'summary' geben Sie bitte eine 
         ausfuehrliche Zusammenfassung an, mit Hilfe derer man die Ziele und wesentlichen Unterschiede der Gesetzesaenderung verstehen kann ohne 
         die zwei Gesetzestexte vorliegen zu haben.
@@ -560,6 +562,8 @@ PROMPT_TEMPLATES: Dict[str, str] = {
     PromptId.REGULATIONS_IDENTIFICATION: (
         LEGIST_PROMPT_OPENING
         + """ 
+        {law_mode_context}
+
         Folgendes ist das konsolidierte, geltende Gesetz: {gesetz_gueltig}
 
         Folgendes konsolidiertes Gesetz wird vorgeschlagen: {gesetz_vorschlag}
@@ -1130,6 +1134,7 @@ def render_prompt(prompt_id: str, **kwargs: Any) -> str:
         if not name.startswith("_") and isinstance(value, str)
     }
     render_values = dict(kwargs)
+    render_values.setdefault("law_mode_context", "")
     raw_norm_addressee = render_values.get("norm_addressee")
     if prompt_id in PROMPTS_REQUIRING_NORM_ADDRESSEE and raw_norm_addressee in (None, ""):
         raise KeyError("render_prompt requires explicit norm_addressee")
@@ -1417,5 +1422,3 @@ def _render_effort_json_schema(norm_addressee: str | None) -> str:
     if not norm_addressee:
         norm_addressee = ADMINISTRATION
     return EFFORT_JSON_SCHEMA_BY_ADDRESSEE.get(norm_addressee, EFFORT_JSON_SCHEMA_DEFAULT).strip()
-
-

--- a/backend/routers/regulations.py
+++ b/backend/routers/regulations.py
@@ -383,9 +383,12 @@ def _render_law_mode_context(prompt_id: str, law_mode: str) -> str:
     try:
         return _LAW_MODE_CONTEXTS[(prompt_id, law_mode)]
     except KeyError as exc:
-        raise ValueError(
+        raise HTTPException(
+            status_code=500,
+            detail=(
             f"Unsupported law mode context combination: prompt_id={prompt_id!r}, "
             f"law_mode={law_mode!r}"
+            ),
         ) from exc
 
 

--- a/backend/routers/regulations.py
+++ b/backend/routers/regulations.py
@@ -33,6 +33,46 @@ from backend.routers._llm_router_utils import (
 
 router = APIRouter(prefix="/regulations", tags=["regulations"])
 
+_NEW_LAW_BASELINE_TEXT = (
+    "Es gibt kein aktuell geltendes Gegenstueck. "
+    "Der Gesetzesvorschlag ist als neue Regelung ohne bestehenden Ausgangstext "
+    "zu behandeln."
+)
+
+_LAW_MODE_CONTEXTS: dict[tuple[str, str], str] = {
+    (
+        PromptId.LAW_SUMMARY,
+        "comparison",
+    ): (
+        "Arbeitsmodus: Vergleich. Vergleichen Sie geltenden Text und "
+        "Gesetzesvorschlag direkt miteinander.\n\n"
+    ),
+    (
+        PromptId.REGULATIONS_IDENTIFICATION,
+        "comparison",
+    ): (
+        "Arbeitsmodus: Vergleich. Identifizieren Sie die Unterschiede zwischen "
+        "geltendem Text und Gesetzesvorschlag.\n\n"
+    ),
+    (
+        PromptId.LAW_SUMMARY,
+        "new_law",
+    ): (
+        "Arbeitsmodus: Neuregelung. Es gibt kein aktuell geltendes "
+        "Vergleichsgesetz. Behandeln Sie den Gesetzesvorschlag als vollstaendig "
+        "neue Regelung und stellen Sie keinen Selbstvergleich an.\n\n"
+    ),
+    (
+        PromptId.REGULATIONS_IDENTIFICATION,
+        "new_law",
+    ): (
+        "Arbeitsmodus: Neuregelung. Es gibt kein aktuell geltendes "
+        "Vergleichsgesetz. Identifizieren Sie die im Gesetzesvorschlag enthaltenen "
+        "Vorgaben als Einfuehrungen, soweit nicht aus dem Text selbst etwas anderes "
+        "hervorgeht, und stellen Sie keinen Selbstvergleich an.\n\n"
+    ),
+}
+
 
 def _ensure_regulations_dir() -> Path:
     path = settings.regulations_path
@@ -320,6 +360,35 @@ def _clear_existing_tiles(session_id: int) -> None:
         db.delete_tile(tile.id, session_id=session_id)
 
 
+def _resolve_law_mode(
+    current_text: str,
+    proposed_text: str,
+) -> tuple[str, str]:
+    if not proposed_text:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                "Proposed law not selected for session. "
+                "Select a proposed law and run summary first."
+            ),
+        )
+    if current_text:
+        return "comparison", current_text
+    return "new_law", _NEW_LAW_BASELINE_TEXT
+
+
+def _render_law_mode_context(prompt_id: str, law_mode: str) -> str:
+    """Render mode-specific prompt guidance for summary vs. regulations tasks.
+    Distinguishes comparison runs from proposed-only new-law runs."""
+    try:
+        return _LAW_MODE_CONTEXTS[(prompt_id, law_mode)]
+    except KeyError as exc:
+        raise ValueError(
+            f"Unsupported law mode context combination: prompt_id={prompt_id!r}, "
+            f"law_mode={law_mode!r}"
+        ) from exc
+
+
 @router.post("/identify")
 async def identify_regulations(
     payload: RegulationIdentifyRequest,
@@ -330,11 +399,7 @@ async def identify_regulations(
         payload.model,
     )
     current_text, proposed_text = db.get_session_law_texts(session_id)
-    if not current_text or not proposed_text:
-        raise HTTPException(
-            status_code=422,
-            detail="Law files not selected for session. Run summary first.",
-        )
+    law_mode, current_prompt_text = _resolve_law_mode(current_text, proposed_text)
     existing = db.list_regulations_for_session(session_id)
     if existing:
         return {
@@ -353,8 +418,11 @@ async def identify_regulations(
     prompt = render_prompt(
         PromptId.REGULATIONS_IDENTIFICATION,
         session_id=session_id,
-        gesetz_gueltig=current_text,
+        gesetz_gueltig=current_prompt_text,
         gesetz_vorschlag=proposed_text,
+        law_mode_context=_render_law_mode_context(
+            PromptId.REGULATIONS_IDENTIFICATION, law_mode
+        ),
     )
     answer_id, llm_result = await query_and_stage_or_http(
         session_id=session_id,
@@ -415,10 +483,12 @@ async def summarize_regulation(
         if not current_content:
             raise HTTPException(status_code=400, detail="Current file is empty")
 
+    law_mode, current_prompt_text = _resolve_law_mode(current_content, content)
     prompt = render_prompt(
         PromptId.LAW_SUMMARY,
-        gesetz_gueltig=current_content or content,
+        gesetz_gueltig=current_prompt_text,
         gesetz_vorschlag=content,
+        law_mode_context=_render_law_mode_context(PromptId.LAW_SUMMARY, law_mode),
     )
 
     if payload.app_session_id:

--- a/frontend/src/components/SessionMenu.tsx
+++ b/frontend/src/components/SessionMenu.tsx
@@ -4,17 +4,18 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
 import { useApp } from "@/contexts/AppContext";
-import {
-  apiClient,
-  buildLlmRequestOptions,
-  type ApiClientError,
-} from "@/lib/api";
+import { apiClient, type ApiClientError } from "@/lib/api";
 import { logClientError } from "@/lib/errorFeedback";
 import {
   emitRunAllStepCleared,
   emitRunAllStepStarted,
   type RunAllStepKey,
 } from "@/lib/runAllStepEvents";
+import {
+  formatSessionStartError,
+  logSessionStartError,
+  prepareSessionDocuments,
+} from "@/lib/sessionStart";
 import { deriveTabFromStatus } from "@/lib/sessionStatus";
 import { SessionStatus, SessionSummary } from "@/types";
 
@@ -52,8 +53,15 @@ function deriveRunAllStepKeyFromStatus(
 export default function SessionMenu({ compact }: SessionMenuProps) {
   const {
     state,
+    setAvailableRegulations,
     setCurrentTab,
     setAppSessionId,
+    setSelectedCurrentLaw,
+    setSelectedRegulation,
+    setPendingCurrentUpload,
+    setPendingProposedUpload,
+    setPendingCurrentUploadName,
+    setPendingProposedUploadName,
     setSummaryReady,
     setRegulationsReady,
     setLastCompletedStep,
@@ -534,19 +542,40 @@ export default function SessionMenu({ compact }: SessionMenuProps) {
     }
     resetStatus();
     setIsRunningAll(true);
+    setStatus("Schritte werden vorbereitet...");
     emitRunAllStepCleared();
-    const { model, provider, keys } = buildLlmRequestOptions({
-      selectedModel: state.selectedModel,
-      availableModels: state.availableModels,
-    });
     try {
+      const { currentFilename, proposedFilename, llm } =
+        await prepareSessionDocuments({
+          appSessionId: state.appSessionId,
+          selectedModel: state.selectedModel,
+          availableModels: state.availableModels,
+          availableRegulations: state.availableRegulations,
+          selectedCurrentLaw: state.selectedCurrentLaw,
+          selectedRegulation: state.selectedRegulation,
+          pendingCurrent: {
+            file: state.pendingCurrentUpload,
+            desiredName: state.pendingCurrentUploadName,
+          },
+          pendingProposed: {
+            file: state.pendingProposedUpload,
+            desiredName: state.pendingProposedUploadName,
+          },
+          setSelectedCurrentLaw,
+          setSelectedRegulation,
+          setPendingCurrentUpload,
+          setPendingProposedUpload,
+          setPendingCurrentUploadName,
+          setPendingProposedUploadName,
+          setAvailableRegulations,
+        });
       const start = await apiClient.startRunAllSteps({
         appSessionId: state.appSessionId,
-        currentFilename: state.selectedCurrentLaw || undefined,
-        proposedFilename: state.selectedRegulation || undefined,
-        model,
-        provider,
-        keys,
+        currentFilename,
+        proposedFilename,
+        model: llm.model,
+        provider: llm.provider,
+        keys: llm.keys,
       });
       setStatus(
         start.started
@@ -557,11 +586,10 @@ export default function SessionMenu({ compact }: SessionMenuProps) {
       setIsCancellingRun(false);
       beginRunEventStream(start.run_id);
     } catch (error) {
-      logClientError("SessionMenu.startRunAll", error, {
+      logSessionStartError("SessionMenu.startRunAll", error, {
         appSessionId: state.appSessionId,
       });
-      const err = error as Error;
-      setStatus(err?.message || "Schritte konnten nicht gestartet werden.");
+      setStatus(formatSessionStartError(error));
       setIsRunningAll(false);
       setCurrentRunId(null);
       setIsCancellingRun(false);

--- a/frontend/src/components/UploadPanel.tsx
+++ b/frontend/src/components/UploadPanel.tsx
@@ -1,10 +1,15 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { useApp } from "@/contexts/AppContext";
-import { ApiClientError, apiClient, buildLlmRequestOptions } from "@/lib/api";
-import { formatActionErrorMessage, logClientError } from "@/lib/errorFeedback";
+import { apiClient } from "@/lib/api";
+import { logClientError } from "@/lib/errorFeedback";
+import {
+  formatSessionStartError,
+  logSessionStartError,
+  prepareSessionDocumentsAndStartSummary,
+} from "@/lib/sessionStart";
 import { useRunAllStepBusy } from "@/lib/runAllStepEvents";
 
 type UploadTarget = "current" | "proposed";
@@ -16,14 +21,14 @@ export default function UploadPanel() {
     setCurrentTab,
     setSelectedCurrentLaw,
     setSelectedRegulation,
+    setPendingCurrentUpload,
+    setPendingProposedUpload,
+    setPendingCurrentUploadName,
+    setPendingProposedUploadName,
     setProcessesReady,
     setRegulationsReady,
     setSummaryReady,
   } = useApp();
-  const [uploadFiles, setUploadFiles] = useState<{
-    current: File | null;
-    proposed: File | null;
-  }>({ current: null, proposed: null });
   const [status, setStatus] = useState<string | null>(null);
   const [isDragging, setIsDragging] = useState({
     current: false,
@@ -36,41 +41,72 @@ export default function UploadPanel() {
   const [isSummarizing, setIsSummarizing] = useState(false);
   const isRunAllBusy = useRunAllStepBusy("summary");
   const isBusy = isSummarizing || isRunAllBusy;
-  const [conflicts, setConflicts] = useState<{
-    current: string | null;
-    proposed: string | null;
-  }>({ current: null, proposed: null });
-  const [renameValues, setRenameValues] = useState({
-    current: "",
-    proposed: "",
-  });
+
+  const pendingUploads = useMemo(
+    () => ({
+      current: {
+        file: state.pendingCurrentUpload,
+        desiredName: state.pendingCurrentUploadName,
+      },
+      proposed: {
+        file: state.pendingProposedUpload,
+        desiredName: state.pendingProposedUploadName,
+      },
+    }),
+    [
+      state.pendingCurrentUpload,
+      state.pendingCurrentUploadName,
+      state.pendingProposedUpload,
+      state.pendingProposedUploadName,
+    ]
+  );
+
+  const conflicts = useMemo(
+    () => ({
+      current:
+        pendingUploads.current.file &&
+        pendingUploads.current.desiredName &&
+        state.availableRegulations.includes(pendingUploads.current.desiredName)
+          ? pendingUploads.current.desiredName
+          : null,
+      proposed:
+        pendingUploads.proposed.file &&
+        pendingUploads.proposed.desiredName &&
+        state.availableRegulations.includes(pendingUploads.proposed.desiredName)
+          ? pendingUploads.proposed.desiredName
+          : null,
+    }),
+    [pendingUploads, state.availableRegulations]
+  );
 
   const clearSelection = (target: UploadTarget) => {
-    setUploadFiles((prev) => ({ ...prev, [target]: null }));
-    setConflicts((prev) => ({ ...prev, [target]: null }));
-    setRenameValues((prev) => ({ ...prev, [target]: "" }));
+    if (target === "current") {
+      setPendingCurrentUpload(null);
+      setPendingCurrentUploadName("");
+      setSelectedCurrentLaw("");
+    } else {
+      setPendingProposedUpload(null);
+      setPendingProposedUploadName("");
+      setSelectedRegulation("");
+    }
     setStatus(null);
     setSummaryReady(false);
     setRegulationsReady(false);
     setProcessesReady(false);
     setShowLists((prev) => ({ ...prev, [target]: false }));
-    if (target === "current") {
-      setSelectedCurrentLaw("");
-    } else {
-      setSelectedRegulation("");
-    }
   };
 
   const selectFromList = (target: UploadTarget, file: string) => {
     if (target === "current") {
       setSelectedCurrentLaw(file);
+      setPendingCurrentUpload(null);
+      setPendingCurrentUploadName("");
     } else {
       setSelectedRegulation(file);
+      setPendingProposedUpload(null);
+      setPendingProposedUploadName("");
     }
-    setUploadFiles((prev) => ({ ...prev, [target]: null }));
-    setRenameValues((prev) => ({ ...prev, [target]: "" }));
     setStatus(null);
-    setConflicts((prev) => ({ ...prev, [target]: null }));
     setSummaryReady(false);
     setRegulationsReady(false);
     setProcessesReady(false);
@@ -91,106 +127,25 @@ export default function UploadPanel() {
     loadRegulations();
   }, [loadRegulations]);
 
-  const summarizeRegulation = async (filename: string, currentLaw: string) => {
-    setSummaryReady(false);
-    setIsSummarizing(true);
-    const llm = buildLlmRequestOptions({
-      selectedModel: state.selectedModel,
-      availableModels: state.availableModels,
-    });
-    try {
-      await apiClient.summarizeRegulation(filename, {
-        currentFilename: currentLaw,
-        appSessionId: state.appSessionId,
-        model: llm.model,
-        provider: llm.provider,
-        keys: llm.keys,
-      });
-      window.dispatchEvent(new Event("tiles-updated"));
-      setSummaryReady(true);
-      setCurrentTab(1);
-    } catch (error) {
-      logClientError("UploadPanel.summarizeRegulation", error, {
-        appSessionId: state.appSessionId,
-        filename,
-        currentLaw,
-      });
-      setStatus(formatActionErrorMessage("Zusammenfassung fehlgeschlagen", error));
-      setSummaryReady(false);
-    } finally {
-      setIsSummarizing(false);
-    }
-  };
-
   const handleFileSelection = (target: UploadTarget, file: File | null) => {
-    setUploadFiles((prev) => ({ ...prev, [target]: file }));
     setStatus(null);
-    setConflicts((prev) => ({ ...prev, [target]: null }));
     setSummaryReady(false);
     setShowLists((prev) => ({ ...prev, [target]: false }));
-    if (!file) {
-      return;
-    }
-    setRenameValues((prev) => ({ ...prev, [target]: file.name }));
     if (target === "current") {
+      setPendingCurrentUpload(file);
+      if (file) {
+        setPendingCurrentUploadName(file.name);
+      }
       setSelectedCurrentLaw("");
     } else {
+      setPendingProposedUpload(file);
+      if (file) {
+        setPendingProposedUploadName(file.name);
+      }
       setSelectedRegulation("");
     }
-    if (state.availableRegulations.includes(file.name)) {
-      setConflicts((prev) => ({ ...prev, [target]: file.name }));
+    if (file && state.availableRegulations.includes(file.name)) {
       setStatus(`Datei existiert bereits: ${file.name}`);
-    }
-  };
-
-  const handleUpload = async (
-    target: UploadTarget,
-    nameOverride?: string
-  ): Promise<string | null> => {
-    const uploadFile = uploadFiles[target];
-    if (!uploadFile) {
-      setStatus("Bitte eine Datei auswählen.");
-      return null;
-    }
-    try {
-      const response = await apiClient.uploadRegulation(uploadFile, nameOverride);
-      setStatus(null);
-      setUploadFiles((prev) => ({ ...prev, [target]: null }));
-      setConflicts((prev) => ({ ...prev, [target]: null }));
-      setRenameValues((prev) => ({ ...prev, [target]: "" }));
-      await loadRegulations();
-      if (target === "current") {
-        setSelectedCurrentLaw(response.filename);
-      } else {
-        setSelectedRegulation(response.filename);
-      }
-      setSummaryReady(false);
-      return response.filename;
-    } catch (error) {
-      logClientError("UploadPanel.handleUpload", error, {
-        target,
-        fileName: uploadFile.name,
-        nameOverride,
-      });
-      const err = error as ApiClientError;
-      const details =
-        err.details && typeof err.details === "object"
-          ? (err.details as { error?: unknown; filename?: unknown })
-          : null;
-      if (
-        err.status === 409 &&
-        details?.error === "exists" &&
-        typeof details.filename === "string"
-      ) {
-        setConflicts((prev) => ({
-          ...prev,
-          [target]: details.filename,
-        }));
-        setStatus(`Datei existiert bereits: ${details.filename}`);
-        return null;
-      }
-      setStatus("Upload fehlgeschlagen.");
-      return null;
     }
   };
 
@@ -198,24 +153,17 @@ export default function UploadPanel() {
     handleFileSelection(target, file);
   };
 
-  const hasCurrent = Boolean(
-    uploadFiles.current || state.selectedCurrentLaw
-  );
   const hasProposed = Boolean(
-    uploadFiles.proposed || state.selectedRegulation
+    pendingUploads.proposed.file || state.selectedRegulation
   );
   const hasConflicts = Boolean(conflicts.current || conflicts.proposed);
   const canStart =
-    hasCurrent &&
-    hasProposed &&
-    !isBusy &&
-    !hasConflicts &&
-    Boolean(state.selectedModel);
+    hasProposed && !isBusy && !hasConflicts && Boolean(state.selectedModel);
 
   const getSelectedName = (target: UploadTarget) => {
-    const uploadName = uploadFiles[target]?.name;
-    if (uploadName) {
-      return uploadName;
+    const upload = target === "current" ? pendingUploads.current : pendingUploads.proposed;
+    if (upload.file) {
+      return upload.desiredName || upload.file.name;
     }
     return target === "current"
       ? state.selectedCurrentLaw
@@ -233,21 +181,37 @@ export default function UploadPanel() {
     setStatus(null);
     setSummaryReady(false);
     setIsSummarizing(true);
-    const currentName = uploadFiles.current
-      ? await handleUpload("current")
-      : state.selectedCurrentLaw;
-    if (!currentName) {
+    try {
+      await prepareSessionDocumentsAndStartSummary({
+        appSessionId: state.appSessionId,
+        selectedModel: state.selectedModel,
+        availableModels: state.availableModels,
+        availableRegulations: state.availableRegulations,
+        selectedCurrentLaw: state.selectedCurrentLaw,
+        selectedRegulation: state.selectedRegulation,
+        pendingCurrent: pendingUploads.current,
+        pendingProposed: pendingUploads.proposed,
+        setSelectedCurrentLaw,
+        setSelectedRegulation,
+        setPendingCurrentUpload,
+        setPendingProposedUpload,
+        setPendingCurrentUploadName,
+        setPendingProposedUploadName,
+        setAvailableRegulations,
+        setSummaryReady,
+        setRegulationsReady,
+        setProcessesReady,
+        setCurrentTab,
+      });
+    } catch (error) {
+      logSessionStartError("UploadPanel.handleStart", error, {
+        appSessionId: state.appSessionId,
+      });
+      setStatus(formatSessionStartError(error));
+      setSummaryReady(false);
+    } finally {
       setIsSummarizing(false);
-      return;
     }
-    const proposedName = uploadFiles.proposed
-      ? await handleUpload("proposed")
-      : state.selectedRegulation;
-    if (!proposedName) {
-      setIsSummarizing(false);
-      return;
-    }
-    await summarizeRegulation(proposedName, currentName);
   };
 
   return (
@@ -310,7 +274,7 @@ export default function UploadPanel() {
                   <>
                     <span>Datei hierher ziehen oder klicken</span>
                     <span className="text-xs font-normal text-slate-500">
-                      um aus hochgeladenen Dateien auszuwählen
+                      optional: aus hochgeladenen Dateien auswählen
                     </span>
                   </>
                 )}
@@ -335,7 +299,7 @@ export default function UploadPanel() {
                 </div>
               )}
             </div>
-            {conflicts.current && uploadFiles.current && (
+            {conflicts.current && pendingUploads.current.file && (
               <div className="mt-3 flex flex-wrap items-center gap-3 text-xs text-slate-600">
                 <span className="rounded-full bg-amber-100 px-3 py-1 font-semibold text-amber-800">
                   Datei existiert bereits
@@ -347,22 +311,13 @@ export default function UploadPanel() {
                   Vorhandene Datei verwenden
                 </button>
                 <input
-                  value={renameValues.current}
+                  value={state.pendingCurrentUploadName}
                   onChange={(event) =>
-                    setRenameValues((prev) => ({
-                      ...prev,
-                      current: event.target.value,
-                    }))
+                    setPendingCurrentUploadName(event.target.value)
                   }
                   className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs"
                   placeholder="Neuer Dateiname"
                 />
-                <button
-                  onClick={() => handleUpload("current", renameValues.current)}
-                  className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-700"
-                >
-                  Umbenannt hochladen
-                </button>
               </div>
             )}
           </div>
@@ -444,7 +399,7 @@ export default function UploadPanel() {
                 </div>
               )}
             </div>
-            {conflicts.proposed && uploadFiles.proposed && (
+            {conflicts.proposed && pendingUploads.proposed.file && (
               <div className="mt-3 flex flex-wrap items-center gap-3 text-xs text-slate-600">
                 <span className="rounded-full bg-amber-100 px-3 py-1 font-semibold text-amber-800">
                   Datei existiert bereits
@@ -456,22 +411,13 @@ export default function UploadPanel() {
                   Vorhandene Datei verwenden
                 </button>
                 <input
-                  value={renameValues.proposed}
+                  value={state.pendingProposedUploadName}
                   onChange={(event) =>
-                    setRenameValues((prev) => ({
-                      ...prev,
-                      proposed: event.target.value,
-                    }))
+                    setPendingProposedUploadName(event.target.value)
                   }
                   className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs"
                   placeholder="Neuer Dateiname"
                 />
-                <button
-                  onClick={() => handleUpload("proposed", renameValues.proposed)}
-                  className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-700"
-                >
-                  Umbenannt hochladen
-                </button>
               </div>
             )}
           </div>

--- a/frontend/src/components/UploadPanel.tsx
+++ b/frontend/src/components/UploadPanel.tsx
@@ -171,10 +171,6 @@ export default function UploadPanel() {
   };
 
   const handleStart = async () => {
-    if (!state.selectedModel) {
-      setStatus("Bitte zuerst ein Modell auswählen.");
-      return;
-    }
     if (!canStart) {
       return;
     }

--- a/frontend/src/components/__tests__/SessionMenu.test.tsx
+++ b/frontend/src/components/__tests__/SessionMenu.test.tsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event";
 import SessionMenu from "@/components/SessionMenu";
 import { useApp } from "@/contexts/AppContext";
 import { apiClient } from "@/lib/api";
+import { prepareSessionDocuments } from "@/lib/sessionStart";
 
 jest.mock("@/contexts/AppContext", () => ({
   useApp: jest.fn(),
@@ -28,15 +29,30 @@ jest.mock("@/lib/api", () => ({
   })),
 }));
 
+jest.mock("@/lib/sessionStart", () => ({
+  prepareSessionDocuments: jest.fn(),
+  formatSessionStartError: jest.fn(() => "Fehler"),
+  logSessionStartError: jest.fn(),
+}));
+
 const mockUseApp = useApp as jest.Mock;
 const mockRebuildTiles = apiClient.rebuildTiles as jest.Mock;
 const mockListSessions = apiClient.listSessions as jest.Mock;
 const mockGetSessionStatus = apiClient.getSessionStatus as jest.Mock;
 const mockUndoLastStep = apiClient.undoLastStep as jest.Mock;
+const mockStartRunAllSteps = apiClient.startRunAllSteps as jest.Mock;
+const mockPrepareSessionDocuments = prepareSessionDocuments as jest.Mock;
 
 describe("SessionMenu", () => {
   const setCurrentTab = jest.fn();
   const setAppSessionId = jest.fn();
+  const setAvailableRegulations = jest.fn();
+  const setSelectedCurrentLaw = jest.fn();
+  const setSelectedRegulation = jest.fn();
+  const setPendingCurrentUpload = jest.fn();
+  const setPendingProposedUpload = jest.fn();
+  const setPendingCurrentUploadName = jest.fn();
+  const setPendingProposedUploadName = jest.fn();
   const setSummaryReady = jest.fn();
   const setRegulationsReady = jest.fn();
   const setLastCompletedStep = jest.fn();
@@ -52,6 +68,11 @@ describe("SessionMenu", () => {
         availableModels: [],
         selectedCurrentLaw: "",
         selectedRegulation: "",
+        availableRegulations: [],
+        pendingCurrentUpload: null,
+        pendingProposedUpload: null,
+        pendingCurrentUploadName: "",
+        pendingProposedUploadName: "",
         summaryReady: true,
         regulationsReady: true,
         processesReady: true,
@@ -62,8 +83,15 @@ describe("SessionMenu", () => {
         lastCompletedStep: "effort",
         lastCompletedLabel: "Aufwand berechnen",
       },
+      setAvailableRegulations,
       setCurrentTab,
       setAppSessionId,
+      setSelectedCurrentLaw,
+      setSelectedRegulation,
+      setPendingCurrentUpload,
+      setPendingProposedUpload,
+      setPendingCurrentUploadName,
+      setPendingProposedUploadName,
       setSummaryReady,
       setRegulationsReady,
       setLastCompletedStep,
@@ -96,6 +124,26 @@ describe("SessionMenu", () => {
       undone_step: "effort",
       undone_label: "Aufwand berechnen",
     });
+    mockStartRunAllSteps.mockResolvedValue({
+      run_id: "run-123",
+      started: true,
+      status: "running",
+    });
+    mockPrepareSessionDocuments.mockResolvedValue({
+      currentFilename: undefined,
+      proposedFilename: "prepared-proposed.txt",
+      llm: {
+        model: "gpt-5.4",
+        provider: "openai",
+        keys: { openaiApiKey: "key" },
+      },
+    });
+    (global as typeof globalThis & { EventSource: jest.Mock }).EventSource = jest
+      .fn()
+      .mockImplementation(() => ({
+        addEventListener: jest.fn(),
+        close: jest.fn(),
+      }));
   });
 
   async function openMenu() {
@@ -146,5 +194,74 @@ describe("SessionMenu", () => {
       expect(mockRebuildTiles).toHaveBeenCalledWith("ABC123", "business")
     );
     expect(mockUndoLastStep).toHaveBeenCalledWith("ABC123");
+  });
+
+  it("prepares pending uploads before starting run-all", async () => {
+    mockUseApp.mockReturnValue({
+      state: {
+        appSessionId: "ABC123",
+        selectedNormAddressee: "business",
+        selectedModel: "gpt-5.4",
+        availableModels: [],
+        selectedCurrentLaw: "",
+        selectedRegulation: "",
+        availableRegulations: [],
+        pendingCurrentUpload: null,
+        pendingProposedUpload: new File(["p"], "proposal.txt", {
+          type: "text/plain",
+        }),
+        pendingCurrentUploadName: "",
+        pendingProposedUploadName: "proposal.txt",
+        summaryReady: false,
+        regulationsReady: false,
+        processesReady: false,
+        caseGroupsReady: false,
+        processStepsReady: false,
+        effortReady: false,
+        totalCostReady: false,
+        lastCompletedStep: null,
+        lastCompletedLabel: null,
+      },
+      setAvailableRegulations,
+      setCurrentTab,
+      setAppSessionId,
+      setSelectedCurrentLaw,
+      setSelectedRegulation,
+      setPendingCurrentUpload,
+      setPendingProposedUpload,
+      setPendingCurrentUploadName,
+      setPendingProposedUploadName,
+      setSummaryReady,
+      setRegulationsReady,
+      setLastCompletedStep,
+      setLastCompletedLabel,
+    });
+
+    const user = await openMenu();
+
+    await user.click(
+      screen.getByRole("button", { name: /alle schritte ausführen/i })
+    );
+
+    await waitFor(() =>
+      expect(mockPrepareSessionDocuments).toHaveBeenCalledWith(
+        expect.objectContaining({
+          appSessionId: "ABC123",
+          pendingProposed: expect.objectContaining({
+            desiredName: "proposal.txt",
+          }),
+        })
+      )
+    );
+    await waitFor(() =>
+      expect(mockStartRunAllSteps).toHaveBeenCalledWith({
+        appSessionId: "ABC123",
+        currentFilename: undefined,
+        proposedFilename: "prepared-proposed.txt",
+        model: "gpt-5.4",
+        provider: "openai",
+        keys: { openaiApiKey: "key" },
+      })
+    );
   });
 });

--- a/frontend/src/components/__tests__/UploadPanel.test.tsx
+++ b/frontend/src/components/__tests__/UploadPanel.test.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { render, screen, waitFor } from "@testing-library/react";
+
+import UploadPanel from "@/components/UploadPanel";
+import { useApp } from "@/contexts/AppContext";
+import { apiClient } from "@/lib/api";
+import { prepareSessionDocumentsAndStartSummary } from "@/lib/sessionStart";
+
+jest.mock("@/contexts/AppContext", () => ({
+  useApp: jest.fn(),
+}));
+
+jest.mock("@/lib/api", () => ({
+  apiClient: {
+    fetchRegulations: jest.fn(),
+  },
+}));
+
+jest.mock("@/lib/sessionStart", () => ({
+  prepareSessionDocumentsAndStartSummary: jest.fn(),
+  formatSessionStartError: jest.fn(() => "Fehler"),
+  logSessionStartError: jest.fn(),
+}));
+
+jest.mock("@/lib/runAllStepEvents", () => ({
+  useRunAllStepBusy: jest.fn(() => false),
+}));
+
+const mockUseApp = useApp as jest.Mock;
+const mockFetchRegulations = apiClient.fetchRegulations as jest.Mock;
+const mockPrepareAndStart = prepareSessionDocumentsAndStartSummary as jest.Mock;
+
+function createAppValue(overrides: Record<string, unknown> = {}) {
+  return {
+    state: {
+      appSessionId: "ABC123",
+      selectedModel: "gpt-5.4",
+      availableModels: [],
+      availableRegulations: [],
+      selectedCurrentLaw: "",
+      selectedRegulation: "",
+      pendingCurrentUpload: null,
+      pendingProposedUpload: null,
+      pendingCurrentUploadName: "",
+      pendingProposedUploadName: "",
+      ...overrides,
+    },
+    setAvailableRegulations: jest.fn(),
+    setCurrentTab: jest.fn(),
+    setSelectedCurrentLaw: jest.fn(),
+    setSelectedRegulation: jest.fn(),
+    setPendingCurrentUpload: jest.fn(),
+    setPendingProposedUpload: jest.fn(),
+    setPendingCurrentUploadName: jest.fn(),
+    setPendingProposedUploadName: jest.fn(),
+    setProcessesReady: jest.fn(),
+    setRegulationsReady: jest.fn(),
+    setSummaryReady: jest.fn(),
+  };
+}
+
+describe("UploadPanel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFetchRegulations.mockResolvedValue({ files: [] });
+    mockPrepareAndStart.mockResolvedValue(undefined);
+    mockUseApp.mockReturnValue(createAppValue());
+  });
+
+  it("disables CCC starten when no file is selected", async () => {
+    render(<UploadPanel />);
+
+    await waitFor(() => expect(mockFetchRegulations).toHaveBeenCalled());
+    expect(screen.getByRole("button", { name: /ccc starten/i })).toBeDisabled();
+  });
+
+  it("disables CCC starten when only a current law is selected", async () => {
+    mockUseApp.mockReturnValue(
+      createAppValue({
+        selectedCurrentLaw: "current.txt",
+      })
+    );
+
+    render(<UploadPanel />);
+
+    await waitFor(() => expect(mockFetchRegulations).toHaveBeenCalled());
+    expect(screen.getByRole("button", { name: /ccc starten/i })).toBeDisabled();
+  });
+
+  it("enables CCC starten when only a proposed law is selected", async () => {
+    mockUseApp.mockReturnValue(
+      createAppValue({
+        selectedRegulation: "proposed.txt",
+      })
+    );
+
+    render(<UploadPanel />);
+
+    await waitFor(() => expect(mockFetchRegulations).toHaveBeenCalled());
+    expect(screen.getByRole("button", { name: /ccc starten/i })).toBeEnabled();
+  });
+
+  it("enables CCC starten when current and proposed law are selected", async () => {
+    mockUseApp.mockReturnValue(
+      createAppValue({
+        selectedCurrentLaw: "current.txt",
+        selectedRegulation: "proposed.txt",
+      })
+    );
+
+    render(<UploadPanel />);
+
+    await waitFor(() => expect(mockFetchRegulations).toHaveBeenCalled());
+    expect(screen.getByRole("button", { name: /ccc starten/i })).toBeEnabled();
+  });
+
+  it("disables CCC starten while a proposed upload conflict is unresolved", async () => {
+    mockUseApp.mockReturnValue(
+      createAppValue({
+        availableRegulations: ["conflict.txt"],
+        pendingProposedUpload: new File(["x"], "proposed.txt", { type: "text/plain" }),
+        pendingProposedUploadName: "conflict.txt",
+      })
+    );
+
+    render(<UploadPanel />);
+
+    await waitFor(() => expect(mockFetchRegulations).toHaveBeenCalled());
+    expect(screen.getByRole("button", { name: /ccc starten/i })).toBeDisabled();
+    expect(screen.getByText(/datei existiert bereits/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/contexts/AppContext.tsx
+++ b/frontend/src/contexts/AppContext.tsx
@@ -63,6 +63,10 @@ interface AppState {
   selectedCurrentLaw: string;
   selectedRegulation: string;
   availableRegulations: string[];
+  pendingCurrentUpload: File | null;
+  pendingProposedUpload: File | null;
+  pendingCurrentUploadName: string;
+  pendingProposedUploadName: string;
   summaryReady: boolean;
   regulationsReady: boolean;
   processesReady: boolean;
@@ -84,6 +88,10 @@ interface AppContextValue {
   setSelectedCurrentLaw: (law: string) => void;
   setSelectedRegulation: (regulation: string) => void;
   setAvailableRegulations: (regulations: string[]) => void;
+  setPendingCurrentUpload: (file: File | null) => void;
+  setPendingProposedUpload: (file: File | null) => void;
+  setPendingCurrentUploadName: (name: string) => void;
+  setPendingProposedUploadName: (name: string) => void;
   setSummaryReady: (ready: boolean) => void;
   setRegulationsReady: (ready: boolean) => void;
   setProcessesReady: (ready: boolean) => void;
@@ -148,6 +156,10 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
   const [selectedCurrentLaw, setSelectedCurrentLaw] = useState("");
   const [selectedRegulation, setSelectedRegulation] = useState("");
   const [availableRegulations, setAvailableRegulations] = useState<string[]>([]);
+  const [pendingCurrentUpload, setPendingCurrentUpload] = useState<File | null>(null);
+  const [pendingProposedUpload, setPendingProposedUpload] = useState<File | null>(null);
+  const [pendingCurrentUploadName, setPendingCurrentUploadName] = useState("");
+  const [pendingProposedUploadName, setPendingProposedUploadName] = useState("");
   const [summaryReady, setSummaryReady] = useState(false);
   const [regulationsReady, setRegulationsReady] = useState(false);
   const [processesReady, setProcessesReady] = useState(false);
@@ -547,6 +559,10 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
           selectedCurrentLaw,
           selectedRegulation,
           availableRegulations,
+          pendingCurrentUpload,
+          pendingProposedUpload,
+          pendingCurrentUploadName,
+          pendingProposedUploadName,
           summaryReady,
           regulationsReady,
           processesReady,
@@ -565,6 +581,24 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
         setSelectedCurrentLaw,
         setSelectedRegulation,
         setAvailableRegulations,
+        setPendingCurrentUpload: (file: File | null) => {
+          setPendingCurrentUpload(file);
+          if (!file) {
+            setPendingCurrentUploadName("");
+          } else {
+            setPendingCurrentUploadName(file.name);
+          }
+        },
+        setPendingProposedUpload: (file: File | null) => {
+          setPendingProposedUpload(file);
+          if (!file) {
+            setPendingProposedUploadName("");
+          } else {
+            setPendingProposedUploadName(file.name);
+          }
+        },
+        setPendingCurrentUploadName,
+        setPendingProposedUploadName,
         setSummaryReady: (ready: boolean) => {
           setSummaryReady(ready);
           if (!ready) {

--- a/frontend/src/lib/__tests__/sessionStart.test.ts
+++ b/frontend/src/lib/__tests__/sessionStart.test.ts
@@ -1,0 +1,173 @@
+import {
+  prepareSessionDocuments,
+  prepareSessionDocumentsAndStartSummary,
+} from "@/lib/sessionStart";
+import { apiClient } from "@/lib/api";
+
+jest.mock("@/lib/api", () => ({
+  apiClient: {
+    uploadRegulation: jest.fn(),
+    fetchRegulations: jest.fn(),
+    summarizeRegulation: jest.fn(),
+  },
+  buildLlmRequestOptions: jest.fn(() => ({
+    model: "gpt-5.4",
+    provider: "openai",
+    keys: { openaiApiKey: "key" },
+  })),
+}));
+
+jest.mock("@/lib/errorFeedback", () => ({
+  formatActionErrorMessage: jest.fn(() => "formatted"),
+  logClientError: jest.fn(),
+}));
+
+const mockUploadRegulation = apiClient.uploadRegulation as jest.Mock;
+const mockFetchRegulations = apiClient.fetchRegulations as jest.Mock;
+const mockSummarizeRegulation = apiClient.summarizeRegulation as jest.Mock;
+
+function createOptions(overrides: Partial<Parameters<typeof prepareSessionDocuments>[0]> = {}) {
+  return {
+    appSessionId: "ABC123",
+    selectedModel: "gpt-5.4",
+    availableModels: [],
+    availableRegulations: [],
+    selectedCurrentLaw: "",
+    selectedRegulation: "",
+    pendingCurrent: { file: null, desiredName: "" },
+    pendingProposed: { file: null, desiredName: "" },
+    setSelectedCurrentLaw: jest.fn(),
+    setSelectedRegulation: jest.fn(),
+    setPendingCurrentUpload: jest.fn(),
+    setPendingProposedUpload: jest.fn(),
+    setPendingCurrentUploadName: jest.fn(),
+    setPendingProposedUploadName: jest.fn(),
+    setAvailableRegulations: jest.fn(),
+    ...overrides,
+  };
+}
+
+describe("sessionStart", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFetchRegulations.mockResolvedValue({ files: ["uploaded-current.txt", "uploaded-proposed.txt"] });
+    mockSummarizeRegulation.mockResolvedValue({ ok: true });
+  });
+
+  it("uploads pending current and proposed files before returning filenames", async () => {
+    mockUploadRegulation
+      .mockResolvedValueOnce({ filename: "uploaded-current.txt" })
+      .mockResolvedValueOnce({ filename: "uploaded-proposed.txt" });
+
+    const options = createOptions({
+      availableRegulations: ["existing.txt"],
+      pendingCurrent: {
+        file: new File(["current"], "current.txt", { type: "text/plain" }),
+        desiredName: "uploaded-current.txt",
+      },
+      pendingProposed: {
+        file: new File(["proposed"], "proposed.txt", { type: "text/plain" }),
+        desiredName: "uploaded-proposed.txt",
+      },
+    });
+
+    const result = await prepareSessionDocuments(options);
+
+    expect(mockUploadRegulation).toHaveBeenNthCalledWith(
+      1,
+      expect.any(File),
+      "uploaded-current.txt"
+    );
+    expect(mockUploadRegulation).toHaveBeenNthCalledWith(
+      2,
+      expect.any(File),
+      "uploaded-proposed.txt"
+    );
+    expect(mockFetchRegulations).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      currentFilename: "uploaded-current.txt",
+      proposedFilename: "uploaded-proposed.txt",
+      llm: {
+        model: "gpt-5.4",
+        provider: "openai",
+        keys: { openaiApiKey: "key" },
+      },
+    });
+    expect(options.setSelectedCurrentLaw).toHaveBeenCalledWith("uploaded-current.txt");
+    expect(options.setSelectedRegulation).toHaveBeenCalledWith("uploaded-proposed.txt");
+  });
+
+  it("returns proposed-only selections without uploading or refetching", async () => {
+    const options = createOptions({
+      selectedRegulation: "existing-proposed.txt",
+    });
+
+    const result = await prepareSessionDocuments(options);
+
+    expect(result.currentFilename).toBeUndefined();
+    expect(result.proposedFilename).toBe("existing-proposed.txt");
+    expect(mockUploadRegulation).not.toHaveBeenCalled();
+    expect(mockFetchRegulations).not.toHaveBeenCalled();
+  });
+
+  it("rejects when only a current law is selected", async () => {
+    const options = createOptions({
+      selectedCurrentLaw: "current-only.txt",
+    });
+
+    await expect(prepareSessionDocuments(options)).rejects.toThrow(
+      "Bitte zuerst einen Gesetzesvorschlag auswählen."
+    );
+    expect(mockUploadRegulation).not.toHaveBeenCalled();
+  });
+
+  it("rejects when no law file is selected", async () => {
+    await expect(prepareSessionDocuments(createOptions())).rejects.toThrow(
+      "Bitte zuerst einen Gesetzesvorschlag auswählen."
+    );
+  });
+
+  it("rejects unresolved upload conflicts before calling the API", async () => {
+    const options = createOptions({
+      availableRegulations: ["conflict.txt"],
+      pendingProposed: {
+        file: new File(["proposed"], "proposed.txt", { type: "text/plain" }),
+        desiredName: "conflict.txt",
+      },
+    });
+
+    await expect(prepareSessionDocuments(options)).rejects.toThrow(
+      "Bitte Namenskonflikt fuer den Gesetzesvorschlag zuerst im Upload-Bereich aufloesen."
+    );
+    expect(mockUploadRegulation).not.toHaveBeenCalled();
+  });
+
+  it("starts summary after preparing session documents", async () => {
+    mockUploadRegulation.mockResolvedValueOnce({ filename: "uploaded-proposed.txt" });
+
+    const options = {
+      ...createOptions({
+        pendingProposed: {
+          file: new File(["proposed"], "proposed.txt", { type: "text/plain" }),
+          desiredName: "uploaded-proposed.txt",
+        },
+      }),
+      setSummaryReady: jest.fn(),
+      setRegulationsReady: jest.fn(),
+      setProcessesReady: jest.fn(),
+      setCurrentTab: jest.fn(),
+    };
+
+    await prepareSessionDocumentsAndStartSummary(options);
+
+    expect(mockSummarizeRegulation).toHaveBeenCalledWith("uploaded-proposed.txt", {
+      currentFilename: undefined,
+      appSessionId: "ABC123",
+      model: "gpt-5.4",
+      provider: "openai",
+      keys: { openaiApiKey: "key" },
+    });
+    expect(options.setSummaryReady).toHaveBeenCalledWith(true);
+    expect(options.setCurrentTab).toHaveBeenCalledWith(1);
+  });
+});

--- a/frontend/src/lib/sessionStart.ts
+++ b/frontend/src/lib/sessionStart.ts
@@ -1,0 +1,189 @@
+import { ApiClientError, apiClient, buildLlmRequestOptions } from "@/lib/api";
+import { formatActionErrorMessage, logClientError } from "@/lib/errorFeedback";
+import type { Model } from "@/types";
+
+type UploadTarget = "current" | "proposed";
+
+type PendingUpload = {
+  file: File | null;
+  desiredName: string;
+};
+
+type PrepareSessionDocumentsOptions = {
+  appSessionId: string;
+  selectedModel: string;
+  availableModels: Model[];
+  availableRegulations: string[];
+  selectedCurrentLaw: string;
+  selectedRegulation: string;
+  pendingCurrent: PendingUpload;
+  pendingProposed: PendingUpload;
+  setSelectedCurrentLaw: (law: string) => void;
+  setSelectedRegulation: (regulation: string) => void;
+  setPendingCurrentUpload: (file: File | null) => void;
+  setPendingProposedUpload: (file: File | null) => void;
+  setPendingCurrentUploadName: (name: string) => void;
+  setPendingProposedUploadName: (name: string) => void;
+  setAvailableRegulations: (regulations: string[]) => void;
+};
+
+export type PrepareSessionDocumentsResult = {
+  currentFilename?: string;
+  proposedFilename: string;
+  llm: ReturnType<typeof buildLlmRequestOptions>;
+};
+
+function _normalizedDesiredName(upload: PendingUpload): string {
+  return (upload.desiredName || upload.file?.name || "").trim();
+}
+
+function _isUnresolvedConflict(
+  upload: PendingUpload,
+  availableRegulations: string[]
+): boolean {
+  if (!upload.file) {
+    return false;
+  }
+  const desiredName = _normalizedDesiredName(upload);
+  return Boolean(desiredName) && availableRegulations.includes(desiredName);
+}
+
+async function _uploadIfNeeded(
+  target: UploadTarget,
+  upload: PendingUpload,
+  availableRegulations: string[],
+  onSelected: (filename: string) => void,
+  clearPendingFile: () => void,
+  clearPendingName: () => void
+): Promise<string | null> {
+  if (!upload.file) {
+    return null;
+  }
+  const desiredName = _normalizedDesiredName(upload);
+  if (!desiredName) {
+    throw new Error("Bitte einen Dateinamen angeben.");
+  }
+  if (_isUnresolvedConflict(upload, availableRegulations)) {
+    throw new Error(
+      target === "current"
+        ? "Bitte Namenskonflikt fuer das geltende Gesetz zuerst im Upload-Bereich aufloesen."
+        : "Bitte Namenskonflikt fuer den Gesetzesvorschlag zuerst im Upload-Bereich aufloesen."
+    );
+  }
+  try {
+    const response = await apiClient.uploadRegulation(
+      upload.file,
+      desiredName !== upload.file.name ? desiredName : undefined
+    );
+    onSelected(response.filename);
+    clearPendingFile();
+    clearPendingName();
+    return response.filename;
+  } catch (error) {
+    const err = error as ApiClientError;
+    const details =
+      err.details && typeof err.details === "object"
+        ? (err.details as { error?: unknown; filename?: unknown })
+        : null;
+    if (
+      err.status === 409 &&
+      details?.error === "exists" &&
+      typeof details.filename === "string"
+    ) {
+      throw new Error(
+        `Bitte Namenskonflikt im Upload-Bereich aufloesen: ${details.filename}`
+      );
+    }
+    throw error;
+  }
+}
+
+export async function prepareSessionDocuments(
+  options: PrepareSessionDocumentsOptions
+): Promise<PrepareSessionDocumentsResult> {
+  if (!options.selectedModel) {
+    throw new Error("Bitte zuerst ein Modell auswählen.");
+  }
+
+  const llm = buildLlmRequestOptions({
+    selectedModel: options.selectedModel,
+    availableModels: options.availableModels,
+  });
+
+  const uploadedCurrentFilename = await _uploadIfNeeded(
+      "current",
+      options.pendingCurrent,
+      options.availableRegulations,
+      options.setSelectedCurrentLaw,
+      () => options.setPendingCurrentUpload(null),
+      () => options.setPendingCurrentUploadName("")
+    );
+  const currentFilename =
+    uploadedCurrentFilename || options.selectedCurrentLaw || undefined;
+
+  const uploadedProposedFilename = await _uploadIfNeeded(
+      "proposed",
+      options.pendingProposed,
+      options.availableRegulations,
+      options.setSelectedRegulation,
+      () => options.setPendingProposedUpload(null),
+      () => options.setPendingProposedUploadName("")
+    );
+  const proposedFilename = uploadedProposedFilename || options.selectedRegulation;
+
+  if (!proposedFilename) {
+    throw new Error("Bitte zuerst einen Gesetzesvorschlag auswählen.");
+  }
+
+  if (uploadedCurrentFilename || uploadedProposedFilename) {
+    const refreshed = await apiClient.fetchRegulations();
+    options.setAvailableRegulations(refreshed.files);
+  }
+
+  return {
+    currentFilename,
+    proposedFilename,
+    llm,
+  };
+}
+
+type StartSummaryOptions = PrepareSessionDocumentsOptions & {
+  setSummaryReady: (ready: boolean) => void;
+  setRegulationsReady: (ready: boolean) => void;
+  setProcessesReady: (ready: boolean) => void;
+  setCurrentTab: (tab: number) => void;
+};
+
+export async function prepareSessionDocumentsAndStartSummary(
+  options: StartSummaryOptions
+): Promise<void> {
+  const { currentFilename, proposedFilename, llm } = await prepareSessionDocuments(options);
+  options.setSummaryReady(false);
+  await apiClient.summarizeRegulation(proposedFilename, {
+    currentFilename,
+    appSessionId: options.appSessionId,
+    model: llm.model,
+    provider: llm.provider,
+    keys: llm.keys,
+  });
+  window.dispatchEvent(new Event("tiles-updated"));
+  options.setSummaryReady(true);
+  options.setRegulationsReady(false);
+  options.setProcessesReady(false);
+  options.setCurrentTab(1);
+}
+
+export function formatSessionStartError(error: unknown): string {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+  return formatActionErrorMessage("Schritte konnten nicht vorbereitet werden", error);
+}
+
+export function logSessionStartError(
+  scope: string,
+  error: unknown,
+  context: Record<string, unknown>
+): void {
+  logClientError(scope, error, context);
+}

--- a/tests/test_regulations_flow.py
+++ b/tests/test_regulations_flow.py
@@ -98,6 +98,71 @@ def test_identify_regulations_flow(test_client, monkeypatch):
     assert repeat_payload["status"] == "existing"
 
 
+def test_identify_regulations_flow_without_current_law_uses_new_law_mode(
+    test_client, monkeypatch
+):
+    db.insert_law("new-law-proposed.txt", "neuer entwurf ohne gegenstueck")
+
+    prompts: list[str] = []
+    responses = iter(
+        [
+            '{"title": "Neue Regelung", "blurb": "Ein Satz."}',
+            """
+            {
+              "vorgaben": [
+                {"normzitat": "§ 1", "beschreibung": "Vorgabe A", "change_status": "new"}
+              ]
+            }
+            """,
+        ]
+    )
+
+    async def fake_query_llm(prompt, *_args, **_kwargs):
+        prompts.append(prompt)
+        return next(responses)
+
+    monkeypatch.setattr(regulations_router, "query_llm", fake_query_llm)
+
+    summary_resp = test_client.post(
+        "/regulations/summary",
+        json={
+            "filename": "new-law-proposed.txt",
+            "app_session_id": "NEW-LAW-FLOW",
+            "model": "test-model",
+            "provider": "deepinfra",
+        },
+    )
+    assert summary_resp.status_code == 200
+
+    identify_resp = test_client.post(
+        "/regulations/identify",
+        json={
+            "app_session_id": "NEW-LAW-FLOW",
+            "model": "test-model",
+            "provider": "deepinfra",
+        },
+    )
+    assert identify_resp.status_code == 200
+    payload = identify_resp.json()
+    assert [row["aenderungsstatus"] for row in payload["vorgaben"]] == ["eingefuehrt"]
+
+    session = db.get_session_by_app_id("NEW-LAW-FLOW")
+    assert session is not None
+    assert session["current_law_id"] is None
+    assert session["proposed_law_id"] is not None
+
+    assert len(prompts) == 2
+    assert "Arbeitsmodus: Neuregelung." in prompts[0]
+    assert "Arbeitsmodus: Neuregelung." in prompts[1]
+    assert "Geltendes Gesetz: neuer entwurf ohne gegenstueck" not in prompts[0]
+    assert (
+        "Folgendes ist das konsolidierte, geltende Gesetz: neuer entwurf ohne gegenstueck"
+        not in prompts[1]
+    )
+    assert "kein aktuell geltendes Gegenstueck" in prompts[0]
+    assert "kein aktuell geltendes Gegenstueck" in prompts[1]
+
+
 def test_identify_regulations_normalizes_change_status_variants(test_client, monkeypatch):
     db.insert_law("status-current.txt", "aktuelles gesetz")
     db.insert_law("status-proposed.txt", "neuer entwurf")
@@ -160,7 +225,7 @@ def test_identify_regulations_normalizes_change_status_variants(test_client, mon
     ]
 
 
-def test_identify_requires_session_law_selection(test_client, monkeypatch):
+def test_identify_requires_proposed_law_selection(test_client, monkeypatch):
     db.upsert_session("NO-LAW-IDS", "test-model")
 
     async def fail_query_llm(*_args, **_kwargs):
@@ -177,7 +242,10 @@ def test_identify_requires_session_law_selection(test_client, monkeypatch):
         },
     )
     assert resp.status_code == 422
-    assert resp.json()["detail"] == "Law files not selected for session. Run summary first."
+    assert resp.json()["detail"] == (
+        "Proposed law not selected for session. "
+        "Select a proposed law and run summary first."
+    )
 
 
 def test_identify_regulations_rejects_invalid_json_payload(test_client, monkeypatch):

--- a/tests/test_sessions_run_all.py
+++ b/tests/test_sessions_run_all.py
@@ -735,6 +735,27 @@ def test_run_all_reports_step_failure(test_client):
     assert payload["final_status"]["summary_ready"] is False
 
 
+def test_run_all_reports_step_failure_when_only_current_law_is_selected(test_client):
+    db.insert_law("current_only.txt", "aktuelles gesetz")
+
+    start_response = test_client.post(
+        "/sessions/run-all/start",
+        json={
+            "app_session_id": "RUNALL-CURRENT-ONLY",
+            "current_filename": "current_only.txt",
+            "model": "test-model",
+        },
+    )
+    assert start_response.status_code == 200
+    payload = _wait_for_run_completion(test_client, start_response.json()["run_id"])
+    assert payload["status"] == "failed"
+    assert payload["ok"] is False
+    assert payload["steps"][0]["key"] == "summary"
+    assert payload["steps"][0]["status"] == "failed"
+    assert payload["steps"][0]["message"] == "Missing proposed_filename for summary step"
+    assert payload["final_status"]["summary_ready"] is False
+
+
 def test_run_all_reports_failing_addressee_in_step_message(test_client, monkeypatch):
     app_session_id = "RUNALL-ADDRESSEE-FAIL"
     db.upsert_session(app_session_id, "test-model")

--- a/tests/test_sessions_run_all.py
+++ b/tests/test_sessions_run_all.py
@@ -600,6 +600,34 @@ def test_run_all_executes_workflow_end_to_end(test_client, monkeypatch):
     assert payload["final_status"]["last_completed_step"] == "total_cost"
 
 
+def test_run_all_executes_workflow_end_to_end_for_new_law_session(
+    test_client, monkeypatch
+):
+    app_session_id = "RUNALL-NEW-LAW"
+    db.insert_law("proposed_new_law.txt", "neuer entwurf")
+    _patch_run_all_llms(monkeypatch, app_session_id)
+
+    start_response = test_client.post(
+        "/sessions/run-all/start",
+        json={
+            "app_session_id": app_session_id,
+            "proposed_filename": "proposed_new_law.txt",
+            "model": "test-model",
+            "provider": "openai",
+        },
+    )
+    assert start_response.status_code == 200
+    payload = _wait_for_run_completion(test_client, start_response.json()["run_id"])
+    assert payload["status"] == "completed"
+    assert payload["ok"] is True
+    assert payload["final_status"]["total_cost_ready"] is True
+
+    session = db.get_session_by_app_id(app_session_id)
+    assert session is not None
+    assert session["current_law_id"] is None
+    assert session["proposed_law_id"] is not None
+
+
 def test_run_all_executes_all_addressees_end_to_end(test_client, monkeypatch):
     app_session_id = "RUNALL-ALL-ADDRESSEES"
     db.insert_law("current_all_addr.txt", "aktuelles gesetz")


### PR DESCRIPTION
The behaviour of this is now changed so that all steps that happen in the individual buttons 1-7 happen in the run-all button. Furthermore, you can compare a proposed file against no file in case you have a completely new regulation.