### PR TITLE
Harden Codex agent model fallback

### DIFF
--- a/.codex/agents/code_mapper.toml
+++ b/.codex/agents/code_mapper.toml
@@ -1,6 +1,6 @@
 name = "code_mapper"
 description = "Read-only mapper for architecture, changed files, call paths, and risk areas."
-model = "gpt-5-mini"
+model = "gpt-5.4-mini"
 sandbox_mode = "read-only"
 
 developer_instructions = """

--- a/.codex/agents/docs_researcher.toml
+++ b/.codex/agents/docs_researcher.toml
@@ -1,6 +1,6 @@
 name = "docs_researcher"
 description = "Documentation specialist that verifies framework and API behavior."
-model = "gpt-5-mini"
+model = "gpt-5.4-mini"
 sandbox_mode = "read-only"
 
 developer_instructions = """

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ This project defines Codex role specifications in `.codex/agents/` and shared sk
 - `AGENTS.md` and `.agents/skills/*` are the repo-local guidance layers that should be assumed to work today.
 - `.codex/agents/*.toml` should be treated as role definitions and controlling instruction sets.
 - When a user refers to a role by name, Codex should decide whether to use native role/subagent support or to follow the corresponding `.codex/agents/<role>.toml` role spec in the current session, depending on runtime capabilities.
+- If native role/subagent launch fails because the configured/native model is unavailable, do not retry the same failing native role path. Fall back to the corresponding `.codex/agents/<role>.toml` behavior spec using an available default subagent or by mimicking the role locally.
 - Referring to a role by name should imply its full behavior contract. For example, asking for `feature_developer` should trigger code inspection, clarifying questions, workplan creation/update, and an approval checkpoint before edits without the user needing to restate those steps.
 - `.claude/agents/*` are Claude Code-native subagent definitions.
 

--- a/AGENT_USER_GUIDE.md
+++ b/AGENT_USER_GUIDE.md
@@ -20,6 +20,7 @@ Use it to answer these questions:
 - `CODING_ASSISTANT.md` is the canonical engineering guide for repo rules and layering expectations.
 - `.codex/agents/*.toml` define Codex role behavior.
 - When you name a Codex role, Codex should decide whether to use native role/subagent support or to follow the corresponding `.codex/agents/*.toml` role spec in the current session.
+- If a native Codex role cannot start because its model is unavailable in the current runtime, Codex should fall back to the matching `.codex/agents/*.toml` behavior spec with an available default subagent or mimic the role locally.
 - Naming a role should imply its full behavior contract. For example, `feature_developer` should inspect the code, ask clarifying questions, create or update a workplan, and wait for approval before editing.
 - `.claude/agents/*` are Claude Code-native subagent definitions.
 - `CLAUDE.md` is the Claude Code entrypoint for this repo.


### PR DESCRIPTION
## Summary

This PR makes the repo-local Codex agent setup more robust in runtimes where older configured model IDs are unavailable.

- updates read-only Codex helper agents from gpt-5-mini to gpt-5.4-mini
- documents that Codex should fall back to the matching TOML role behavior when native role launch fails because the configured or native model is unavailable

## Tests

- git diff --check

This is a config/docs-only change.