### PR TITLE
Fix tile rebuild addressee targeting

### DIFF
--- a/frontend/src/contexts/AppContext.tsx
+++ b/frontend/src/contexts/AppContext.tsx
@@ -108,24 +108,6 @@ const APP_SESSION_STORAGE_KEY = "app_session_id";
 const LEGACY_SESSION_STORAGE_KEY = "session_id";
 const SELECTED_NORM_ADDRESSEE_STORAGE_KEY = "selected_norm_addressee";
 
-// Lazy-Initializer fuer selectedNormAddressee: liest den zuletzt gewaehlten
-// Adressaten aus SessionStorage, damit nach Reload keine Verwaltung-Flash
-// entsteht und die Anzeige konsistent mit dem vorherigen User-Zustand ist.
-function readStoredNormAddressee(): NormAddressee {
-  if (typeof window === "undefined") {
-    return "administration";
-  }
-  try {
-    const stored = sessionStorage.getItem(SELECTED_NORM_ADDRESSEE_STORAGE_KEY);
-    if (stored === "administration" || stored === "business" || stored === "citizens") {
-      return stored;
-    }
-  } catch {
-    // SessionStorage kann in privaten Browsing-Modi oder SSR unzugaenglich
-    // sein - dann faellt das Feature auf den Default zurueck.
-  }
-  return "administration";
-}
 const NORM_ADDRESSEE_READINESS_STORAGE_KEY = "norm_addressee_readiness";
 const READINESS_STORAGE_KEYS = [
   "summary_ready",
@@ -149,7 +131,9 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
   const [appSessionId, setAppSessionIdState] = useState("");
   const [isFreshAppSessionId, setIsFreshAppSessionId] = useState(false);
   const [selectedNormAddressee, setSelectedNormAddresseeState] =
-    useState<NormAddressee>(readStoredNormAddressee);
+    useState<NormAddressee>("administration");
+  const [selectedNormAddresseeHydrated, setSelectedNormAddresseeHydrated] =
+    useState(false);
   const [selectedModel, setSelectedModel] = useState("");
   const [selectedModelHydrated, setSelectedModelHydrated] = useState(false);
   const [availableModels, setAvailableModels] = useState<Model[]>([]);
@@ -251,6 +235,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     if (stored === "administration" || stored === "business" || stored === "citizens") {
       setSelectedNormAddresseeState(stored);
     }
+    setSelectedNormAddresseeHydrated(true);
     const storedReadiness = sessionStorage.getItem(NORM_ADDRESSEE_READINESS_STORAGE_KEY);
     if (!storedReadiness) {
       return;
@@ -287,11 +272,14 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
   }, [appSessionId, readinessSetters, logDebug]);
 
   useEffect(() => {
+    if (!selectedNormAddresseeHydrated) {
+      return;
+    }
     sessionStorage.setItem(
       SELECTED_NORM_ADDRESSEE_STORAGE_KEY,
       selectedNormAddressee
     );
-  }, [selectedNormAddressee]);
+  }, [selectedNormAddressee, selectedNormAddresseeHydrated]);
 
   useEffect(() => {
     sessionStorage.setItem(

--- a/frontend/src/contexts/__tests__/AppContext.test.tsx
+++ b/frontend/src/contexts/__tests__/AppContext.test.tsx
@@ -1,5 +1,6 @@
 import { render, waitFor } from "@testing-library/react";
 import React from "react";
+import { renderToString } from "react-dom/server.node";
 
 import { AppProvider, useApp } from "@/contexts/AppContext";
 import { apiClient } from "@/lib/api";
@@ -118,5 +119,38 @@ describe("AppContext session status sync", () => {
       const node = getByTestId("state");
       expect(node.getAttribute("data-addressee")).toBe("citizens");
     });
+  });
+
+  it("does not overwrite the stored addressee before hydration completes", async () => {
+    sessionStorage.setItem("app_session_id", "ABC123");
+    sessionStorage.setItem("selected_norm_addressee", "business");
+    const setItemSpy = jest.spyOn(Storage.prototype, "setItem");
+
+    const { getByTestId } = render(
+      <AppProvider>
+        <ContextProbe />
+      </AppProvider>
+    );
+
+    await waitFor(() => {
+      expect(getByTestId("state").getAttribute("data-addressee")).toBe("business");
+    });
+    expect(setItemSpy).not.toHaveBeenCalledWith(
+      "selected_norm_addressee",
+      "administration"
+    );
+    setItemSpy.mockRestore();
+  });
+
+  it("uses the default addressee for server render even when storage has another value", () => {
+    sessionStorage.setItem("selected_norm_addressee", "business");
+
+    const html = renderToString(
+      <AppProvider>
+        <ContextProbe />
+      </AppProvider>
+    );
+
+    expect(html).toContain('data-addressee="administration"');
   });
 });

--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -42,7 +42,7 @@ describe("apiClient.rebuildTiles", () => {
     );
   });
 
