### PR TITLE
Update prompt role to Bundesressort

### DIFF
--- a/backend/core/prompts.py
+++ b/backend/core/prompts.py
@@ -36,8 +36,9 @@ PROMPTS_REQUIRING_NORM_ADDRESSEE = {
 
 LEGIST_PROMPT_OPENING = (
     """
-    Sie sind Legist im Bundesressort und damit betraut, die
-    Erfuellungsaufwandsaenderung zu einer geplanten Gesetzesaenderung zu berechnen.
+    Sie sind Legist und unterstuetzen die fachliche Pruefung eines
+    Gesetzesentwurfs auf Bundesebene, indem Sie die
+    Erfuellungsaufwandsaenderung zu einer geplanten Gesetzesaenderung berechnen.
 
     Insbesondere werden zur Ermittlung der zu erwartenden Aenderung des Aufwands
     pro Fall die wesentlichen Taetigkeiten identifiziert, die zur Erfuellung
@@ -546,7 +547,8 @@ PROMPT_TEMPLATES: Dict[str, str] = {
     # - gesetz_vorschlag: str
     PromptId.LAW_SUMMARY: (
         """
-        Sie sind Legist im Bundesressort.
+        Sie sind Legist und unterstuetzen die fachliche Pruefung eines
+        Gesetzesentwurfs auf Bundesebene.
 
         {law_mode_context}
 
@@ -566,8 +568,9 @@ PROMPT_TEMPLATES: Dict[str, str] = {
     # - gesetz_vorschlag: str
     PromptId.REGULATIONS_IDENTIFICATION: (
         """
-        Sie sind Legist im Bundesressort und damit betraut, die
-        Erfuellungsaufwandsaenderung zu einer geplanten Gesetzesaenderung zu berechnen.
+        Sie sind Legist und unterstuetzen die fachliche Pruefung eines
+        Gesetzesentwurfs auf Bundesebene, indem Sie die
+        Erfuellungsaufwandsaenderung zu einer geplanten Gesetzesaenderung berechnen.
 
         Insbesondere werden zur Ermittlung der zu erwartenden Aenderung des Aufwands
         pro Fall die wesentlichen Taetigkeiten identifiziert, die zur Erfuellung

--- a/backend/core/prompts.py
+++ b/backend/core/prompts.py
@@ -36,7 +36,7 @@ PROMPTS_REQUIRING_NORM_ADDRESSEE = {
 
 LEGIST_PROMPT_OPENING = (
     """
-    Sie sind Legist im deutschen Bundestag und damit betraut, die
+    Sie sind Legist im Bundesressort und damit betraut, die
     Erfuellungsaufwandsaenderung zu einer geplanten Gesetzesaenderung zu berechnen.
 
     Insbesondere werden zur Ermittlung der zu erwartenden Aenderung des Aufwands
@@ -546,7 +546,7 @@ PROMPT_TEMPLATES: Dict[str, str] = {
     # - gesetz_vorschlag: str
     PromptId.LAW_SUMMARY: (
         """
-        Sie sind Legist im deutschen Bundestag.
+        Sie sind Legist im Bundesressort.
 
         {law_mode_context}
 
@@ -566,7 +566,7 @@ PROMPT_TEMPLATES: Dict[str, str] = {
     # - gesetz_vorschlag: str
     PromptId.REGULATIONS_IDENTIFICATION: (
         """
-        Sie sind Legist im deutschen Bundestag und damit betraut, die
+        Sie sind Legist im Bundesressort und damit betraut, die
         Erfuellungsaufwandsaenderung zu einer geplanten Gesetzesaenderung zu berechnen.
 
         Insbesondere werden zur Ermittlung der zu erwartenden Aenderung des Aufwands

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -273,7 +273,7 @@ def test_norm_addressee_prompts_integrate_guidance_before_schema(prompt_id, norm
 def test_process_step_analysis_prompt_sets_known_norm_addressee_after_context():
     prompt = _render_step_analysis_prompt(BUSINESS)
 
-    assert prompt.index("Sie sind Legist im Bundesressort") < prompt.index(
+    assert prompt.index("Sie sind Legist und unterstuetzen die fachliche Pruefung") < prompt.index(
         "Das Gesetz bzw. die Gesetzesaenderung ist wie folgt"
     )
     assert "Dieser Lauf betrifft nur den Normadressaten Wirtschaft" in prompt
@@ -304,7 +304,7 @@ def test_process_step_analysis_prompt_uses_integrated_step_specific_intro():
     prompt = _render_step_analysis_prompt(BUSINESS)
 
     assert "Ihre Aufgabe ist es, die wesentlichen anfallenden Taetigkeiten" in prompt
-    assert prompt.index("Sie sind Legist im Bundesressort") < prompt.index(
+    assert prompt.index("Sie sind Legist und unterstuetzen die fachliche Pruefung") < prompt.index(
         "Ihre Aufgabe ist es, die wesentlichen anfallenden Taetigkeiten"
     )
 

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -273,7 +273,7 @@ def test_norm_addressee_prompts_integrate_guidance_before_schema(prompt_id, norm
 def test_process_step_analysis_prompt_sets_known_norm_addressee_after_context():
     prompt = _render_step_analysis_prompt(BUSINESS)
 
-    assert prompt.index("Sie sind Legist im deutschen Bundestag") < prompt.index(
+    assert prompt.index("Sie sind Legist im Bundesressort") < prompt.index(
         "Das Gesetz bzw. die Gesetzesaenderung ist wie folgt"
     )
     assert "Dieser Lauf betrifft nur den Normadressaten Wirtschaft" in prompt
@@ -304,7 +304,7 @@ def test_process_step_analysis_prompt_uses_integrated_step_specific_intro():
     prompt = _render_step_analysis_prompt(BUSINESS)
 
     assert "Ihre Aufgabe ist es, die wesentlichen anfallenden Taetigkeiten" in prompt
-    assert prompt.index("Sie sind Legist im deutschen Bundestag") < prompt.index(
+    assert prompt.index("Sie sind Legist im Bundesressort") < prompt.index(
         "Ihre Aufgabe ist es, die wesentlichen anfallenden Taetigkeiten"
     )
 
@@ -476,5 +476,4 @@ def test_citizens_step_analysis_prompt_matches_schema_without_time_estimate():
     assert "Schaetzen Sie in diesem Schritt keine Minuten, Lohngruppen" in prompt
     assert "Schaetzen Sie in der Schrittanalyse keine Zeit-" not in prompt
     assert "Gesamtzeitaufwand" not in prompt
-
 


### PR DESCRIPTION
## Summary
- replace the prompt role wording from "Legist im deutschen Bundestag" to "Legist im Bundesressort"
- update prompt tests that assert the role wording order

## Tests
- venv/bin/python -m pytest tests/test_prompts.py