-  it("omits administration because the backend default is administration", async () => {
+  it("also sends administration explicitly", async () => {
     await apiClient.rebuildTiles("ABC123", "administration");
 
     expect(fetchMock).toHaveBeenCalledWith(
@@ -50,7 +50,7 @@ describe("apiClient.rebuildTiles", () => {
       expect.objectContaining({
         body: JSON.stringify({
           app_session_id: "ABC123",
-          norm_addressee: undefined,
+          norm_addressee: "administration",
         }),
       })
     );

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -274,10 +274,7 @@ export const apiClient = {
       },
       body: JSON.stringify({
         app_session_id: appSessionId,
-        norm_addressee:
-          normAddressee && normAddressee !== "administration"
-            ? normAddressee
-            : undefined,
+        norm_addressee: normAddressee,
       }),
     });
     if (!response.ok) {

--- a/tests/test_tiles_rebuild_steps.py
+++ b/tests/test_tiles_rebuild_steps.py
@@ -1,6 +1,6 @@
 from backend.core import db
 from backend.core.models import Tile
-from backend.core.norm_addressees import BUSINESS, CITIZENS
+from backend.core.norm_addressees import ADMINISTRATION, BUSINESS, CITIZENS
 
 
 def test_rebuild_tiles_keeps_step_order(test_client):
@@ -45,6 +45,77 @@ def test_rebuild_tiles_keeps_step_order(test_client):
     by_id = {tile.id: tile for tile in step_tiles}
     assert by_id[f"step_{step_one}"].column < by_id[f"step_{step_two}"].column
     assert by_id[f"step_{step_two}"].column < by_id[f"step_{step_three}"].column
+
+
+def test_rebuild_tiles_restores_deleted_business_tiles_for_selected_addressee(test_client):
+    """Regression for #19: rebuild must restore the active addressee snapshot."""
+    app_session_id = "TILES-REBUILD-BUSINESS"
+    session_id, _ = db.upsert_session(app_session_id, "test-model")
+    db.update_session_summary(
+        app_session_id,
+        "Titel",
+        "Zusammenfassung",
+        law_diff_blurb="Kurzfassung",
+    )
+
+    admin_process_id = db.insert_process(
+        session_id,
+        "Admin Prozess",
+        "Admin Beschreibung",
+        norm_addressee=ADMINISTRATION,
+    )
+    business_process_id = db.insert_process(
+        session_id,
+        "Business Prozess",
+        "Business Beschreibung",
+        norm_addressee=BUSINESS,
+    )
+    business_regulation_id = db.insert_regulation(
+        session_id,
+        "§ B",
+        "Business Vorgabe",
+        applies_to_administration=False,
+        applies_to_business=True,
+    )
+    assert db.update_regulation_process(
+        regulation_id=business_regulation_id,
+        process_id=business_process_id,
+        norm_addressee=BUSINESS,
+    )
+
+    resp = test_client.post(
+        "/tiles/rebuild",
+        json={"app_session_id": app_session_id, "norm_addressee": BUSINESS},
+    )
+    assert resp.status_code == 200
+    assert {
+        tile.id for tile in db.fetch_tiles(session_id=session_id, norm_addressee=BUSINESS)
+    } >= {f"regulation_{business_regulation_id}", f"process_{business_process_id}"}
+
+    delete_resp = test_client.delete(
+        f"/tiles/process_{business_process_id}",
+        params={"app_session_id": app_session_id, "norm_addressee": BUSINESS},
+    )
+    assert delete_resp.status_code == 200
+    assert f"process_{business_process_id}" not in {
+        tile.id for tile in db.fetch_tiles(session_id=session_id, norm_addressee=BUSINESS)
+    }
+
+    resp = test_client.post(
+        "/tiles/rebuild",
+        json={"app_session_id": app_session_id, "norm_addressee": BUSINESS},
+    )
+    assert resp.status_code == 200
+
+    business_tile_ids = {
+        tile.id for tile in db.fetch_tiles(session_id=session_id, norm_addressee=BUSINESS)
+    }
+    admin_tile_ids = {
+        tile.id for tile in db.fetch_tiles(session_id=session_id, norm_addressee=ADMINISTRATION)
+    }
+    assert f"process_{business_process_id}" in business_tile_ids
+    assert f"process_{admin_process_id}" not in business_tile_ids
+    assert f"process_{business_process_id}" not in admin_tile_ids
 
 
 def test_rebuild_uses_blurb_for_law_tile_text(test_client):


### PR DESCRIPTION
## Summary

Fixes the tile rebuild path for sessions with multiple norm addressees. The frontend now sends the selected norm addressee explicitly for every rebuild request, including administration, so the backend does not silently fall back to its default.

Added a backend regression test for the Issue #19 addressee-targeting scenario: a deleted business tile is restored by a business rebuild while the administration snapshot stays separate.

Also fixes a React hydration mismatch caused by reading `selected_norm_addressee` from `sessionStorage` during initial render. The app now renders the default addressee consistently first and restores the stored addressee after mount.

## Tests

- Python: `tests/test_tiles_rebuild_steps.py tests/test_tiles_session_scope.py`
- Frontend: `api.test.ts SessionMenu.test.tsx AppContext.test.tsx Header.test.tsx`
- `git diff --check`

## Im Tool getestet

- In `Wirtschaft`, deleted a business tile and used `Kacheln dieser Session neu laden`.
- Confirmed that the deleted business tile was restored in the business view.
- Switched to `Verwaltung` and confirmed that business tiles did not appear in the administration view.
- Reloaded the page after selecting `Wirtschaft` and confirmed that the selected addressee was restored without the previous React hydration warning.

## Notes

Addresses the addressee-targeting bug from #19. The broader product decision for domain-aware tile deletion remains separate and should be handled via #28 or a follow-up issue.