### PR TITLE
Deep Research with Gemini (Issue 27)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,8 @@ This project defines Codex role specifications in `.codex/agents/` and shared sk
 ## Critical Invariants (Quick Reference)
 
 - Workflow is the 7-step pipeline (`summary` -> `total_cost`); EA editing is post-step (outside run-all).
+- Run-all is only a sequencer: apart from skipping completed steps, it must have the same effect as pressing each step button in order.
+- Run-all must not contain step-specific business logic that differs from manual execution.
 - Run-all skips completed steps and only re-runs them after `undo` (revert/reset) of state.
 - Step 6 (`effort`) performs paired parallel prompt calls (`cases_calculation` + `effort_calculation`).
 - Keep layering boundaries:

--- a/CODING_ASSISTANT.md
+++ b/CODING_ASSISTANT.md
@@ -66,6 +66,8 @@
 
 ## Run-All Rules
 - Run-all executes steps in the defined 7-step order.
+- Run-all is only a sequencer: apart from skipping completed steps, it must have the same effect as the user pressing each step button in order.
+- Run-all must not contain step-specific business logic that differs from manual execution; shared step runners/services should own step behavior.
 - Completed steps are skipped; steps are re-run only after undo (revert/reset) of the corresponding state.
 - Start: `POST /sessions/run-all/start`
 - Observe:

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -31,6 +31,9 @@ class Settings(BaseSettings):
     prompt_audit_enabled: bool = False
     prompt_audit_output_dir: Path = BASE_DIR / "prompt_audits"
     prompt_audit_session_ids: str = ""
+    deep_research_primary_agent: str = "deep-research-preview-04-2026"
+    deep_research_fallback_agent: str = "deep-research-pro-preview-12-2025"
+    deep_research_poll_interval_seconds: float = 5.0
     db_path: Path = DEFAULT_DB_PATH
     regulations_path: Path = DEFAULT_REGULATIONS_PATH
 

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -34,6 +34,11 @@ class Settings(BaseSettings):
     deep_research_primary_agent: str = "deep-research-preview-04-2026"
     deep_research_fallback_agent: str = "deep-research-pro-preview-12-2025"
     deep_research_poll_interval_seconds: float = 5.0
+    # 2026-06-10: Gemini docs state Deep Research has a 60-minute server-side max
+    # and most tasks should complete within 20 minutes; keep the local poll cap
+    # explicit so stuck interactions cannot run forever.
+    deep_research_max_poll_seconds: float = 1800.0
+    deep_research_request_timeout_seconds: float = 30.0
     db_path: Path = DEFAULT_DB_PATH
     regulations_path: Path = DEFAULT_REGULATIONS_PATH
 

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -43,27 +43,27 @@ class Settings(BaseSettings):
 settings = Settings()
 
 OPENAI_RECOMMENDED = [
+    "gpt-5.5",
+    "gpt-5.4",
+    "gpt-5.4-mini",
+    "gpt-5.4-nano",
     "gpt-5.2",
-    "gpt-5.2-pro",
-    "gpt-5.1",
-    "gpt-5",
-    "gpt-5-mini",
 ]
 
 DEEPINFRA_RECOMMENDED = [
-    "anthropic/claude-4-opus",
-    "anthropic/claude-4-sonnet",
-    "deepseek-ai/DeepSeek-R1-0528",
+    "anthropic/claude-sonnet-4-6",
+    "anthropic/claude-opus-4-7",
+    "deepseek-ai/DeepSeek-V3.2",
+    "Qwen/Qwen3.5-397B-A17B",
     "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8",
-    "Qwen/Qwen2.5-72B-Instruct",
 ]
 
 GEMINI_RECOMMENDED = [
-    "gemini-2.5-pro",
-    "gemini-2.5-flash",
-    "gemini-2.5-flash-lite",
-    "gemini-3-pro-preview",
+    "gemini-3.5-flash",
+    "gemini-3.1-pro-preview",
+    "gemini-3.1-flash-lite",
     "gemini-3-flash-preview",
+    "gemini-2.5-pro",
     # "gemini-2.0-flash",
     # "gemini-2.0-flash-lite",
 ]

--- a/backend/core/db.py
+++ b/backend/core/db.py
@@ -4,6 +4,7 @@ import json
 import sqlite3
 from contextlib import contextmanager
 from contextvars import ContextVar
+from datetime import datetime
 from pathlib import Path
 from typing import Iterable, List
 
@@ -1964,6 +1965,113 @@ def get_latest_deep_research_run_status(session_id: int, purpose: str) -> str:
     return str(run.get("status") or "idle") if run else "idle"
 
 
+def get_latest_deep_research_run_elapsed_seconds(
+    session_id: int,
+    purpose: str,
+) -> int | None:
+    run = get_latest_deep_research_run(session_id, purpose)
+    if not run or not run.get("started_at"):
+        return None
+    completed_at = run.get("completed_at")
+    try:
+        started = datetime.fromisoformat(str(run["started_at"]).replace(" ", "T"))
+        completed = (
+            datetime.fromisoformat(str(completed_at).replace(" ", "T"))
+            if completed_at
+            else datetime.utcnow()
+        )
+    except ValueError:
+        return None
+    return max(0, int((completed - started).total_seconds()))
+
+
+def _elapsed_ms_between(started_at: object, completed_at: object) -> int | None:
+    if not started_at or not completed_at:
+        return None
+    try:
+        started = datetime.fromisoformat(str(started_at).replace(" ", "T"))
+        completed = datetime.fromisoformat(str(completed_at).replace(" ", "T"))
+    except ValueError:
+        return None
+    elapsed = int((completed - started).total_seconds() * 1000)
+    return max(elapsed, 0)
+
+
+def list_recent_deep_research_monitor_rows_for_session(
+    session_id: int,
+    limit: int = 80,
+) -> list[dict]:
+    safe_limit = max(1, min(limit, 500))
+    conn = get_conn()
+    cur = conn.cursor()
+    cur.execute(
+        """
+        SELECT
+            research_run_id,
+            purpose,
+            provider,
+            agent,
+            status,
+            error,
+            input_tokens,
+            output_tokens,
+            thought_tokens,
+            estimated_cost_usd,
+            created_at,
+            started_at,
+            completed_at,
+            parsed_at
+        FROM deep_research_runs
+        WHERE session_id = ? AND purpose = 'case_group_metrics'
+        ORDER BY research_run_id DESC
+        LIMIT ?
+        """,
+        (session_id, safe_limit),
+    )
+    rows = [dict(row) for row in cur.fetchall()]
+    _maybe_close(conn)
+
+    normalized: list[dict] = []
+    for row in rows:
+        status = str(row.get("status") or "")
+        if status == "running":
+            continue
+        if status == "parsed":
+            answer_state = LLM_ANSWER_STATE_ACTIVE
+            state_reason = "session_updated"
+        elif status == "completed":
+            answer_state = LLM_ANSWER_STATE_PENDING
+            state_reason = "waiting_for_session_update"
+        else:
+            answer_state = LLM_ANSWER_STATE_INVALID
+            state_reason = status or "deep_research_failed"
+        completed_at = row.get("parsed_at") or row.get("completed_at")
+        normalized.append(
+            {
+                "answer_id": None,
+                "prompt_id": "deep_research_case_group_metrics",
+                "model": str(row.get("agent") or ""),
+                "provider": str(row.get("provider") or "gemini"),
+                "attempt_id": f"deep_research:{row.get('research_run_id')}",
+                "request_id": None,
+                "route_method": None,
+                "route_path": None,
+                "elapsed_ms": _elapsed_ms_between(row.get("started_at"), completed_at),
+                "answer_state": answer_state,
+                "state_reason": state_reason,
+                "input_tokens": row.get("input_tokens"),
+                "output_tokens": row.get("output_tokens"),
+                "hidden_thinking_tokens": row.get("thought_tokens"),
+                "estimated_cost_usd": row.get("estimated_cost_usd"),
+                "error_kind": status if status in {"failed", "cancelled"} else None,
+                "error_status_code": None,
+                "error": row.get("error"),
+                "created_at": completed_at or row.get("created_at"),
+            }
+        )
+    return normalized
+
+
 def clear_case_group_research(session_id: int) -> None:
     conn = get_conn()
     cur = conn.cursor()
@@ -2116,6 +2224,10 @@ def get_session_status(app_session_id: str) -> dict | None:
             session.get("case_group_research_enabled")
         ),
         "case_group_research_status": get_latest_deep_research_run_status(
+            session_id,
+            "case_group_metrics",
+        ),
+        "case_group_research_elapsed_seconds": get_latest_deep_research_run_elapsed_seconds(
             session_id,
             "case_group_metrics",
         ),

--- a/backend/core/db.py
+++ b/backend/core/db.py
@@ -598,6 +598,7 @@ def _create_case_groups_table(cur: sqlite3.Cursor, table_name: str = "case_group
             cases_proposed_edited       REAL,
             cost                        REAL,
             last_edited_at              TEXT,
+            case_metric_research_json   JSON,
             FOREIGN KEY (process_id)
             REFERENCES processes
                 ON UPDATE CASCADE
@@ -607,6 +608,49 @@ def _create_case_groups_table(cur: sqlite3.Cursor, table_name: str = "case_group
                 ON UPDATE CASCADE
                 ON DELETE CASCADE
         )
+        """
+    )
+
+
+def _create_deep_research_runs_table(
+    cur: sqlite3.Cursor,
+    table_name: str = "deep_research_runs",
+) -> None:
+    cur.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {table_name} (
+            research_run_id       INTEGER PRIMARY KEY,
+            session_id            INTEGER NOT NULL,
+            purpose               TEXT NOT NULL,
+            provider              TEXT NOT NULL DEFAULT 'gemini',
+            agent                 TEXT NOT NULL,
+            status                TEXT NOT NULL,
+            interaction_id        TEXT,
+            prompt_text           TEXT,
+            report_md             TEXT,
+            result_json           JSON,
+            response_json         JSON,
+            error                 TEXT,
+            input_tokens          INTEGER,
+            output_tokens         INTEGER,
+            thought_tokens        INTEGER,
+            total_tokens          INTEGER,
+            estimated_cost_usd    REAL,
+            created_at            TEXT NOT NULL DEFAULT current_timestamp,
+            started_at            TEXT,
+            completed_at          TEXT,
+            parsed_at             TEXT,
+            FOREIGN KEY (session_id)
+            REFERENCES sessions (session_id)
+                ON UPDATE CASCADE
+                ON DELETE CASCADE
+        )
+        """
+    )
+    cur.execute(
+        f"""
+        CREATE INDEX IF NOT EXISTS idx_{table_name}_session_purpose
+        ON {table_name}(session_id, purpose, research_run_id)
         """
     )
 
@@ -982,6 +1026,12 @@ def _run_legacy_migrations(cur: sqlite3.Cursor) -> None:
     _ensure_column(
         cur,
         "sessions",
+        "case_group_research_enabled",
+        "INTEGER NOT NULL DEFAULT 0",
+    )
+    _ensure_column(
+        cur,
+        "sessions",
         "pay_rate_administration_level",
         f"TEXT NOT NULL DEFAULT '{PAY_RATE_LEVEL_BUND}'",
     )
@@ -1043,6 +1093,7 @@ def _run_legacy_migrations(cur: sqlite3.Cursor) -> None:
     _ensure_column(cur, "case_groups", "annual_frequency_proposed_edited", "REAL")
     _ensure_column(cur, "case_groups", "cases_proposed_edited", "REAL")
     _ensure_column(cur, "case_groups", "last_edited_at", "TEXT")
+    _ensure_column(cur, "case_groups", "case_metric_research_json", "JSON")
 
     # Migration helper: add editable overrides for process-step metrics.
     for suffix in ("current", "proposed"):
@@ -1171,6 +1222,7 @@ def init_db() -> None:
     )
     _create_pay_rate_defaults_table(cur)
     _seed_pay_rate_defaults(cur)
+    _create_deep_research_runs_table(cur)
     # TODO: Maybe add updated_at with trigger rule: https://www.sqlitetutorial.net/sqlite-date-functions/sqlite-current_timestamp/
     # TODO: Potentially add the change in cases? How meaningful is that number?
     cur.execute(
@@ -1196,6 +1248,7 @@ def init_db() -> None:
             law_diff_title      TEXT,
             law_diff_blurb      TEXT,
             law_diff_summary    TEXT,
+            case_group_research_enabled INTEGER NOT NULL DEFAULT 0,
             cc_cost             REAL,
             FOREIGN KEY (current_law_id) 
             REFERENCES laws(document_id) 
@@ -1213,6 +1266,7 @@ def init_db() -> None:
     )
     _create_session_total_costs_by_addressee_table(cur)
     _create_session_pay_rate_overrides_by_addressee_table(cur)
+    _create_deep_research_runs_table(cur)
     _create_session_scoped_tile_tables(cur)
     cur.execute(
         """
@@ -1738,7 +1792,8 @@ def list_sessions(limit: int = 50) -> List[dict]:
             s.app_session_id,
             s.created_at,
             s.llm_model,
-            s.used_llm_models
+            s.used_llm_models,
+            s.case_group_research_enabled
         FROM sessions AS s
         ORDER BY s.created_at DESC, s.session_id DESC
         LIMIT ?
@@ -1748,6 +1803,193 @@ def list_sessions(limit: int = 50) -> List[dict]:
     rows = [dict(row) for row in cur.fetchall()]
     _maybe_close(conn)
     return rows
+
+
+def get_case_group_research_enabled(session_id: int) -> bool:
+    conn = get_conn()
+    cur = conn.cursor()
+    cur.execute(
+        """
+        SELECT case_group_research_enabled
+        FROM sessions
+        WHERE session_id = ?
+        LIMIT 1
+        """,
+        (session_id,),
+    )
+    row = cur.fetchone()
+    _maybe_close(conn)
+    return bool(row and row["case_group_research_enabled"])
+
+
+def update_case_group_research_enabled(session_id: int, enabled: bool) -> bool:
+    conn = get_conn()
+    cur = conn.cursor()
+    cur.execute(
+        """
+        UPDATE sessions
+        SET case_group_research_enabled = ?
+        WHERE session_id = ?
+          AND COALESCE(case_group_research_enabled, 0) != ?
+        """,
+        (1 if enabled else 0, session_id, 1 if enabled else 0),
+    )
+    changed = cur.rowcount > 0
+    _maybe_commit(conn)
+    _maybe_close(conn)
+    return changed
+
+
+def create_deep_research_run(
+    *,
+    session_id: int,
+    purpose: str,
+    agent: str,
+    provider: str = "gemini",
+    prompt_text: str | None = None,
+    status: str = "idle",
+) -> int:
+    conn = get_conn()
+    cur = conn.cursor()
+    cur.execute(
+        """
+        INSERT INTO deep_research_runs (
+            session_id,
+            purpose,
+            provider,
+            agent,
+            status,
+            prompt_text,
+            started_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, CASE WHEN ? = 'running' THEN current_timestamp ELSE NULL END)
+        """,
+        (session_id, purpose, provider, agent, status, prompt_text, status),
+    )
+    _maybe_commit(conn)
+    research_run_id = int(cur.lastrowid)
+    _maybe_close(conn)
+    return research_run_id
+
+
+def update_deep_research_run(
+    research_run_id: int,
+    *,
+    status: str | None = None,
+    agent: str | None = None,
+    interaction_id: str | None = None,
+    report_md: str | None = None,
+    result_json: dict | list | None = None,
+    response_json: dict | list | None = None,
+    error: str | None = None,
+    input_tokens: int | None = None,
+    output_tokens: int | None = None,
+    thought_tokens: int | None = None,
+    total_tokens: int | None = None,
+    estimated_cost_usd: float | None = None,
+) -> None:
+    assignments: list[str] = []
+    values: list[object] = []
+    if status is not None:
+        assignments.append("status = ?")
+        values.append(status)
+        if status == "running":
+            assignments.append("started_at = COALESCE(started_at, current_timestamp)")
+        if status in {"completed", "failed", "cancelled"}:
+            assignments.append("completed_at = COALESCE(completed_at, current_timestamp)")
+        if status == "parsed":
+            assignments.append("parsed_at = COALESCE(parsed_at, current_timestamp)")
+            assignments.append("completed_at = COALESCE(completed_at, current_timestamp)")
+    for column, value in (
+        ("agent", agent),
+        ("interaction_id", interaction_id),
+        ("report_md", report_md),
+        ("error", error),
+        ("input_tokens", input_tokens),
+        ("output_tokens", output_tokens),
+        ("thought_tokens", thought_tokens),
+        ("total_tokens", total_tokens),
+        ("estimated_cost_usd", estimated_cost_usd),
+    ):
+        if value is not None:
+            assignments.append(f"{column} = ?")
+            values.append(value)
+    if result_json is not None:
+        assignments.append("result_json = ?")
+        values.append(json.dumps(result_json, ensure_ascii=False))
+    if response_json is not None:
+        assignments.append("response_json = ?")
+        values.append(json.dumps(response_json, ensure_ascii=False))
+    if not assignments:
+        return
+    conn = get_conn()
+    cur = conn.cursor()
+    cur.execute(
+        f"""
+        UPDATE deep_research_runs
+        SET {", ".join(assignments)}
+        WHERE research_run_id = ?
+        """,
+        (*values, research_run_id),
+    )
+    _maybe_commit(conn)
+    _maybe_close(conn)
+
+
+def get_latest_deep_research_run(
+    session_id: int,
+    purpose: str,
+) -> dict | None:
+    conn = get_conn()
+    cur = conn.cursor()
+    cur.execute(
+        """
+        SELECT *
+        FROM deep_research_runs
+        WHERE session_id = ? AND purpose = ?
+        ORDER BY research_run_id DESC
+        LIMIT 1
+        """,
+        (session_id, purpose),
+    )
+    row = cur.fetchone()
+    _maybe_close(conn)
+    if row is None:
+        return None
+    return dict(row)
+
+
+def get_latest_deep_research_run_status(session_id: int, purpose: str) -> str:
+    run = get_latest_deep_research_run(session_id, purpose)
+    return str(run.get("status") or "idle") if run else "idle"
+
+
+def clear_case_group_research(session_id: int) -> None:
+    conn = get_conn()
+    cur = conn.cursor()
+    cur.execute(
+        """
+        DELETE FROM deep_research_runs
+        WHERE session_id = ? AND purpose = 'case_group_metrics'
+        """,
+        (session_id,),
+    )
+    cur.execute(
+        """
+        UPDATE case_groups
+        SET addressees_current = NULL,
+            annual_frequency_current = NULL,
+            cases_current = NULL,
+            addressees_proposed = NULL,
+            annual_frequency_proposed = NULL,
+            cases_proposed = NULL,
+            case_metric_research_json = NULL
+        WHERE session_id = ?
+        """,
+        (session_id,),
+    )
+    _maybe_commit(conn)
+    _maybe_close(conn)
 
 
 def list_edit_audit_for_session(session_id: int, limit: int = 200) -> List[dict]:
@@ -1870,7 +2112,58 @@ def get_session_status(app_session_id: str) -> dict | None:
         ),
         "effort_ready_by_addressee": effort_ready_by_addressee,
         "total_cost_ready_by_addressee": total_cost_ready_by_addressee,
+        "case_group_research_enabled": bool(
+            session.get("case_group_research_enabled")
+        ),
+        "case_group_research_status": get_latest_deep_research_run_status(
+            session_id,
+            "case_group_metrics",
+        ),
     }
+
+
+def _count_process_steps_with_cost_inputs(
+    cur: sqlite3.Cursor,
+    session_id: int,
+    norm_addressee: str,
+) -> tuple[int, int]:
+    cur.execute(
+        """
+        SELECT COUNT(*) AS total_count
+        FROM process_steps
+        WHERE session_id = ? AND norm_addressee = ?
+        """,
+        (session_id, norm_addressee),
+    )
+    total_steps = int(cur.fetchone()["total_count"] or 0)
+    if total_steps == 0:
+        return 0, 0
+
+    # Ready-Check MUSS auf dieselben Felder schauen, die _has_step_cost_inputs
+    # in costs.py fordert, sonst meldet die Pipeline faelschlich "fertig",
+    # effort.py skippt die Neuberechnung, und compute_costs wirft 422.
+    # hourly_rate ist allein nicht kostenrelevant; die Rate kommt ggf. aus active_rates.
+    cur.execute(
+        """
+        SELECT COUNT(*) AS count
+        FROM process_steps
+        WHERE session_id = ? AND norm_addressee = ?
+          AND (
+            time_required_in_min_a_current IS NOT NULL
+            OR time_required_in_min_b_current IS NOT NULL
+            OR time_required_in_min_c_current IS NOT NULL
+            OR time_required_in_min_d_current IS NOT NULL
+            OR time_required_in_min_a_proposed IS NOT NULL
+            OR time_required_in_min_b_proposed IS NOT NULL
+            OR time_required_in_min_c_proposed IS NOT NULL
+            OR time_required_in_min_d_proposed IS NOT NULL
+            OR expenses_current IS NOT NULL
+            OR expenses_proposed IS NOT NULL
+          )
+        """,
+        (session_id, norm_addressee),
+    )
+    return total_steps, int(cur.fetchone()["count"])
 
 
 def has_effort_metrics(session_id: int, norm_addressee: str = ADMINISTRATION) -> bool:
@@ -1903,41 +2196,11 @@ def has_effort_metrics(session_id: int, norm_addressee: str = ADMINISTRATION) ->
         (session_id, resolved),
     )
     groups_with_metrics = int(cur.fetchone()["count"])
-    cur.execute(
-        """
-        SELECT COUNT(*) AS total_count
-        FROM process_steps
-        WHERE session_id = ? AND norm_addressee = ?
-        """,
-        (session_id, resolved),
+    total_steps, steps_with_metrics = _count_process_steps_with_cost_inputs(
+        cur,
+        session_id,
+        resolved,
     )
-    total_steps = int(cur.fetchone()["total_count"] or 0)
-    # Ready-Check MUSS auf dieselben Felder schauen, die _has_step_cost_inputs
-    # in costs.py fordert, sonst meldet die Pipeline faelschlich "fertig",
-    # effort.py skippt die Neuberechnung, und compute_costs wirft 422.
-    # hourly_rate und execution_per_case sind allein nicht kostenrelevant
-    # (Rate kommt ggf. aus active_rates, execution_per_case ist Metadaten).
-    cur.execute(
-        """
-        SELECT COUNT(*) AS count
-        FROM process_steps
-        WHERE session_id = ? AND norm_addressee = ?
-          AND (
-            time_required_in_min_a_current IS NOT NULL
-            OR time_required_in_min_b_current IS NOT NULL
-            OR time_required_in_min_c_current IS NOT NULL
-            OR time_required_in_min_d_current IS NOT NULL
-            OR time_required_in_min_a_proposed IS NOT NULL
-            OR time_required_in_min_b_proposed IS NOT NULL
-            OR time_required_in_min_c_proposed IS NOT NULL
-            OR time_required_in_min_d_proposed IS NOT NULL
-            OR expenses_current IS NOT NULL
-            OR expenses_proposed IS NOT NULL
-          )
-        """,
-        (session_id, resolved),
-    )
-    steps_with_metrics = int(cur.fetchone()["count"])
     _maybe_close(conn)
     return (
         total_case_groups > 0
@@ -1945,6 +2208,22 @@ def has_effort_metrics(session_id: int, norm_addressee: str = ADMINISTRATION) ->
         and groups_with_metrics == total_case_groups
         and steps_with_metrics == total_steps
     )
+
+
+def has_process_step_effort_metrics(
+    session_id: int,
+    norm_addressee: str = ADMINISTRATION,
+) -> bool:
+    resolved = normalize_norm_addressee(norm_addressee)
+    conn = get_conn()
+    cur = conn.cursor()
+    total_steps, steps_with_metrics = _count_process_steps_with_cost_inputs(
+        cur,
+        session_id,
+        resolved,
+    )
+    _maybe_close(conn)
+    return total_steps > 0 and steps_with_metrics == total_steps
 
 
 def has_total_cost_for_addressee(session_id: int, norm_addressee: str = ADMINISTRATION) -> bool:
@@ -2655,6 +2934,7 @@ def list_case_groups_for_session_and_addressee(
             annual_frequency_proposed_edited,
             cases_proposed_edited,
             last_edited_at,
+            case_metric_research_json,
             cost
         FROM case_groups
         WHERE session_id = ?
@@ -3460,6 +3740,7 @@ def upsert_case_group_metrics_by_addressee(
     annual_frequency_proposed: float | None = None,
     cases_current: float | None = None,
     cases_proposed: float | None = None,
+    case_metric_research_json: dict | list | None = None,
 ) -> None:
     resolved = normalize_norm_addressee(norm_addressee)
     if cases_current is None and addressees_current is not None and annual_frequency_current is not None:
@@ -3468,28 +3749,32 @@ def upsert_case_group_metrics_by_addressee(
         cases_proposed = addressees_proposed * annual_frequency_proposed
     conn = get_conn()
     cur = conn.cursor()
+    assignments = [
+        "addressees_current = ?",
+        "annual_frequency_current = ?",
+        "addressees_proposed = ?",
+        "annual_frequency_proposed = ?",
+        "cases_current = ?",
+        "cases_proposed = ?",
+    ]
+    values: list[object] = [
+        addressees_current,
+        annual_frequency_current,
+        addressees_proposed,
+        annual_frequency_proposed,
+        cases_current,
+        cases_proposed,
+    ]
+    if case_metric_research_json is not None:
+        assignments.append("case_metric_research_json = ?")
+        values.append(json.dumps(case_metric_research_json, ensure_ascii=False))
     cur.execute(
-        """
+        f"""
         UPDATE case_groups
-        SET addressees_current = ?,
-            annual_frequency_current = ?,
-            addressees_proposed = ?,
-            annual_frequency_proposed = ?,
-            cases_current = ?,
-            cases_proposed = ?
+        SET {", ".join(assignments)}
         WHERE case_group_id = ? AND session_id = ? AND norm_addressee = ?
         """,
-        (
-            addressees_current,
-            annual_frequency_current,
-            addressees_proposed,
-            annual_frequency_proposed,
-            cases_current,
-            cases_proposed,
-            case_group_id,
-            session_id,
-            resolved,
-        ),
+        (*values, case_group_id, session_id, resolved),
     )
     _maybe_commit(conn)
     _maybe_close(conn)

--- a/backend/core/db.py
+++ b/backend/core/db.py
@@ -2035,8 +2035,9 @@ def list_recent_deep_research_monitor_rows_for_session(
     for row in rows:
         status = str(row.get("status") or "")
         if status == "running":
-            continue
-        if status == "parsed":
+            answer_state = LLM_ANSWER_STATE_PENDING
+            state_reason = "querying"
+        elif status == "parsed":
             answer_state = LLM_ANSWER_STATE_ACTIVE
             state_reason = "session_updated"
         elif status == "completed":
@@ -2046,6 +2047,11 @@ def list_recent_deep_research_monitor_rows_for_session(
             answer_state = LLM_ANSWER_STATE_INVALID
             state_reason = status or "deep_research_failed"
         completed_at = row.get("parsed_at") or row.get("completed_at")
+        elapsed_ms = (
+            _elapsed_ms_between(row.get("started_at"), completed_at)
+            if completed_at
+            else None
+        )
         normalized.append(
             {
                 "answer_id": None,
@@ -2056,7 +2062,7 @@ def list_recent_deep_research_monitor_rows_for_session(
                 "request_id": None,
                 "route_method": None,
                 "route_path": None,
-                "elapsed_ms": _elapsed_ms_between(row.get("started_at"), completed_at),
+                "elapsed_ms": elapsed_ms,
                 "answer_state": answer_state,
                 "state_reason": state_reason,
                 "input_tokens": row.get("input_tokens"),
@@ -2177,13 +2183,22 @@ def get_session_status(app_session_id: str) -> dict | None:
         or session.get("current_law_id")
         or session.get("proposed_law_id")
     )
-    effort_ready_by_addressee = {
-        addressee: (
-            has_effort_metrics(session_id, addressee)
-            or (regulations_count > 0 and not regulations_present_by_addressee[addressee])
+    case_group_research_enabled = bool(session.get("case_group_research_enabled"))
+    case_group_research_status = get_latest_deep_research_run_status(
+        session_id,
+        "case_group_metrics",
+    )
+    case_group_research_ready = (
+        not case_group_research_enabled or case_group_research_status == "parsed"
+    )
+    effort_ready_by_addressee = {}
+    for addressee in ALL_NORM_ADDRESSEES:
+        addressee_is_skippable = (
+            regulations_count > 0 and not regulations_present_by_addressee[addressee]
         )
-        for addressee in ALL_NORM_ADDRESSEES
-    }
+        effort_ready_by_addressee[addressee] = addressee_is_skippable or (
+            has_effort_metrics(session_id, addressee) and case_group_research_ready
+        )
     total_cost_ready_by_addressee = {
         addressee: (
             has_total_cost_for_addressee(session_id, addressee)
@@ -2220,13 +2235,8 @@ def get_session_status(app_session_id: str) -> dict | None:
         ),
         "effort_ready_by_addressee": effort_ready_by_addressee,
         "total_cost_ready_by_addressee": total_cost_ready_by_addressee,
-        "case_group_research_enabled": bool(
-            session.get("case_group_research_enabled")
-        ),
-        "case_group_research_status": get_latest_deep_research_run_status(
-            session_id,
-            "case_group_metrics",
-        ),
+        "case_group_research_enabled": case_group_research_enabled,
+        "case_group_research_status": case_group_research_status,
         "case_group_research_elapsed_seconds": get_latest_deep_research_run_elapsed_seconds(
             session_id,
             "case_group_metrics",

--- a/backend/core/db_formatting.py
+++ b/backend/core/db_formatting.py
@@ -86,13 +86,13 @@ def build_case_group_tile_text(
         return f"{label}: " + " | ".join(parts)
 
     current_line = _format_case_line(
-        "Gueltig",
+        "Aktuell",
         addressees_current,
         annual_frequency_current,
         cases_current,
     )
     proposed_line = _format_case_line(
-        "Vorschlag",
+        "Entwurf",
         addressees_proposed,
         annual_frequency_proposed,
         cases_proposed,
@@ -151,14 +151,14 @@ def build_process_step_tile_text(
         return f"{label}: " + " | ".join(parts)
 
     current_line = _format_effort_values(
-        "Gueltig",
+        "Aktuell",
         hourly_rates_current,
         time_required_current,
         expenses_current,
         cost_current,
     )
     proposed_line = _format_effort_values(
-        "Vorschlag",
+        "Entwurf",
         hourly_rates_proposed,
         time_required_proposed,
         expenses_proposed,

--- a/backend/core/deep_research_cases.py
+++ b/backend/core/deep_research_cases.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from fastapi import HTTPException
+
+from backend.core import db
+from backend.core.llm_json import require_json_object
+from backend.core.norm_addressees import normalize_norm_addressee
+from backend.core.parsing import parse_first_int, parse_optional_number
+
+
+CASE_GROUP_RESEARCH_PURPOSE = "case_group_metrics"
+
+
+@dataclass(frozen=True)
+class ParsedResearchCaseGroup:
+    norm_addressee: str
+    process_id: int
+    case_group_id: int
+    addressees_current: float | None
+    annual_frequency_current: float | None
+    addressees_proposed: float | None
+    annual_frequency_proposed: float | None
+    metadata: dict[str, Any]
+
+
+def _extract_process_entries(data: dict[str, Any]) -> list[dict[str, Any]]:
+    processes = data.get("prozesse")
+    if not isinstance(processes, list):
+        raise HTTPException(
+            status_code=422,
+            detail="Invalid Deep Research payload: expected top-level 'prozesse' list",
+        )
+    return [process for process in processes if isinstance(process, dict)]
+
+
+def parse_deep_research_case_metrics(report_text: str) -> tuple[dict[str, Any], list[ParsedResearchCaseGroup]]:
+    data, _parse_mode = require_json_object(
+        report_text,
+        error_context="Invalid Deep Research case metrics payload",
+        required_top_level_key="prozesse",
+    )
+    parsed: list[ParsedResearchCaseGroup] = []
+    for process in _extract_process_entries(data):
+        try:
+            norm_addressee = normalize_norm_addressee(str(process.get("normadressat") or ""))
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=422,
+                detail=f"Invalid Deep Research payload: {exc}",
+            ) from exc
+        process_id = parse_first_int(process, "prozess_id", "process_id")
+        if process_id is None:
+            raise HTTPException(
+                status_code=422,
+                detail="Invalid Deep Research payload: process is missing prozess_id",
+            )
+        fallgruppen = process.get("fallgruppen")
+        if not isinstance(fallgruppen, list):
+            continue
+        for group in fallgruppen:
+            if not isinstance(group, dict):
+                continue
+            case_group_id = parse_first_int(
+                group,
+                "fallgruppen_id",
+                "fallgruppe_id",
+                "case_group_id",
+            )
+            if case_group_id is None:
+                raise HTTPException(
+                    status_code=422,
+                    detail="Invalid Deep Research payload: fallgruppe is missing fallgruppen_id",
+                )
+            addressees_current = parse_optional_number(
+                group.get("anzahl_betroffene_gueltig")
+            )
+            annual_frequency_current = parse_optional_number(
+                group.get("haeufigkeit_pro_jahr_gueltig")
+            )
+            addressees_proposed = parse_optional_number(
+                group.get("anzahl_betroffene_vorschlag")
+            )
+            annual_frequency_proposed = parse_optional_number(
+                group.get("haeufigkeit_pro_jahr_vorschlag")
+            )
+            metadata = {
+                "confidence": group.get("confidence"),
+                "erklaerungen": group.get("erklaerungen"),
+                "quellen": group.get("quellen"),
+                "fallzahl_gueltig": parse_optional_number(group.get("fallzahl_gueltig")),
+                "fallzahl_vorschlag": parse_optional_number(group.get("fallzahl_vorschlag")),
+                "raw": group,
+            }
+            parsed.append(
+                ParsedResearchCaseGroup(
+                    norm_addressee=norm_addressee,
+                    process_id=int(process_id),
+                    case_group_id=int(case_group_id),
+                    addressees_current=addressees_current,
+                    annual_frequency_current=annual_frequency_current,
+                    addressees_proposed=addressees_proposed,
+                    annual_frequency_proposed=annual_frequency_proposed,
+                    metadata=metadata,
+                )
+            )
+    return data, parsed
+
+
+def apply_deep_research_case_metrics(
+    *,
+    session_id: int,
+    report_text: str,
+    research_run_id: int | None = None,
+) -> int:
+    data, parsed = parse_deep_research_case_metrics(report_text)
+    if not parsed:
+        raise HTTPException(
+            status_code=422,
+            detail="Invalid Deep Research payload: no case-group metrics parsed",
+        )
+
+    expected: dict[tuple[str, int], dict] = {}
+    for group in db.list_case_groups_for_session(session_id):
+        expected[(str(group["norm_addressee"]), int(group["case_group_id"]))] = group
+
+    missing: list[str] = []
+    process_mismatches: list[str] = []
+    seen: set[tuple[str, int]] = set()
+    for entry in parsed:
+        key = (entry.norm_addressee, entry.case_group_id)
+        seen.add(key)
+        existing = expected.get(key)
+        if existing is None:
+            missing.append(f"{entry.norm_addressee}:{entry.case_group_id}")
+            continue
+        if int(existing["process_id"]) != int(entry.process_id):
+            process_mismatches.append(
+                f"{entry.norm_addressee}:{entry.case_group_id} "
+                f"(expected process {existing['process_id']}, got {entry.process_id})"
+            )
+    if missing:
+        raise HTTPException(
+            status_code=422,
+            detail="Unknown Deep Research fallgruppen_id values: " + ", ".join(missing),
+        )
+    if process_mismatches:
+        raise HTTPException(
+            status_code=422,
+            detail="Deep Research process_id mismatch: " + "; ".join(process_mismatches),
+        )
+    omitted = sorted(
+        f"{norm_addressee}:{case_group_id}"
+        for norm_addressee, case_group_id in expected
+        if (norm_addressee, case_group_id) not in seen
+    )
+    if omitted:
+        raise HTTPException(
+            status_code=422,
+            detail="Deep Research omitted fallgruppen_id values: " + ", ".join(omitted),
+        )
+
+    with db.transaction():
+        for entry in parsed:
+            db.upsert_case_group_metrics_by_addressee(
+                session_id=session_id,
+                case_group_id=entry.case_group_id,
+                norm_addressee=entry.norm_addressee,
+                addressees_current=entry.addressees_current,
+                annual_frequency_current=entry.annual_frequency_current,
+                addressees_proposed=entry.addressees_proposed,
+                annual_frequency_proposed=entry.annual_frequency_proposed,
+                case_metric_research_json=entry.metadata,
+            )
+        if research_run_id is not None:
+            db.update_deep_research_run(
+                research_run_id,
+                status="parsed",
+                report_md=report_text,
+                result_json=data,
+            )
+    return len(parsed)

--- a/backend/core/deep_research_cases_prompt.py
+++ b/backend/core/deep_research_cases_prompt.py
@@ -1,0 +1,358 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Any
+
+from backend.core import db
+from backend.core.norm_addressees import ALL_NORM_ADDRESSEES
+from backend.core.payload_builders import (
+    build_case_groups_payload,
+    dump_prompt_json,
+)
+
+
+def _resolve_session(*, app_session_id: str | None, session_id: int | None) -> dict[str, Any]:
+    if session_id is not None:
+        session = db.get_session_by_id(int(session_id))
+    elif app_session_id:
+        session = db.get_session_by_app_id(app_session_id)
+    else:
+        raise ValueError("Either app_session_id or session_id is required")
+    if session is None:
+        identifier = session_id if session_id is not None else app_session_id
+        raise ValueError(f"Session not found: {identifier}")
+    return session
+
+
+def _session_context_payload(
+    session: dict[str, Any],
+    *,
+    include_law_texts: bool,
+) -> dict[str, Any]:
+    session_id = int(session["session_id"])
+    norm_addressees: list[dict[str, Any]] = []
+    all_regulations = db.list_regulations_for_session(session_id)
+
+    for norm_addressee in ALL_NORM_ADDRESSEES:
+        processes = db.list_processes_for_session_and_addressee(
+            session_id,
+            norm_addressee,
+        )
+        case_groups = db.list_case_groups_for_session_and_addressee(
+            session_id,
+            norm_addressee,
+        )
+        if not processes and not case_groups:
+            continue
+        regulations = db.list_regulations_for_session_and_addressee(
+            session_id,
+            norm_addressee,
+        )
+        norm_addressees.append(
+            {
+                "normadressat": norm_addressee,
+                "prozesse": build_case_groups_payload(
+                    processes=processes,
+                    case_groups=case_groups,
+                    regulations=regulations,
+                    norm_addressee=norm_addressee,
+                ),
+            }
+        )
+
+    payload = {
+        "session": {
+            "session_id": session_id,
+            "app_session_id": session.get("app_session_id"),
+            "law_diff_title": session.get("law_diff_title"),
+            "law_diff_blurb": session.get("law_diff_blurb"),
+            "law_diff_summary": session.get("law_diff_summary"),
+        },
+        "vorgaben_gesamt": all_regulations,
+        "normadressaten": norm_addressees,
+    }
+    if include_law_texts:
+        current_law_text, proposed_law_text = db.get_session_law_texts(session_id)
+        payload["gesetz_gueltig"] = current_law_text
+        payload["gesetz_vorschlag"] = proposed_law_text
+    return payload
+
+
+def build_deep_research_cases_prompt(
+    *,
+    app_session_id: str | None = None,
+    session_id: int | None = None,
+    include_law_texts: bool = False,
+) -> str:
+    """Render a standalone Deep Research prompt for yearly case-number research.
+
+    Intended notebook usage:
+
+    ```
+    from backend.core.deep_research_cases_prompt import build_deep_research_cases_prompt
+    prompt = build_deep_research_cases_prompt(app_session_id="BI2J3R")
+    ```
+    """
+    session = _resolve_session(app_session_id=app_session_id, session_id=session_id)
+    payload = _session_context_payload(
+        session,
+        include_law_texts=include_law_texts,
+    )
+    payload_json = dump_prompt_json(payload)
+    return _render_prompt(payload_json)
+
+
+def _render_prompt(session_payload_json: str) -> str:
+    return f"""Rechercheauftrag: Ermittlung der jaehrlichen Fallzahlen fuer alle definierten Fallgruppen einer deutschen Gesetzesaenderung.
+
+Sie erhalten unten einen strukturierten Session-Kontext aus einer Fachanwendung. Dieser Kontext enthaelt:
+
+- Informationen zur Session,
+- soweit vorhanden den Text des geltenden Rechts und des Gesetzesvorschlags,
+- die identifizierten Vorgaben,
+- die betroffenen Normadressaten,
+- die zugeordneten Verwaltungs-, Wirtschafts- oder Buergerprozesse,
+- und die innerhalb dieser Prozesse gebildeten Fallgruppen.
+
+Ihre Aufgabe ist es, fuer alle im Kontext enthaltenen Fallgruppen belastbare quantitative Werte zu recherchieren und herzuleiten. Die Recherche soll nicht nur isolierte Einzelwerte liefern, sondern ein konsistentes Mengenbild ueber alle Normadressaten hinweg entwickeln.
+
+Wichtig:
+
+- Dies ist kein Software- oder Workflow-Task.
+- Verwenden Sie nur die fachlichen Informationen aus dem Session-Kontext und externe Quellen fuer die Recherche.
+- Formulieren Sie die gesamte Antwort auf Deutsch.
+- Liefern Sie konkrete Zahlen, nicht nur qualitative Einordnungen.
+- Der Auftrag ist gesetzesagnostisch formuliert: Leiten Sie die fachliche Fragestellung aus dem Session-Kontext ab und vermeiden Sie Annahmen, die dort nicht angelegt sind.
+
+Ziel der Recherche
+
+Fuer jede Fallgruppe sollen Sie bestimmen:
+
+- wie viele relevante Normadressaten bzw. betroffene Personen, Unternehmen, Organisationen oder Verwaltungseinheiten unter dem geltenden Recht relevant sind,
+- wie haeufig ein solcher Normadressat den Vorgang durchschnittlich pro Jahr ausloest oder bearbeitet,
+- wie viele relevante Normadressaten bzw. Betroffene unter dem Gesetzesvorschlag relevant sind,
+- wie haeufig ein solcher Normadressat den Vorgang unter dem Gesetzesvorschlag durchschnittlich pro Jahr ausloest oder bearbeitet,
+- und welche jaehrlichen Fallzahlen sich daraus ergeben.
+
+Die gesuchten Werte sind sowohl fuer das geltende Recht als auch fuer den Gesetzesvorschlag zu ermitteln.
+
+Verbindliche Zielwerte je Fallgruppe
+
+Liefern Sie fuer jede Fallgruppe genau diese vier Eingabewerte:
+
+- `anzahl_betroffene_gueltig`
+- `haeufigkeit_pro_jahr_gueltig`
+- `anzahl_betroffene_vorschlag`
+- `haeufigkeit_pro_jahr_vorschlag`
+
+Ergaenzend sollen Sie rechnerisch ausweisen:
+
+- `fallzahl_gueltig = anzahl_betroffene_gueltig * haeufigkeit_pro_jahr_gueltig`
+- `fallzahl_vorschlag = anzahl_betroffene_vorschlag * haeufigkeit_pro_jahr_vorschlag`
+
+Verbindliche Definitionen
+
+- `anzahl_betroffene_gueltig`: Anzahl der unterschiedlichen Normadressaten, Einheiten oder Fallausloeser, die unter geltendem Recht in diese Fallgruppe fallen und im Jahreskontext relevant sind.
+- `haeufigkeit_pro_jahr_gueltig`: Durchschnittliche Haeufigkeit pro Jahr, mit der ein solcher Normadressat oder Fallausloeser unter geltendem Recht diesen Vorgang ausloest bzw. bearbeitet.
+- `anzahl_betroffene_vorschlag`: Anzahl der unterschiedlichen Normadressaten, Einheiten oder Fallausloeser, die unter dem vorgeschlagenen Recht in diese Fallgruppe fallen und im Jahreskontext relevant sind.
+- `haeufigkeit_pro_jahr_vorschlag`: Durchschnittliche Haeufigkeit pro Jahr, mit der ein solcher Normadressat oder Fallausloeser unter dem vorgeschlagenen Recht diesen Vorgang ausloest bzw. bearbeitet.
+
+Interpretation nach Normadressat
+
+- Bei `business` ist die Anzahl Betroffene typischerweise die Zahl der betroffenen Unternehmen, Betriebe, Organisationen oder wirtschaftlichen Einheiten. Die Fallzahl ergibt sich bei periodischen Pflichten aus Bestand mal Periodizitaet und bei anlassbezogenen Pflichten aus den jaehrlich erwarteten Ereignissen.
+- Bei `citizens` ist die Anzahl Betroffene typischerweise die Zahl betroffener Personen oder Haushalte. Verwenden Sie keine Gesamtbevoelkerung, wenn nur eine spezifische Teilgruppe betroffen ist.
+- Bei `administration` ist die Anzahl Betroffene nicht automatisch die Zahl aller extern Betroffenen. Entscheidend sind die jaehrlich von der Verwaltung zu bearbeitenden Vorgaenge, Antraege, Pruefungen, Bescheide, Kontrollen oder sonstigen Vollzugshandlungen dieser Fallgruppe. Wenn die Verwaltung dieselben Antraege bearbeitet, die Wirtschaft oder Buerger ausloesen, muss die Fallzahl dazu konsistent sein.
+
+Konsistenz ueber Normadressaten hinweg
+
+Pruefen Sie aktiv, ob Fallzahlen zwischen Normadressaten gespiegelt oder gekoppelt sind:
+
+- Wenn Unternehmen Antraege stellen, Anzeigen abgeben oder Nachweise einreichen, pruefen Sie, ob die Verwaltung dieselbe Anzahl an Antraegen, Anzeigen oder Nachweisen bearbeitet.
+- Wenn Buergerinnen und Buerger einen Antrag stellen, pruefen Sie, ob eine Verwaltungsfallgruppe dieselbe oder eine sachgerecht verteilte Bearbeitungsmenge abbildet.
+- Wenn eine Verwaltungsfallgruppe mehrere wirtschafts- oder buergerseitige Fallgruppen buendelt, erklaeren Sie die Summenbildung.
+- Wenn eine wirtschafts- oder buergerseitige Fallgruppe nur einen Teil einer Verwaltungsfallgruppe ausloest, erklaeren Sie die Abgrenzung.
+- Vermeiden Sie widerspruechliche Mengenbilder, etwa 500 Antraege auf Seiten der Wirtschaft und 50 Bearbeitungsfaelle auf Seiten der Verwaltung, sofern keine fachliche Begruendung vorliegt.
+
+Erwartete Herleitung
+
+Arbeiten Sie fuer jede wesentliche Mengenannahme mindestens entlang dieser Fragen:
+
+1. Welche externe Grundgesamtheit ist fachlich einschlaegig?
+2. Welche Teilmenge faellt tatsaechlich unter die konkrete Vorgabe, den Prozess oder die Fallgruppe?
+3. Ist der Vorgang periodisch, anlassbezogen, einmalig oder bestandsbezogen?
+4. Ist die Fallzahl besser ueber Bestand mal Haeufigkeit oder direkt ueber jaehrliche Ereignisse/Antraege/Faelle zu modellieren?
+5. Aendert die Gesetzesaenderung nur den Aufwand pro Fall oder auch die Menge der Faelle?
+6. Gibt es Nachfrage-, Verhaltens-, Klarstellungs-, Adressatenkreis- oder Vollzugseffekte, die unterschiedliche Werte fuer geltendes Recht und Vorschlag rechtfertigen?
+7. Welche Werte anderer Normadressaten muessen damit konsistent sein?
+
+Recherchehinweise
+
+- Fokus ausschliesslich auf Deutschland, sofern der Session-Kontext keine andere Abgrenzung vorgibt.
+- Bevorzugen Sie hochwertige und moeglichst primaere Quellen, insbesondere:
+  - Gesetzestexte und Gesetzesbegruendungen,
+  - Bundestags- oder Ausschussmaterialien,
+  - Verwaltungs-, Ministeriums- oder Statistikmaterialien,
+  - OnDEA bzw. vorhandene Erfuellungsaufwandsschaetzungen, soweit einschlaegig,
+  - amtliche Statistiken,
+  - Registerdaten,
+  - Verbandsinformationen,
+  - wissenschaftliche, juristische oder fachliche Analysen.
+- Wenn es keine direkte Statistik gibt, leiten Sie Werte transparent aus Proxys her.
+- Unterscheiden Sie sauber zwischen Gesamtbestand, betroffener Teilmenge, jaehrlich aktiven Faellen und Verwaltungsvorgaengen.
+
+Was Sie nicht tun sollen
+
+- Keine qualitativen Platzhalter wie "niedrig", "mittel", "hoch" als Endwert.
+- Keine undifferenzierten Gesamtbestandszahlen als direkte Fallzahl verwenden.
+- Nicht unterstellen, dass jeder Betroffene jedes Jahr einen Antrag stellt oder eine Pflicht ausloest.
+- Nicht automatisch annehmen, dass geltendes Recht exakt 0 Faelle hat.
+- Nicht automatisch annehmen, dass der Gesetzesvorschlag sehr hohe Fallzahlen erzeugt.
+- Keine Software-, App- oder Datenbankimplementierung beschreiben.
+
+Verbindliche Ausgabeanforderungen
+
+Die Antwort soll aus drei Teilen bestehen.
+
+Teil 1: Vollstaendiger Forschungsbericht
+
+Erstellen Sie einen ausfuehrlichen Bericht mit:
+
+1. Management-Zusammenfassung,
+2. Methodik,
+3. Darstellung der relevanten Quellenlage,
+4. Analyse der Mengenannahmen fuer das geltende Recht,
+5. Analyse der Mengenannahmen fuer den Gesetzesvorschlag,
+6. Konsistenzabgleich ueber alle Normadressaten und Fallgruppen hinweg,
+7. Unsicherheiten, Alternativannahmen und plausible Spannbreiten,
+8. Quellenliste mit URLs.
+
+Teil 2: Kurze Begruendungszeilen je Fallgruppe und Kennzahl
+
+Fuegen Sie danach fuer jede Fallgruppe genau eine kurze Zeile je Kennzahl ein. Jede Zeile muss einen echten numerischen Wert und einen kurzen Begruendungssatz enthalten.
+
+Format:
+
+- `normadressat=<normadressat>; fallgruppen_id=<id>; anzahl_betroffene_gueltig = <zahl>, weil <kurze Begruendung>`
+- `normadressat=<normadressat>; fallgruppen_id=<id>; haeufigkeit_pro_jahr_gueltig = <zahl>, weil <kurze Begruendung>`
+- `normadressat=<normadressat>; fallgruppen_id=<id>; anzahl_betroffene_vorschlag = <zahl>, weil <kurze Begruendung>`
+- `normadressat=<normadressat>; fallgruppen_id=<id>; haeufigkeit_pro_jahr_vorschlag = <zahl>, weil <kurze Begruendung>`
+
+Teil 3: Tabellarische Kurzfassung und JSON-Block
+
+Fuegen Sie eine kurze Tabelle mit folgenden Spalten hinzu:
+
+- Normadressat
+- Prozess-ID
+- Fallgruppen-ID
+- Kennzahl
+- empfohlener Wert
+- kurze Begruendung
+- Konfidenz (`high`, `medium` oder `low`)
+
+Fuegen Sie am Ende einen maschinenlesbaren JSON-Block genau nach folgendem Schema hinzu. Verwenden Sie echte Zahlen, keine verbalen Platzhalter. Fuehren Sie alle Normadressaten und Fallgruppen aus dem Session-Kontext auf.
+
+```json
+{{
+  "session": {{
+    "session_id": 0,
+    "app_session_id": ""
+  }},
+  "prozesse": [
+    {{
+      "normadressat": "administration | business | citizens",
+      "prozess_id": 0,
+      "prozess_bezeichnung": "",
+      "fallgruppen": [
+        {{
+          "fallgruppen_id": 0,
+          "fallgruppe_bezeichnung": "",
+          "anzahl_betroffene_gueltig": 0,
+          "haeufigkeit_pro_jahr_gueltig": 0,
+          "fallzahl_gueltig": 0,
+          "anzahl_betroffene_vorschlag": 0,
+          "haeufigkeit_pro_jahr_vorschlag": 0,
+          "fallzahl_vorschlag": 0,
+          "erklaerungen": {{
+            "anzahl_betroffene_gueltig": "",
+            "haeufigkeit_pro_jahr_gueltig": "",
+            "anzahl_betroffene_vorschlag": "",
+            "haeufigkeit_pro_jahr_vorschlag": ""
+          }},
+          "confidence": {{
+            "anzahl_betroffene_gueltig": "high | medium | low",
+            "haeufigkeit_pro_jahr_gueltig": "high | medium | low",
+            "anzahl_betroffene_vorschlag": "high | medium | low",
+            "haeufigkeit_pro_jahr_vorschlag": "high | medium | low"
+          }},
+          "quellen": [
+            {{
+              "titel": "",
+              "url": "",
+              "verwendung": ""
+            }}
+          ]
+        }}
+      ]
+    }}
+  ],
+  "konsistenzpruefung": [
+    {{
+      "beschreibung": "",
+      "betroffene_fallgruppen": [
+        {{"normadressat": "", "fallgruppen_id": 0}}
+      ],
+      "bewertung": ""
+    }}
+  ],
+  "notizen": [
+    ""
+  ]
+}}
+```
+
+Qualitaetsmassstab
+
+- Liefern Sie konkrete Zahlen fuer jede Fallgruppe und jede der vier verbindlichen Kennzahlen.
+- Wenn Sie schaetzen muessen, tun Sie das transparent und begruendet.
+- Wenn die Evidenz schwach ist, nennen Sie trotzdem einen bestmoeglichen empfohlenen Zahlenwert und markieren die Konfidenz entsprechend.
+- Der Bericht muss fuer eine Person verstaendlich sein, die nur den Session-Kontext und Ihre Antwort liest.
+- Der JSON-Block muss vollstaendig sein und die im Session-Kontext enthaltenen IDs unveraendert uebernehmen.
+
+Session-Kontext
+
+```json
+{session_payload_json}
+```
+"""
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Render a standalone Deep Research prompt for case-group numbers.",
+    )
+    selector = parser.add_mutually_exclusive_group(required=True)
+    selector.add_argument("--app-session-id", help="App-facing session id, e.g. BI2J3R")
+    selector.add_argument("--session-id", type=int, help="Numeric DB session id")
+    parser.add_argument(
+        "--include-law-texts",
+        action="store_true",
+        help="Include raw current/proposed law texts in the rendered session context",
+    )
+    parser.add_argument("--output", type=Path, help="Optional markdown output path")
+    args = parser.parse_args(argv)
+
+    prompt = build_deep_research_cases_prompt(
+        app_session_id=args.app_session_id,
+        session_id=args.session_id,
+        include_law_texts=args.include_law_texts,
+    )
+    if args.output:
+        args.output.write_text(prompt, encoding="utf-8")
+    else:
+        print(prompt)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/core/deep_research_cases_prompt.py
+++ b/backend/core/deep_research_cases_prompt.py
@@ -193,6 +193,7 @@ Recherchehinweise
   - Gesetzestexte und Gesetzesbegruendungen,
   - Bundestags- oder Ausschussmaterialien,
   - Verwaltungs-, Ministeriums- oder Statistikmaterialien,
+  - Destatis, die Webseite des Statistischen Bundesamtes (https://www.destatis.de/DE/Home/_inhalt.html),
   - OnDEA bzw. vorhandene Erfuellungsaufwandsschaetzungen, soweit einschlaegig,
   - amtliche Statistiken,
   - Registerdaten,
@@ -230,6 +231,7 @@ Erstellen Sie einen ausfuehrlichen Bericht mit:
 Teil 2: Kurze Begruendungszeilen je Fallgruppe und Kennzahl
 
 Fuegen Sie danach fuer jede Fallgruppe genau eine kurze Zeile je Kennzahl ein. Jede Zeile muss einen echten numerischen Wert und einen kurzen Begruendungssatz enthalten.
+Der Begruendungssatz soll in sich verstaendlich sein und, soweit die Quelle fuer die Einordnung wichtig ist, die relevante Quelle oder URL direkt in der Zeile nennen.
 
 Format:
 
@@ -274,10 +276,10 @@ Fuegen Sie am Ende einen maschinenlesbaren JSON-Block genau nach folgendem Schem
           "haeufigkeit_pro_jahr_vorschlag": 0,
           "fallzahl_vorschlag": 0,
           "erklaerungen": {{
-            "anzahl_betroffene_gueltig": "",
-            "haeufigkeit_pro_jahr_gueltig": "",
-            "anzahl_betroffene_vorschlag": "",
-            "haeufigkeit_pro_jahr_vorschlag": ""
+            "anzahl_betroffene_gueltig": "kurze, eigenstaendige Begruendung mit Quellenhinweis/URL, soweit fuer die Einordnung erforderlich",
+            "haeufigkeit_pro_jahr_gueltig": "kurze, eigenstaendige Begruendung mit Quellenhinweis/URL, soweit fuer die Einordnung erforderlich",
+            "anzahl_betroffene_vorschlag": "kurze, eigenstaendige Begruendung mit Quellenhinweis/URL, soweit fuer die Einordnung erforderlich",
+            "haeufigkeit_pro_jahr_vorschlag": "kurze, eigenstaendige Begruendung mit Quellenhinweis/URL, soweit fuer die Einordnung erforderlich"
           }},
           "confidence": {{
             "anzahl_betroffene_gueltig": "high | medium | low",
@@ -318,6 +320,7 @@ Qualitaetsmassstab
 - Wenn die Evidenz schwach ist, nennen Sie trotzdem einen bestmoeglichen empfohlenen Zahlenwert und markieren die Konfidenz entsprechend.
 - Der Bericht muss fuer eine Person verstaendlich sein, die nur den Session-Kontext und Ihre Antwort liest.
 - Der JSON-Block muss vollstaendig sein und die im Session-Kontext enthaltenen IDs unveraendert uebernehmen.
+- Die Feldwerte in `erklaerungen` werden spaeter direkt in der App angezeigt. Formulieren Sie sie deshalb knapp, eigenstaendig und mit Quellenhinweis/URL im Text, sofern die Quelle zum Verstaendnis der Zahl erforderlich ist. Die separate `quellen`-Liste bleibt zusaetzliche Audit- und Report-Metadaten.
 
 Session-Kontext
 

--- a/backend/core/deep_research_service.py
+++ b/backend/core/deep_research_service.py
@@ -2,16 +2,26 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Callable
 
 from google import genai
 
 from backend.core.auth import ApiKeys
 from backend.core.config import settings
+from backend.core.llm_service import _resolve_estimated_cost_usd
 
 
 class DeepResearchError(RuntimeError):
     pass
+
+
+def _as_int(value: Any) -> int | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
 
 
 @dataclass(frozen=True)
@@ -24,6 +34,7 @@ class DeepResearchResult:
     output_tokens: int | None = None
     thought_tokens: int | None = None
     total_tokens: int | None = None
+    estimated_cost_usd: float | None = None
 
 
 def _to_jsonable(value: Any) -> Any:
@@ -82,11 +93,25 @@ def _extract_usage(interaction_json: dict[str, Any] | list[Any] | None) -> dict[
             "total_tokens": None,
         }
     return {
-        "input_tokens": usage.get("total_input_tokens"),
-        "output_tokens": usage.get("total_output_tokens"),
-        "thought_tokens": usage.get("total_thought_tokens"),
-        "total_tokens": usage.get("total_tokens"),
+        "input_tokens": _as_int(usage.get("total_input_tokens")),
+        "output_tokens": _as_int(usage.get("total_output_tokens")),
+        "thought_tokens": _as_int(usage.get("total_thought_tokens")),
+        "total_tokens": _as_int(usage.get("total_tokens")),
     }
+
+
+def _billable_output_tokens_for_cost(
+    *,
+    input_tokens: int | None,
+    output_tokens: int | None,
+    thought_tokens: int | None,
+    total_tokens: int | None,
+) -> int | None:
+    if total_tokens is not None and input_tokens is not None:
+        return max(total_tokens - input_tokens, 0)
+    if output_tokens is None and thought_tokens is None:
+        return None
+    return (output_tokens or 0) + (thought_tokens or 0)
 
 
 def _run_interaction_sync(
@@ -95,6 +120,7 @@ def _run_interaction_sync(
     prompt: str,
     agent: str,
     poll_interval_seconds: float,
+    on_interaction_started: Callable[[str, str], None] | None = None,
 ) -> DeepResearchResult:
     if not api_key:
         raise DeepResearchError("Gemini API key is required for Deep Research")
@@ -112,6 +138,8 @@ def _run_interaction_sync(
     interaction_id = str(getattr(interaction, "id", "") or "")
     if not interaction_id:
         raise DeepResearchError("Gemini did not return a Deep Research interaction id")
+    if on_interaction_started:
+        on_interaction_started(agent, interaction_id)
 
     while True:
         result = client.interactions.get(id=interaction_id)
@@ -122,6 +150,12 @@ def _run_interaction_sync(
             if not report_text.strip():
                 raise DeepResearchError("Gemini Deep Research completed without report text")
             usage = _extract_usage(response_json)
+            billable_output_tokens = _billable_output_tokens_for_cost(
+                input_tokens=usage["input_tokens"],
+                output_tokens=usage["output_tokens"],
+                thought_tokens=usage["thought_tokens"],
+                total_tokens=usage["total_tokens"],
+            )
             return DeepResearchResult(
                 agent=agent,
                 interaction_id=interaction_id,
@@ -131,6 +165,12 @@ def _run_interaction_sync(
                 output_tokens=usage["output_tokens"],
                 thought_tokens=usage["thought_tokens"],
                 total_tokens=usage["total_tokens"],
+                estimated_cost_usd=_resolve_estimated_cost_usd(
+                    provider="gemini",
+                    model=agent,
+                    input_tokens=usage["input_tokens"],
+                    output_tokens=billable_output_tokens,
+                ),
             )
         if status == "failed":
             error = getattr(result, "error", None)
@@ -147,6 +187,7 @@ async def run_deep_research(
     prompt: str,
     api_keys: ApiKeys,
     agent: str | None = None,
+    on_interaction_started: Callable[[str, str], None] | None = None,
 ) -> DeepResearchResult:
     primary_agent = agent or settings.deep_research_primary_agent
     fallback_agent = settings.deep_research_fallback_agent
@@ -158,6 +199,7 @@ async def run_deep_research(
             prompt=prompt,
             agent=primary_agent,
             poll_interval_seconds=poll_interval,
+            on_interaction_started=on_interaction_started,
         )
     except Exception as exc:
         message = str(exc)
@@ -169,6 +211,7 @@ async def run_deep_research(
                     prompt=prompt,
                     agent=fallback_agent,
                     poll_interval_seconds=poll_interval,
+                    on_interaction_started=on_interaction_started,
                 )
             except Exception as fallback_exc:
                 raise DeepResearchError(

--- a/backend/core/deep_research_service.py
+++ b/backend/core/deep_research_service.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
+import threading
+import time
 from typing import Any, Callable
 
 from google import genai
+from google.genai import types
 
 from backend.core.auth import ApiKeys
 from backend.core.config import settings
@@ -120,11 +123,22 @@ def _run_interaction_sync(
     prompt: str,
     agent: str,
     poll_interval_seconds: float,
+    max_poll_seconds: float = 1800.0,
+    request_timeout_seconds: float = 30.0,
+    stop_event: threading.Event | None = None,
     on_interaction_started: Callable[[str, str], None] | None = None,
 ) -> DeepResearchResult:
     if not api_key:
         raise DeepResearchError("Gemini API key is required for Deep Research")
-    client = genai.Client(api_key=api_key)
+    timeout_ms = (
+        int(request_timeout_seconds * 1000)
+        if request_timeout_seconds and request_timeout_seconds > 0
+        else None
+    )
+    client = genai.Client(
+        api_key=api_key,
+        http_options=types.HttpOptions(timeout=timeout_ms),
+    )
     interaction = client.interactions.create(
         agent=agent,
         input=prompt,
@@ -141,7 +155,14 @@ def _run_interaction_sync(
     if on_interaction_started:
         on_interaction_started(agent, interaction_id)
 
+    started = time.monotonic()
     while True:
+        if stop_event is not None and stop_event.is_set():
+            raise DeepResearchError("Gemini Deep Research polling was cancelled")
+        if max_poll_seconds > 0 and time.monotonic() - started >= max_poll_seconds:
+            raise DeepResearchError(
+                f"Gemini Deep Research timed out after {int(max_poll_seconds)} seconds"
+            )
         result = client.interactions.get(id=interaction_id)
         status = str(getattr(result, "status", "") or "").lower()
         if status == "completed":
@@ -177,9 +198,11 @@ def _run_interaction_sync(
             raise DeepResearchError(f"Gemini Deep Research failed: {error or 'unknown error'}")
         if status in {"cancelled", "canceled"}:
             raise DeepResearchError("Gemini Deep Research was cancelled")
-        import time
 
-        time.sleep(poll_interval_seconds)
+        if stop_event is not None:
+            stop_event.wait(poll_interval_seconds)
+        else:
+            time.sleep(poll_interval_seconds)
 
 
 async def run_deep_research(
@@ -192,6 +215,9 @@ async def run_deep_research(
     primary_agent = agent or settings.deep_research_primary_agent
     fallback_agent = settings.deep_research_fallback_agent
     poll_interval = max(float(settings.deep_research_poll_interval_seconds), 1.0)
+    max_poll_seconds = max(float(settings.deep_research_max_poll_seconds), 1.0)
+    request_timeout_seconds = max(float(settings.deep_research_request_timeout_seconds), 1.0)
+    stop_event = threading.Event()
     try:
         return await asyncio.to_thread(
             _run_interaction_sync,
@@ -199,11 +225,18 @@ async def run_deep_research(
             prompt=prompt,
             agent=primary_agent,
             poll_interval_seconds=poll_interval,
+            max_poll_seconds=max_poll_seconds,
+            request_timeout_seconds=request_timeout_seconds,
+            stop_event=stop_event,
             on_interaction_started=on_interaction_started,
         )
+    except asyncio.CancelledError:
+        stop_event.set()
+        raise
     except Exception as exc:
         message = str(exc)
         if fallback_agent and fallback_agent != primary_agent and "agent" in message.lower():
+            fallback_stop_event = threading.Event()
             try:
                 return await asyncio.to_thread(
                     _run_interaction_sync,
@@ -211,8 +244,14 @@ async def run_deep_research(
                     prompt=prompt,
                     agent=fallback_agent,
                     poll_interval_seconds=poll_interval,
+                    max_poll_seconds=max_poll_seconds,
+                    request_timeout_seconds=request_timeout_seconds,
+                    stop_event=fallback_stop_event,
                     on_interaction_started=on_interaction_started,
                 )
+            except asyncio.CancelledError:
+                fallback_stop_event.set()
+                raise
             except Exception as fallback_exc:
                 raise DeepResearchError(
                     "Gemini Deep Research failed with primary and fallback agents: "

--- a/backend/core/deep_research_service.py
+++ b/backend/core/deep_research_service.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any
+
+from google import genai
+
+from backend.core.auth import ApiKeys
+from backend.core.config import settings
+
+
+class DeepResearchError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class DeepResearchResult:
+    agent: str
+    interaction_id: str
+    report_text: str
+    response_json: dict[str, Any] | list[Any] | None
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    thought_tokens: int | None = None
+    total_tokens: int | None = None
+
+
+def _to_jsonable(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, dict):
+        return {str(key): _to_jsonable(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_to_jsonable(item) for item in value]
+    if hasattr(value, "model_dump"):
+        return _to_jsonable(value.model_dump())
+    if hasattr(value, "to_dict"):
+        return _to_jsonable(value.to_dict())
+    if hasattr(value, "__dict__"):
+        return _to_jsonable(value.__dict__)
+    return str(value)
+
+
+def _extract_text_from_interaction(interaction: Any) -> str:
+    outputs = getattr(interaction, "outputs", None)
+    if outputs:
+        last = outputs[-1]
+        text = getattr(last, "text", None)
+        if isinstance(text, str) and text.strip():
+            return text
+
+    steps = getattr(interaction, "steps", None) or []
+    for step in reversed(steps):
+        if getattr(step, "type", None) != "model_output":
+            continue
+        content = getattr(step, "content", None) or []
+        pieces: list[str] = []
+        for item in content:
+            text = getattr(item, "text", None)
+            if isinstance(text, str) and text:
+                pieces.append(text)
+        if pieces:
+            return "\n".join(pieces)
+    return ""
+
+
+def _extract_usage(interaction_json: dict[str, Any] | list[Any] | None) -> dict[str, int | None]:
+    if not isinstance(interaction_json, dict):
+        return {
+            "input_tokens": None,
+            "output_tokens": None,
+            "thought_tokens": None,
+            "total_tokens": None,
+        }
+    usage = interaction_json.get("usage")
+    if not isinstance(usage, dict):
+        return {
+            "input_tokens": None,
+            "output_tokens": None,
+            "thought_tokens": None,
+            "total_tokens": None,
+        }
+    return {
+        "input_tokens": usage.get("total_input_tokens"),
+        "output_tokens": usage.get("total_output_tokens"),
+        "thought_tokens": usage.get("total_thought_tokens"),
+        "total_tokens": usage.get("total_tokens"),
+    }
+
+
+def _run_interaction_sync(
+    *,
+    api_key: str,
+    prompt: str,
+    agent: str,
+    poll_interval_seconds: float,
+) -> DeepResearchResult:
+    if not api_key:
+        raise DeepResearchError("Gemini API key is required for Deep Research")
+    client = genai.Client(api_key=api_key)
+    interaction = client.interactions.create(
+        agent=agent,
+        input=prompt,
+        agent_config={
+            "type": "deep-research",
+            "thinking_summaries": "auto",
+            "collaborative_planning": False,
+        },
+        background=True,
+    )
+    interaction_id = str(getattr(interaction, "id", "") or "")
+    if not interaction_id:
+        raise DeepResearchError("Gemini did not return a Deep Research interaction id")
+
+    while True:
+        result = client.interactions.get(id=interaction_id)
+        status = str(getattr(result, "status", "") or "").lower()
+        if status == "completed":
+            response_json = _to_jsonable(result)
+            report_text = _extract_text_from_interaction(result)
+            if not report_text.strip():
+                raise DeepResearchError("Gemini Deep Research completed without report text")
+            usage = _extract_usage(response_json)
+            return DeepResearchResult(
+                agent=agent,
+                interaction_id=interaction_id,
+                report_text=report_text,
+                response_json=response_json,
+                input_tokens=usage["input_tokens"],
+                output_tokens=usage["output_tokens"],
+                thought_tokens=usage["thought_tokens"],
+                total_tokens=usage["total_tokens"],
+            )
+        if status == "failed":
+            error = getattr(result, "error", None)
+            raise DeepResearchError(f"Gemini Deep Research failed: {error or 'unknown error'}")
+        if status in {"cancelled", "canceled"}:
+            raise DeepResearchError("Gemini Deep Research was cancelled")
+        import time
+
+        time.sleep(poll_interval_seconds)
+
+
+async def run_deep_research(
+    *,
+    prompt: str,
+    api_keys: ApiKeys,
+    agent: str | None = None,
+) -> DeepResearchResult:
+    primary_agent = agent or settings.deep_research_primary_agent
+    fallback_agent = settings.deep_research_fallback_agent
+    poll_interval = max(float(settings.deep_research_poll_interval_seconds), 1.0)
+    try:
+        return await asyncio.to_thread(
+            _run_interaction_sync,
+            api_key=api_keys.gemini_api_key,
+            prompt=prompt,
+            agent=primary_agent,
+            poll_interval_seconds=poll_interval,
+        )
+    except Exception as exc:
+        message = str(exc)
+        if fallback_agent and fallback_agent != primary_agent and "agent" in message.lower():
+            try:
+                return await asyncio.to_thread(
+                    _run_interaction_sync,
+                    api_key=api_keys.gemini_api_key,
+                    prompt=prompt,
+                    agent=fallback_agent,
+                    poll_interval_seconds=poll_interval,
+                )
+            except Exception as fallback_exc:
+                raise DeepResearchError(
+                    "Gemini Deep Research failed with primary and fallback agents: "
+                    f"primary={primary_agent}: {exc}; fallback={fallback_agent}: {fallback_exc}"
+                ) from fallback_exc
+        raise DeepResearchError(
+            f"Gemini Deep Research failed for agent={primary_agent}: {exc}"
+        ) from exc

--- a/backend/core/llm_attempts.py
+++ b/backend/core/llm_attempts.py
@@ -362,6 +362,54 @@ async def query_and_stage_llm_answer(
                 **query_kwargs,
             )
         )
+    except asyncio.CancelledError:
+        failure_elapsed_ms = int((time.perf_counter() - started) * 1000)
+        exc = LlmQueryError(
+            provider=provider or "unknown",
+            model=model,
+            reason="cancelled",
+            message="LLM query was cancelled before completion",
+        )
+        llm_trace.record_failure(
+            prompt_id=prompt_id,
+            model=model,
+            provider=provider,
+            attempt_id=attempt_id,
+            prompt=prompt,
+            exc=exc,
+            elapsed_ms=failure_elapsed_ms,
+        )
+        mark_llm_query_failed(
+            session_id=session_id,
+            prompt_id=prompt_id,
+            model=model,
+            provider=provider,
+            prompt=prompt,
+            exc=exc,
+            elapsed_ms=failure_elapsed_ms,
+            attempt_id=attempt_id,
+            request_context=request_ctx,
+            norm_addressee=norm_addressee,
+        )
+        await _publish_monitor_event(
+            app_session_id=app_session_id,
+            event={
+                "event_type": "llm_query_failed",
+                "attempt_id": attempt_id,
+                "session_id": session_id,
+                "prompt_id": prompt_id,
+                "model": model,
+                "provider": provider,
+                "request_id": request_ctx.get("request_id"),
+                "route_method": request_ctx.get("route_method"),
+                "route_path": request_ctx.get("route_path"),
+                "elapsed_ms": failure_elapsed_ms,
+                "error": str(exc),
+                "error_kind": exc.reason,
+                "error_status_code": exc.status_code,
+            },
+        )
+        raise
     except Exception as exc:
         failure_elapsed_ms = int((time.perf_counter() - started) * 1000)
         llm_trace.record_failure(
@@ -480,15 +528,34 @@ async def query_and_stage_llm_answers_parallel(
     pending_answer_ids: dict[str, int] = {}
     query_results: dict[str, LlmResult] = {}
     query_errors: list[str] = []
-    for task in asyncio.as_completed(tasks):
-        spec, answer_id, result, query_error = await task
-        if query_error is not None:
-            query_errors.append(f"{spec.query_label} query failed: {query_error}")
-            continue
-        assert answer_id is not None
-        assert result is not None
-        pending_answer_ids[spec.prompt_id] = answer_id
-        query_results[spec.prompt_id] = result
+    try:
+        for task in asyncio.as_completed(tasks):
+            spec, answer_id, result, query_error = await task
+            if query_error is not None:
+                query_errors.append(f"{spec.query_label} query failed: {query_error}")
+                continue
+            assert answer_id is not None
+            assert result is not None
+            pending_answer_ids[spec.prompt_id] = answer_id
+            query_results[spec.prompt_id] = result
+    except asyncio.CancelledError:
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        settled = await asyncio.gather(*tasks, return_exceptions=True)
+        for item in settled:
+            if not isinstance(item, tuple):
+                continue
+            spec, answer_id, _result, _query_error = item
+            if answer_id is None:
+                continue
+            pending_answer_ids[spec.prompt_id] = int(answer_id)
+        for answer_id in pending_answer_ids.values():
+            mark_llm_answer_apply_failed(
+                answer_id=answer_id,
+                exc=RuntimeError("Step execution was cancelled before applying LLM answer"),
+            )
+        raise
     return pending_answer_ids, query_results, query_errors
 
 

--- a/backend/core/llm_service.py
+++ b/backend/core/llm_service.py
@@ -1483,11 +1483,15 @@ def _estimate_cost_usd(
         return None
 
     # Standard API pricing, USD per 1M tokens.
-    # Sources (checked on 2026-02-27):
+    # Sources (checked on 2026-06-01):
     # - https://openai.com/api/pricing
     # - https://ai.google.dev/gemini-api/docs/pricing
     pricing_per_million: dict[str, dict[str, tuple[float, float]]] = {
         "openai": {
+            "gpt-5.5": (5.00, 30.00),
+            "gpt-5.4-mini": (0.75, 4.50),
+            "gpt-5.4-nano": (0.20, 1.25),
+            "gpt-5.4": (2.50, 15.00),
             "gpt-5.2-pro": (21.00, 168.00),
             "gpt-5.2": (1.75, 14.00),
             "gpt-5-pro": (15.00, 120.00),
@@ -1502,6 +1506,13 @@ def _estimate_cost_usd(
             "gpt-4o": (2.50, 10.00),
         },
         "gemini": {
+            "deep-research-pro-preview": (2.00, 12.00),
+            "deep-research-preview": (2.00, 12.00),
+            "gemini-3.5-flash": (1.50, 9.00),
+            "gemini-3.1-pro-preview": (2.00, 12.00),
+            "gemini-3.1-flash-lite": (0.25, 1.50),
+            "gemini-3-pro-preview": (2.00, 12.00),
+            "gemini-3-flash-preview": (0.50, 3.00),
             "gemini-2.5-pro": (1.25, 10.00),
             "gemini-2.5-flash-lite": (0.10, 0.40),
             "gemini-2.5-flash": (0.30, 2.50),

--- a/backend/core/workflow.py
+++ b/backend/core/workflow.py
@@ -41,6 +41,8 @@ def _undo_total_cost(session_id: int) -> None:
 def _undo_effort(session_id: int) -> None:
     for addressee in SUPPORTED_NORM_ADDRESSEES:
         db.clear_effort_metrics(session_id, norm_addressee=addressee)
+    if db.get_case_group_research_enabled(session_id):
+        db.clear_case_group_research(session_id)
     db.invalidate_llm_answers(
         session_id,
         [PromptId.CASES_CALCULATION, PromptId.EFFORT_CALCULATION],

--- a/backend/core/workflow.py
+++ b/backend/core/workflow.py
@@ -41,8 +41,7 @@ def _undo_total_cost(session_id: int) -> None:
 def _undo_effort(session_id: int) -> None:
     for addressee in SUPPORTED_NORM_ADDRESSEES:
         db.clear_effort_metrics(session_id, norm_addressee=addressee)
-    if db.get_case_group_research_enabled(session_id):
-        db.clear_case_group_research(session_id)
+    db.clear_case_group_research(session_id)
     db.invalidate_llm_answers(
         session_id,
         [PromptId.CASES_CALCULATION, PromptId.EFFORT_CALCULATION],

--- a/backend/core/workflow.py
+++ b/backend/core/workflow.py
@@ -4,8 +4,9 @@ from dataclasses import dataclass
 from typing import Callable
 
 from backend.core import db
-from backend.core.norm_addressees import SUPPORTED_NORM_ADDRESSEES
+from backend.core.norm_addressees import ALL_NORM_ADDRESSEES, SUPPORTED_NORM_ADDRESSEES
 from backend.core.prompts import PromptId
+from backend.core.session_graph import sync_all_norm_addressee_tile_snapshots
 
 
 @dataclass(frozen=True)
@@ -110,3 +111,11 @@ def undo_step(session_id: int, step_key: str) -> None:
     if handler is None:
         raise ValueError(f"Unknown workflow step: {step_key}")
     handler(session_id)
+    session = db.get_session_by_id(session_id)
+    if session is None:
+        return
+    if step_key == "summary":
+        for addressee in ALL_NORM_ADDRESSEES:
+            db.clear_tiles(session_id=session_id, norm_addressee=addressee)
+        return
+    sync_all_norm_addressee_tile_snapshots(session)

--- a/backend/routers/_edit_schemas.py
+++ b/backend/routers/_edit_schemas.py
@@ -32,6 +32,7 @@ class EditableCaseGroupRow(BaseModel):
     addressees_proposed_effective: float | None = None
     annual_frequency_proposed_effective: float | None = None
     cases_proposed_effective: float | None = None
+    case_metric_research_json: dict | list | str | None = None
 
 
 class EditableCaseGroupsResponse(BaseModel):

--- a/backend/routers/effort.py
+++ b/backend/routers/effort.py
@@ -528,6 +528,19 @@ async def calculate_effort(
     payload: EffortCalculationRequest,
     api_keys: ApiKeys = Depends(get_api_keys),
 ) -> dict:
+    return await _calculate_effort(
+        payload,
+        api_keys,
+        skip_cases_calculation=False,
+    )
+
+
+async def _calculate_effort(
+    payload: EffortCalculationRequest,
+    api_keys: ApiKeys,
+    *,
+    skip_cases_calculation: bool = False,
+) -> dict:
     session_id, _created, model = ensure_session_or_400(
         payload.app_session_id,
         payload.model,
@@ -565,7 +578,11 @@ async def calculate_effort(
         )
     if not steps:
         raise HTTPException(status_code=400, detail="No process steps for session")
-    has_existing_metrics = db.has_effort_metrics(session_id, norm_addressee)
+    has_existing_metrics = (
+        db.has_process_step_effort_metrics(session_id, norm_addressee)
+        if skip_cases_calculation
+        else db.has_effort_metrics(session_id, norm_addressee)
+    )
     if has_existing_metrics:
         return {
             "status": "existing",
@@ -574,12 +591,6 @@ async def calculate_effort(
             "norm_addressee": norm_addressee,
         }
 
-    case_groups_payload = build_case_groups_payload(
-        processes=processes,
-        case_groups=case_groups,
-        regulations=regulations,
-        norm_addressee=norm_addressee,
-    )
     steps_payload = build_step_analysis_payload(
         processes=processes,
         case_groups=case_groups,
@@ -588,12 +599,6 @@ async def calculate_effort(
         norm_addressee=norm_addressee,
     )
 
-    cases_prompt = render_prompt(
-        PromptId.CASES_CALCULATION,
-        session_id=session_id,
-        case_groups_json=dump_prompt_json(case_groups_payload),
-        norm_addressee=norm_addressee,
-    )
     effort_prompt = render_prompt(
         PromptId.EFFORT_CALCULATION,
         session_id=session_id,
@@ -601,20 +606,36 @@ async def calculate_effort(
         norm_addressee=norm_addressee,
     )
 
-    all_specs = [
-        LlmPromptSpec(
-            prompt_id=PromptId.CASES_CALCULATION,
-            query_label="CASES_CALCULATION",
-            prompt=cases_prompt,
+    all_specs = []
+    if not skip_cases_calculation:
+        case_groups_payload = build_case_groups_payload(
+            processes=processes,
+            case_groups=case_groups,
+            regulations=regulations,
             norm_addressee=norm_addressee,
-        ),
+        )
+        cases_prompt = render_prompt(
+            PromptId.CASES_CALCULATION,
+            session_id=session_id,
+            case_groups_json=dump_prompt_json(case_groups_payload),
+            norm_addressee=norm_addressee,
+        )
+        all_specs.append(
+            LlmPromptSpec(
+                prompt_id=PromptId.CASES_CALCULATION,
+                query_label="CASES_CALCULATION",
+                prompt=cases_prompt,
+                norm_addressee=norm_addressee,
+            )
+        )
+    all_specs.append(
         LlmPromptSpec(
             prompt_id=PromptId.EFFORT_CALCULATION,
             query_label="EFFORT_CALCULATION",
             prompt=effort_prompt,
             norm_addressee=norm_addressee,
         ),
-    ]
+    )
     pending_answer_ids = {}
     query_results = {}
     query_errors: list[str] = []
@@ -656,23 +677,25 @@ async def calculate_effort(
             )
         raise HTTPException(status_code=502, detail="; ".join(query_errors))
 
-    cases_result = query_results[PromptId.CASES_CALCULATION]
     effort_result = query_results[PromptId.EFFORT_CALCULATION]
+    parsed_cases: list[dict] = []
 
     try:
-        parsed_cases, cases_fallback_kinds = _parse_cases_payload(
-            cases_result.text,
-            norm_addressee,
-        )
-        for fallback_kind in sorted(cases_fallback_kinds):
-            mark_llm_parse_fallback(
-                answer_id=pending_answer_ids[PromptId.CASES_CALCULATION],
-                session_id=session_id,
-                prompt_id=PromptId.CASES_CALCULATION,
-                fallback_kind=fallback_kind,
+        if not skip_cases_calculation:
+            cases_result = query_results[PromptId.CASES_CALCULATION]
+            parsed_cases, cases_fallback_kinds = _parse_cases_payload(
+                cases_result.text,
+                norm_addressee,
             )
-        if not parsed_cases:
-            raise HTTPException(status_code=422, detail="No case group metrics parsed")
+            for fallback_kind in sorted(cases_fallback_kinds):
+                mark_llm_parse_fallback(
+                    answer_id=pending_answer_ids[PromptId.CASES_CALCULATION],
+                    session_id=session_id,
+                    prompt_id=PromptId.CASES_CALCULATION,
+                    fallback_kind=fallback_kind,
+                )
+            if not parsed_cases:
+                raise HTTPException(status_code=422, detail="No case group metrics parsed")
         parsed_effort, effort_fallback_kinds = _parse_effort_payload(
             effort_result.text,
             norm_addressee,
@@ -690,16 +713,17 @@ async def calculate_effort(
         case_group_ids = {int(group["case_group_id"]) for group in case_groups}
         step_ids = {int(step["step_id"]) for step in steps}
 
-        missing_case_groups = [
-            str(entry["case_group_id"])
-            for entry in parsed_cases
-            if entry["case_group_id"] not in case_group_ids
-        ]
-        if missing_case_groups:
-            raise HTTPException(
-                status_code=422,
-                detail="Unknown fallgruppen_id values: " + ", ".join(missing_case_groups),
-            )
+        if not skip_cases_calculation:
+            missing_case_groups = [
+                str(entry["case_group_id"])
+                for entry in parsed_cases
+                if entry["case_group_id"] not in case_group_ids
+            ]
+            if missing_case_groups:
+                raise HTTPException(
+                    status_code=422,
+                    detail="Unknown fallgruppen_id values: " + ", ".join(missing_case_groups),
+                )
 
         missing_steps = [
             str(entry["step_id"])
@@ -713,34 +737,35 @@ async def calculate_effort(
             )
 
         with db.transaction():
-            for entry in parsed_cases:
-                addressees_current = entry.get("addressees_current")
-                annual_frequency_current = entry.get("annual_frequency_current")
-                addressees_proposed = entry.get("addressees_proposed")
-                annual_frequency_proposed = entry.get("annual_frequency_proposed")
-                cases_current = (
-                    addressees_current * annual_frequency_current
-                    if addressees_current is not None
-                    and annual_frequency_current is not None
-                    else None
-                )
-                cases_proposed = (
-                    addressees_proposed * annual_frequency_proposed
-                    if addressees_proposed is not None
-                    and annual_frequency_proposed is not None
-                    else None
-                )
-                db.upsert_case_group_metrics_by_addressee(
-                    session_id=session_id,
-                    case_group_id=entry["case_group_id"],
-                    norm_addressee=norm_addressee,
-                    addressees_current=addressees_current,
-                    annual_frequency_current=annual_frequency_current,
-                    addressees_proposed=addressees_proposed,
-                    annual_frequency_proposed=annual_frequency_proposed,
-                    cases_current=cases_current,
-                    cases_proposed=cases_proposed,
-                )
+            if not skip_cases_calculation:
+                for entry in parsed_cases:
+                    addressees_current = entry.get("addressees_current")
+                    annual_frequency_current = entry.get("annual_frequency_current")
+                    addressees_proposed = entry.get("addressees_proposed")
+                    annual_frequency_proposed = entry.get("annual_frequency_proposed")
+                    cases_current = (
+                        addressees_current * annual_frequency_current
+                        if addressees_current is not None
+                        and annual_frequency_current is not None
+                        else None
+                    )
+                    cases_proposed = (
+                        addressees_proposed * annual_frequency_proposed
+                        if addressees_proposed is not None
+                        and annual_frequency_proposed is not None
+                        else None
+                    )
+                    db.upsert_case_group_metrics_by_addressee(
+                        session_id=session_id,
+                        case_group_id=entry["case_group_id"],
+                        norm_addressee=norm_addressee,
+                        addressees_current=addressees_current,
+                        annual_frequency_current=annual_frequency_current,
+                        addressees_proposed=addressees_proposed,
+                        annual_frequency_proposed=annual_frequency_proposed,
+                        cases_current=cases_current,
+                        cases_proposed=cases_proposed,
+                    )
 
             for entry in parsed_effort:
                 db.upsert_process_step_effort_split_by_addressee(
@@ -756,11 +781,12 @@ async def calculate_effort(
                     execution_per_case=entry.get("execution_per_case"),
                 )
 
-            mark_llm_answer_applied(
-                answer_id=pending_answer_ids[PromptId.CASES_CALCULATION],
-                session_id=session_id,
-                prompt_id=PromptId.CASES_CALCULATION,
-            )
+            if not skip_cases_calculation:
+                mark_llm_answer_applied(
+                    answer_id=pending_answer_ids[PromptId.CASES_CALCULATION],
+                    session_id=session_id,
+                    prompt_id=PromptId.CASES_CALCULATION,
+                )
             mark_llm_answer_applied(
                 answer_id=pending_answer_ids[PromptId.EFFORT_CALCULATION],
                 session_id=session_id,

--- a/backend/routers/sessions.py
+++ b/backend/routers/sessions.py
@@ -1,20 +1,28 @@
 from __future__ import annotations
 
 import asyncio
+import html
 import inspect
 import json
 import time
 import uuid
 from dataclasses import dataclass, field
+from io import BytesIO
 from typing import Annotated, AsyncGenerator, Awaitable, Callable, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-from fastapi.responses import StreamingResponse
+from fastapi.responses import Response, StreamingResponse
 from pydantic import BaseModel, StringConstraints
 
 from backend.core.auth import ApiKeys, get_api_keys
 from backend.core import db, llm_monitor, llm_trace
 from backend.core.config import settings
+from backend.core.deep_research_cases import (
+    CASE_GROUP_RESEARCH_PURPOSE,
+    apply_deep_research_case_metrics,
+)
+from backend.core.deep_research_cases_prompt import build_deep_research_cases_prompt
+from backend.core.deep_research_service import DeepResearchError, run_deep_research
 from backend.core.norm_addressees import SUPPORTED_NORM_ADDRESSEES
 from backend.core.norm_addressees import ADMINISTRATION, BUSINESS, CITIZENS
 from backend.core.session_graph import build_session_tiles_snapshot
@@ -65,6 +73,7 @@ class SessionSummary(BaseModel):
     created_at: str
     llm_model: str
     used_llm_models: str | None = None
+    case_group_research_enabled: bool = False
 
 
 class SessionListResponse(BaseModel):
@@ -84,6 +93,8 @@ class SessionStatusResponse(BaseModel):
     effort_ready_by_addressee: dict[str, bool] = {}
     total_cost_ready: bool
     total_cost_ready_by_addressee: dict[str, bool] = {}
+    case_group_research_enabled: bool = False
+    case_group_research_status: str = "idle"
     last_completed_step: str | None = None
     last_completed_label: str | None = None
 
@@ -122,6 +133,18 @@ class SessionEditAuditRow(BaseModel):
 class SessionEditAuditResponse(BaseModel):
     app_session_id: str
     rows: list[SessionEditAuditRow]
+
+
+class CaseGroupResearchSettingsRequest(BaseModel):
+    app_session_id: AppSessionId
+    enabled: bool
+
+
+class CaseGroupResearchSettingsResponse(BaseModel):
+    app_session_id: str
+    enabled: bool
+    status: str = "idle"
+    locked: bool = False
 
 
 class SessionExportResponse(BaseModel):
@@ -460,6 +483,79 @@ def _step_error_message(exc: Exception) -> str:
     return message or exc.__class__.__name__
 
 
+async def _run_case_group_deep_research(
+    *,
+    app_session_id: str,
+    session_id: int,
+    api_keys: ApiKeys,
+) -> None:
+    latest = db.get_latest_deep_research_run(session_id, CASE_GROUP_RESEARCH_PURPOSE)
+    latest_status = str(latest.get("status") or "") if latest else "idle"
+    if latest_status == "parsed":
+        return
+    if latest_status == "completed" and latest and latest.get("report_md"):
+        apply_deep_research_case_metrics(
+            session_id=session_id,
+            report_text=str(latest["report_md"]),
+            research_run_id=int(latest["research_run_id"]),
+        )
+        return
+    if latest_status == "running":
+        raise HTTPException(
+            status_code=409,
+            detail="Deep Research for case groups is already running.",
+        )
+
+    prompt = build_deep_research_cases_prompt(app_session_id=app_session_id)
+    research_run_id = db.create_deep_research_run(
+        session_id=session_id,
+        purpose=CASE_GROUP_RESEARCH_PURPOSE,
+        agent=settings.deep_research_primary_agent,
+        status="running",
+        prompt_text=prompt,
+    )
+    try:
+        result = await run_deep_research(prompt=prompt, api_keys=api_keys)
+        db.update_deep_research_run(
+            research_run_id,
+            status="completed",
+            agent=result.agent,
+            interaction_id=result.interaction_id,
+            report_md=result.report_text,
+            response_json=result.response_json,
+            input_tokens=result.input_tokens,
+            output_tokens=result.output_tokens,
+            thought_tokens=result.thought_tokens,
+            total_tokens=result.total_tokens,
+        )
+        apply_deep_research_case_metrics(
+            session_id=session_id,
+            report_text=result.report_text,
+            research_run_id=research_run_id,
+        )
+    except asyncio.CancelledError:
+        db.update_deep_research_run(
+            research_run_id,
+            status="cancelled",
+            error="Deep Research was cancelled by the run-all task.",
+        )
+        raise
+    except DeepResearchError as exc:
+        db.update_deep_research_run(
+            research_run_id,
+            status="failed",
+            error=str(exc),
+        )
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+    except Exception as exc:
+        db.update_deep_research_run(
+            research_run_id,
+            status="failed",
+            error=_step_error_message(exc),
+        )
+        raise
+
+
 async def _run_single_step(
     step_key: str,
     payload: SessionRunAllRequest,
@@ -597,6 +693,11 @@ async def _run_single_step(
         return
 
     if step_key == "effort":
+        session_id = db.get_session_id_by_app_id(payload.app_session_id)
+        if session_id is None:
+            raise HTTPException(status_code=404, detail="Session not found")
+        use_deep_research = db.get_case_group_research_enabled(session_id)
+
         async def _run_effort(norm_addressee: str) -> None:
             effort_payload = effort_router.EffortCalculationRequest(
                 app_session_id=payload.app_session_id,
@@ -604,9 +705,23 @@ async def _run_single_step(
                 provider=payload.provider,
                 norm_addressee=norm_addressee,
             )
-            await effort_router.calculate_effort(effort_payload, api_keys)
+            await effort_router._calculate_effort(
+                effort_payload,
+                api_keys,
+                skip_cases_calculation=use_deep_research,
+            )
 
-        await _run_for_supported_addressees(_run_effort)
+        if use_deep_research:
+            await asyncio.gather(
+                _run_case_group_deep_research(
+                    app_session_id=payload.app_session_id,
+                    session_id=session_id,
+                    api_keys=api_keys,
+                ),
+                _run_for_supported_addressees(_run_effort),
+            )
+        else:
+            await _run_for_supported_addressees(_run_effort)
         return
 
     if step_key == "total_cost":
@@ -830,6 +945,45 @@ async def session_edit_audit(
     return SessionEditAuditResponse(app_session_id=app_session_id, rows=rows)
 
 
+def _research_settings_response(app_session_id: str) -> CaseGroupResearchSettingsResponse:
+    session = db.get_session_by_app_id(app_session_id)
+    if not session:
+        raise HTTPException(status_code=404, detail="Session not found")
+    session_id = int(session["session_id"])
+    status = db.get_latest_deep_research_run_status(session_id, "case_group_metrics")
+    return CaseGroupResearchSettingsResponse(
+        app_session_id=app_session_id,
+        enabled=bool(session.get("case_group_research_enabled")),
+        status=status,
+        locked=status not in {"idle", "failed", "cancelled"},
+    )
+
+
+@router.get("/case-group-research", response_model=CaseGroupResearchSettingsResponse)
+async def case_group_research_settings(
+    app_session_id: str = APP_SESSION_ID_QUERY_VALIDATION,
+) -> CaseGroupResearchSettingsResponse:
+    return _research_settings_response(app_session_id)
+
+
+@router.post("/case-group-research", response_model=CaseGroupResearchSettingsResponse)
+async def case_group_research_settings_update(
+    payload: CaseGroupResearchSettingsRequest,
+) -> CaseGroupResearchSettingsResponse:
+    session = db.get_session_by_app_id(payload.app_session_id)
+    if not session:
+        raise HTTPException(status_code=404, detail="Session not found")
+    session_id = int(session["session_id"])
+    status = db.get_latest_deep_research_run_status(session_id, "case_group_metrics")
+    if status not in {"idle", "failed", "cancelled"}:
+        raise HTTPException(
+            status_code=409,
+            detail="Deep Research mode is locked after a research run has started. Revert effort to change it.",
+        )
+    db.update_case_group_research_enabled(session_id, payload.enabled)
+    return _research_settings_response(payload.app_session_id)
+
+
 @router.get("/export", response_model=SessionExportResponse)
 async def export_session(
     app_session_id: str = APP_SESSION_ID_QUERY_VALIDATION
@@ -909,6 +1063,91 @@ async def export_session(
 
     filename = f"ccc_session_{info['app_session_id']}.md"
     return SessionExportResponse(filename=filename, markdown=markdown)
+
+
+def _render_research_report_pdf(report_md: str, title: str) -> bytes:
+    try:
+        from reportlab.lib.pagesizes import A4
+        from reportlab.lib.styles import getSampleStyleSheet
+        from reportlab.platypus import Paragraph, SimpleDocTemplate, Spacer
+    except Exception as exc:  # pragma: no cover - exercised only without optional dep.
+        raise HTTPException(
+            status_code=500,
+            detail={
+                "error": "render_failed",
+                "message": "PDF rendering requires reportlab. Please install project requirements.",
+            },
+        ) from exc
+
+    buffer = BytesIO()
+    doc = SimpleDocTemplate(
+        buffer,
+        pagesize=A4,
+        rightMargin=36,
+        leftMargin=36,
+        topMargin=36,
+        bottomMargin=36,
+        title=title,
+    )
+    styles = getSampleStyleSheet()
+    story = [Paragraph(html.escape(title), styles["Title"]), Spacer(1, 12)]
+    for block in report_md.split("\n\n"):
+        text = block.strip()
+        if not text:
+            continue
+        if text.startswith("#"):
+            heading = text.lstrip("#").strip()
+            story.append(Paragraph(html.escape(heading), styles["Heading2"]))
+        else:
+            story.append(Paragraph(html.escape(text).replace("\n", "<br/>"), styles["BodyText"]))
+        story.append(Spacer(1, 8))
+    try:
+        doc.build(story)
+    except Exception as exc:  # pragma: no cover - reportlab internals.
+        raise HTTPException(
+            status_code=500,
+            detail={"error": "render_failed", "message": str(exc)},
+        ) from exc
+    return buffer.getvalue()
+
+
+@router.get("/deep-research-report")
+async def download_deep_research_report(
+    app_session_id: str = APP_SESSION_ID_QUERY_VALIDATION,
+    format: Literal["pdf", "md"] = "pdf",
+) -> Response:
+    session = db.get_session_by_app_id(app_session_id)
+    if not session:
+        raise HTTPException(status_code=404, detail="Session not found")
+    run = db.get_latest_deep_research_run(
+        int(session["session_id"]),
+        CASE_GROUP_RESEARCH_PURPOSE,
+    )
+    if not run:
+        raise HTTPException(status_code=404, detail="No Deep Research report for session")
+    status = str(run.get("status") or "")
+    if status not in {"completed", "parsed"}:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Deep Research report is not ready yet (status: {status or 'idle'}).",
+        )
+    report_md = str(run.get("report_md") or "").strip()
+    if not report_md:
+        raise HTTPException(status_code=404, detail="Deep Research report is empty")
+
+    base_filename = f"ccc_deep_research_{app_session_id}"
+    if format == "md":
+        return Response(
+            content=report_md,
+            media_type="text/markdown; charset=utf-8",
+            headers={"Content-Disposition": f'attachment; filename="{base_filename}.md"'},
+        )
+    pdf = _render_research_report_pdf(report_md, f"Deep Research Report {app_session_id}")
+    return Response(
+        content=pdf,
+        media_type="application/pdf",
+        headers={"Content-Disposition": f'attachment; filename="{base_filename}.pdf"'},
+    )
 
 
 @router.post("/undo", response_model=SessionUndoResponse)

--- a/backend/routers/sessions.py
+++ b/backend/routers/sessions.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime
 import html
 import inspect
 import json
+import re
 import time
 import uuid
 from dataclasses import dataclass, field
@@ -25,6 +27,7 @@ from backend.core.deep_research_cases_prompt import build_deep_research_cases_pr
 from backend.core.deep_research_service import DeepResearchError, run_deep_research
 from backend.core.norm_addressees import SUPPORTED_NORM_ADDRESSEES
 from backend.core.norm_addressees import ADMINISTRATION, BUSINESS, CITIZENS
+from backend.core.request_context import get_request_context
 from backend.core.session_graph import build_session_tiles_snapshot
 from backend.core.workflow import (
     get_last_completed_step,
@@ -47,6 +50,8 @@ from backend.routers import (
 
 
 router = APIRouter(prefix="/sessions", tags=["sessions"])
+
+DEEP_RESEARCH_MONITOR_PROMPT_ID = "deep_research_case_group_metrics"
 
 ModelName = Annotated[
     str,
@@ -95,6 +100,7 @@ class SessionStatusResponse(BaseModel):
     total_cost_ready_by_addressee: dict[str, bool] = {}
     case_group_research_enabled: bool = False
     case_group_research_status: str = "idle"
+    case_group_research_elapsed_seconds: int | None = None
     last_completed_step: str | None = None
     last_completed_label: str | None = None
 
@@ -145,6 +151,7 @@ class CaseGroupResearchSettingsResponse(BaseModel):
     enabled: bool
     status: str = "idle"
     locked: bool = False
+    elapsed_seconds: int | None = None
 
 
 class SessionExportResponse(BaseModel):
@@ -483,6 +490,67 @@ def _step_error_message(exc: Exception) -> str:
     return message or exc.__class__.__name__
 
 
+def _deep_research_attempt_id(research_run_id: int) -> str:
+    return f"deep_research:{research_run_id}"
+
+
+async def _publish_deep_research_monitor_event(
+    *,
+    app_session_id: str,
+    session_id: int,
+    research_run_id: int,
+    event_type: str,
+    agent: str,
+    request_context: dict[str, str | None],
+    elapsed_ms: int | None = None,
+    prompt_chars: int | None = None,
+    input_tokens: int | None = None,
+    output_tokens: int | None = None,
+    thought_tokens: int | None = None,
+    estimated_cost_usd: float | None = None,
+    error: str | None = None,
+    error_kind: str | None = None,
+    answer_state: str | None = None,
+    state_reason: str | None = None,
+) -> None:
+    event: dict[str, object] = {
+        "event_type": event_type,
+        "attempt_id": _deep_research_attempt_id(research_run_id),
+        "session_id": session_id,
+        "prompt_id": DEEP_RESEARCH_MONITOR_PROMPT_ID,
+        "model": agent,
+        "provider": "gemini",
+        "request_id": request_context.get("request_id"),
+        "route_method": request_context.get("route_method"),
+        "route_path": request_context.get("route_path"),
+        "stream_mode": "non_stream",
+    }
+    for key, value in (
+        ("elapsed_ms", elapsed_ms),
+        ("prompt_chars", prompt_chars),
+        ("input_tokens", input_tokens),
+        ("output_tokens", output_tokens),
+        ("hidden_thinking_tokens", thought_tokens),
+        ("estimated_cost_usd", estimated_cost_usd),
+        ("error", error),
+        ("error_kind", error_kind),
+        ("answer_state", answer_state),
+        ("state_reason", state_reason),
+    ):
+        if value is not None:
+            event[key] = value
+    await llm_monitor.publish_llm_event(app_session_id=app_session_id, event=event)
+
+
+def _recent_monitor_rows(session_id: int, limit: int) -> list[dict]:
+    rows = [
+        *db.list_recent_llm_answers_for_session(session_id, limit=limit),
+        *db.list_recent_deep_research_monitor_rows_for_session(session_id, limit=limit),
+    ]
+    rows.sort(key=lambda row: str(row.get("created_at") or ""), reverse=True)
+    return rows[: max(1, min(limit, 500))]
+
+
 async def _run_case_group_deep_research(
     *,
     app_session_id: str,
@@ -514,8 +582,29 @@ async def _run_case_group_deep_research(
         status="running",
         prompt_text=prompt,
     )
+    request_context = get_request_context()
+    started = time.perf_counter()
+    await _publish_deep_research_monitor_event(
+        app_session_id=app_session_id,
+        session_id=session_id,
+        research_run_id=research_run_id,
+        event_type="llm_query_started",
+        agent=settings.deep_research_primary_agent,
+        request_context=request_context,
+        prompt_chars=len(prompt),
+    )
+    query_succeeded = False
     try:
-        result = await run_deep_research(prompt=prompt, api_keys=api_keys)
+        result = await run_deep_research(
+            prompt=prompt,
+            api_keys=api_keys,
+            on_interaction_started=lambda agent, interaction_id: db.update_deep_research_run(
+                research_run_id,
+                agent=agent,
+                interaction_id=interaction_id,
+            ),
+        )
+        elapsed_ms = int((time.perf_counter() - started) * 1000)
         db.update_deep_research_run(
             research_run_id,
             status="completed",
@@ -527,17 +616,74 @@ async def _run_case_group_deep_research(
             output_tokens=result.output_tokens,
             thought_tokens=result.thought_tokens,
             total_tokens=result.total_tokens,
+            estimated_cost_usd=result.estimated_cost_usd,
         )
-        apply_deep_research_case_metrics(
+        await _publish_deep_research_monitor_event(
+            app_session_id=app_session_id,
             session_id=session_id,
-            report_text=result.report_text,
             research_run_id=research_run_id,
+            event_type="llm_query_succeeded",
+            agent=result.agent,
+            request_context=request_context,
+            elapsed_ms=elapsed_ms,
+            input_tokens=result.input_tokens,
+            output_tokens=result.output_tokens,
+            thought_tokens=result.thought_tokens,
+            estimated_cost_usd=result.estimated_cost_usd,
+        )
+        query_succeeded = True
+        try:
+            apply_deep_research_case_metrics(
+                session_id=session_id,
+                report_text=result.report_text,
+                research_run_id=research_run_id,
+            )
+        except Exception as exc:
+            await _publish_deep_research_monitor_event(
+                app_session_id=app_session_id,
+                session_id=session_id,
+                research_run_id=research_run_id,
+                event_type="llm_apply_failed",
+                agent=result.agent,
+                request_context=request_context,
+                elapsed_ms=int((time.perf_counter() - started) * 1000),
+                error=_step_error_message(exc),
+                error_kind="deep_research_apply_failed",
+                answer_state="invalid",
+                state_reason="session_update_failed",
+            )
+            raise
+        await _publish_deep_research_monitor_event(
+            app_session_id=app_session_id,
+            session_id=session_id,
+            research_run_id=research_run_id,
+            event_type="llm_apply_succeeded",
+            agent=result.agent,
+            request_context=request_context,
+            elapsed_ms=int((time.perf_counter() - started) * 1000),
+            input_tokens=result.input_tokens,
+            output_tokens=result.output_tokens,
+            thought_tokens=result.thought_tokens,
+            estimated_cost_usd=result.estimated_cost_usd,
+            answer_state="active",
+            state_reason="session_updated",
         )
     except asyncio.CancelledError:
         db.update_deep_research_run(
             research_run_id,
             status="cancelled",
             error="Deep Research was cancelled by the run-all task.",
+        )
+        await _publish_deep_research_monitor_event(
+            app_session_id=app_session_id,
+            session_id=session_id,
+            research_run_id=research_run_id,
+            event_type="llm_query_failed",
+            agent=settings.deep_research_primary_agent,
+            request_context=request_context,
+            elapsed_ms=int((time.perf_counter() - started) * 1000),
+            error="Deep Research was cancelled by the run-all task.",
+            error_kind="cancelled",
         )
         raise
     except DeepResearchError as exc:
@@ -546,6 +692,17 @@ async def _run_case_group_deep_research(
             status="failed",
             error=str(exc),
         )
+        await _publish_deep_research_monitor_event(
+            app_session_id=app_session_id,
+            session_id=session_id,
+            research_run_id=research_run_id,
+            event_type="llm_query_failed",
+            agent=settings.deep_research_primary_agent,
+            request_context=request_context,
+            elapsed_ms=int((time.perf_counter() - started) * 1000),
+            error=str(exc),
+            error_kind="deep_research_query_failed",
+        )
         raise HTTPException(status_code=502, detail=str(exc)) from exc
     except Exception as exc:
         db.update_deep_research_run(
@@ -553,6 +710,18 @@ async def _run_case_group_deep_research(
             status="failed",
             error=_step_error_message(exc),
         )
+        if not query_succeeded:
+            await _publish_deep_research_monitor_event(
+                app_session_id=app_session_id,
+                session_id=session_id,
+                research_run_id=research_run_id,
+                event_type="llm_query_failed",
+                agent=settings.deep_research_primary_agent,
+                request_context=request_context,
+                elapsed_ms=int((time.perf_counter() - started) * 1000),
+                error=_step_error_message(exc),
+                error_kind="deep_research_failed",
+            )
         raise
 
 
@@ -956,6 +1125,10 @@ def _research_settings_response(app_session_id: str) -> CaseGroupResearchSetting
         enabled=bool(session.get("case_group_research_enabled")),
         status=status,
         locked=status not in {"idle", "failed", "cancelled"},
+        elapsed_seconds=db.get_latest_deep_research_run_elapsed_seconds(
+            session_id,
+            CASE_GROUP_RESEARCH_PURPOSE,
+        ),
     )
 
 
@@ -1065,11 +1238,143 @@ async def export_session(
     return SessionExportResponse(filename=filename, markdown=markdown)
 
 
-def _render_research_report_pdf(report_md: str, title: str) -> bytes:
+def _split_pipe_table_row(line: str) -> list[str]:
+    stripped = line.strip()
+    if stripped.startswith("|"):
+        stripped = stripped[1:]
+    if stripped.endswith("|"):
+        stripped = stripped[:-1]
+    cells: list[str] = []
+    current: list[str] = []
+    escaped = False
+    for char in stripped:
+        if escaped:
+            current.append(char)
+            escaped = False
+            continue
+        if char == "\\":
+            escaped = True
+            continue
+        if char == "|":
+            cells.append("".join(current).strip())
+            current = []
+            continue
+        current.append(char)
+    if escaped:
+        current.append("\\")
+    cells.append("".join(current).strip())
+    return cells
+
+
+def _is_pipe_table_separator(line: str) -> bool:
+    cells = _split_pipe_table_row(line)
+    if len(cells) < 2:
+        return False
+    for cell in cells:
+        marker = cell.strip()
+        if len(marker) < 3:
+            return False
+        marker = marker.strip(":")
+        if not marker or any(char != "-" for char in marker):
+            return False
+    return True
+
+
+def _parse_pipe_table(block: str) -> list[list[str]] | None:
+    lines = [line.strip() for line in block.splitlines() if line.strip()]
+    if len(lines) < 3 or "|" not in lines[0] or not _is_pipe_table_separator(lines[1]):
+        return None
+    rows = [_split_pipe_table_row(lines[0])]
+    expected_columns = len(rows[0])
+    if expected_columns < 2:
+        return None
+    body_rows = [_split_pipe_table_row(line) for line in lines[2:]]
+    if not body_rows:
+        return None
+    for row in body_rows:
+        if len(row) != expected_columns:
+            return None
+    rows.extend(body_rows)
+    return rows
+
+
+def _research_pdf_inline_markup(text: str) -> str:
+    escaped = html.escape(text).replace("\n", "<br/>")
+    parts = escaped.split("**")
+    if len(parts) == 1:
+        return _linkify_research_pdf_urls(escaped)
+    rendered: list[str] = []
+    for index, part in enumerate(parts):
+        linked_part = _linkify_research_pdf_urls(part)
+        if index % 2 == 1 and part:
+            rendered.append(f"<b>{linked_part}</b>")
+        else:
+            rendered.append(linked_part)
+    return "".join(rendered)
+
+
+def _linkify_research_pdf_urls(escaped_text: str) -> str:
+    url_pattern = re.compile(r"https?://[^\s<]+")
+
+    def replace(match: re.Match[str]) -> str:
+        url = match.group(0)
+        trailing = ""
+        while url and url[-1] in ".,;:)]]":
+            trailing = f"{url[-1]}{trailing}"
+            url = url[:-1]
+        if not url:
+            return match.group(0)
+        return f'<link href="{url}"><font color="blue">{url}</font></link>{trailing}'
+
+    return url_pattern.sub(replace, escaped_text)
+
+
+def _format_research_report_metadata_lines(metadata: dict[str, object]) -> list[str]:
+    lines = [
+        "<b>Hinweis:</b> Dieser Deep-Research-Bericht wurde KI-gestuetzt erzeugt. "
+        "Die genannten Zahlen, Quellen und Schlussfolgerungen sollten vor einer offiziellen "
+        "Verwendung fachlich geprueft werden.",
+    ]
+    for label, value in (
+        ("Session", metadata.get("app_session_id")),
+        ("Erstellt", metadata.get("generated_at")),
+        ("Agent", metadata.get("agent")),
+        ("Status", metadata.get("status")),
+    ):
+        if value:
+            lines.append(f"<b>{label}:</b> {html.escape(str(value))}")
+    token_parts = [
+        f"in {metadata.get('input_tokens')}" if metadata.get("input_tokens") is not None else None,
+        f"out {metadata.get('output_tokens')}" if metadata.get("output_tokens") is not None else None,
+        (
+            f"thinking {metadata.get('thought_tokens')}"
+            if metadata.get("thought_tokens") is not None
+            else None
+        ),
+        f"total {metadata.get('total_tokens')}" if metadata.get("total_tokens") is not None else None,
+    ]
+    tokens = " / ".join(part for part in token_parts if part)
+    if tokens:
+        lines.append(f"<b>Token:</b> {html.escape(tokens)}")
+    cost = metadata.get("estimated_cost_usd")
+    if cost is not None:
+        try:
+            lines.append(f"<b>Geschaetzte API-Kosten:</b> ${float(cost):.4f}")
+        except (TypeError, ValueError):
+            lines.append(f"<b>Geschaetzte API-Kosten:</b> {html.escape(str(cost))}")
+    return lines
+
+
+def _render_research_report_pdf(
+    report_md: str,
+    title: str,
+    metadata: dict[str, object] | None = None,
+) -> bytes:
     try:
+        from reportlab.lib import colors
         from reportlab.lib.pagesizes import A4
-        from reportlab.lib.styles import getSampleStyleSheet
-        from reportlab.platypus import Paragraph, SimpleDocTemplate, Spacer
+        from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+        from reportlab.platypus import Paragraph, SimpleDocTemplate, Spacer, Table, TableStyle
     except Exception as exc:  # pragma: no cover - exercised only without optional dep.
         raise HTTPException(
             status_code=500,
@@ -1090,7 +1395,33 @@ def _render_research_report_pdf(report_md: str, title: str) -> bytes:
         title=title,
     )
     styles = getSampleStyleSheet()
+    table_cell_style = ParagraphStyle(
+        "ResearchTableCell",
+        parent=styles["BodyText"],
+        fontSize=8,
+        leading=10,
+    )
+    available_width = A4[0] - doc.leftMargin - doc.rightMargin
     story = [Paragraph(html.escape(title), styles["Title"]), Spacer(1, 12)]
+    if metadata:
+        metadata_lines = _format_research_report_metadata_lines(metadata)
+        metadata_box = Table(
+            [[Paragraph("<br/>".join(metadata_lines), styles["BodyText"])]],
+            colWidths=[available_width],
+        )
+        metadata_box.setStyle(
+            TableStyle(
+                [
+                    ("BACKGROUND", (0, 0), (-1, -1), colors.HexColor("#f8fafc")),
+                    ("BOX", (0, 0), (-1, -1), 0.5, colors.HexColor("#94a3b8")),
+                    ("LEFTPADDING", (0, 0), (-1, -1), 8),
+                    ("RIGHTPADDING", (0, 0), (-1, -1), 8),
+                    ("TOPPADDING", (0, 0), (-1, -1), 6),
+                    ("BOTTOMPADDING", (0, 0), (-1, -1), 6),
+                ]
+            )
+        )
+        story.extend([metadata_box, Spacer(1, 12)])
     for block in report_md.split("\n\n"):
         text = block.strip()
         if not text:
@@ -1098,11 +1429,50 @@ def _render_research_report_pdf(report_md: str, title: str) -> bytes:
         if text.startswith("#"):
             heading = text.lstrip("#").strip()
             story.append(Paragraph(html.escape(heading), styles["Heading2"]))
+        elif table_rows := _parse_pipe_table(text):
+            column_count = len(table_rows[0])
+            table_data = [
+                [
+                    Paragraph(_research_pdf_inline_markup(cell), table_cell_style)
+                    for cell in row
+                ]
+                for row in table_rows
+            ]
+            table = Table(
+                table_data,
+                colWidths=[available_width / column_count] * column_count,
+                repeatRows=1,
+            )
+            table.setStyle(
+                TableStyle(
+                    [
+                        ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#f1f5f9")),
+                        ("GRID", (0, 0), (-1, -1), 0.35, colors.HexColor("#cbd5e1")),
+                        ("VALIGN", (0, 0), (-1, -1), "TOP"),
+                        ("LEFTPADDING", (0, 0), (-1, -1), 4),
+                        ("RIGHTPADDING", (0, 0), (-1, -1), 4),
+                        ("TOPPADDING", (0, 0), (-1, -1), 3),
+                        ("BOTTOMPADDING", (0, 0), (-1, -1), 3),
+                    ]
+                )
+            )
+            story.append(table)
         else:
-            story.append(Paragraph(html.escape(text).replace("\n", "<br/>"), styles["BodyText"]))
+            story.append(Paragraph(_research_pdf_inline_markup(text), styles["BodyText"]))
         story.append(Spacer(1, 8))
     try:
-        doc.build(story)
+        def add_page_number(canvas, document) -> None:
+            canvas.saveState()
+            canvas.setFont("Helvetica", 8)
+            canvas.setFillColor(colors.HexColor("#64748b"))
+            canvas.drawRightString(
+                document.pagesize[0] - document.rightMargin,
+                18,
+                f"Seite {document.page}",
+            )
+            canvas.restoreState()
+
+        doc.build(story, onFirstPage=add_page_number, onLaterPages=add_page_number)
     except Exception as exc:  # pragma: no cover - reportlab internals.
         raise HTTPException(
             status_code=500,
@@ -1142,7 +1512,21 @@ async def download_deep_research_report(
             media_type="text/markdown; charset=utf-8",
             headers={"Content-Disposition": f'attachment; filename="{base_filename}.md"'},
         )
-    pdf = _render_research_report_pdf(report_md, f"Deep Research Report {app_session_id}")
+    pdf = _render_research_report_pdf(
+        report_md,
+        f"Deep Research Report {app_session_id}",
+        metadata={
+            "app_session_id": app_session_id,
+            "generated_at": datetime.now().strftime("%Y-%m-%d %H:%M"),
+            "agent": run.get("agent"),
+            "status": status,
+            "input_tokens": run.get("input_tokens"),
+            "output_tokens": run.get("output_tokens"),
+            "thought_tokens": run.get("thought_tokens"),
+            "total_tokens": run.get("total_tokens"),
+            "estimated_cost_usd": run.get("estimated_cost_usd"),
+        },
+    )
     return Response(
         content=pdf,
         media_type="application/pdf",
@@ -1466,7 +1850,7 @@ async def get_llm_monitor_snapshot(
         raise HTTPException(status_code=404, detail="Session not found")
     session_id = int(session["session_id"])
     pending = await llm_monitor.get_pending(app_session_id)
-    recent = db.list_recent_llm_answers_for_session(session_id, limit=limit)
+    recent = _recent_monitor_rows(session_id, limit)
     events = await llm_monitor.get_recent_events(app_session_id, limit=limit)
     stream_attempts = await llm_monitor.get_stream_attempts(
         app_session_id,
@@ -1504,10 +1888,7 @@ async def stream_llm_monitor_events(
                     "pending": monitor_snapshot["pending"],
                     "events": monitor_snapshot["events"],
                     "stream_attempts": monitor_snapshot["stream_attempts"],
-                    "recent": db.list_recent_llm_answers_for_session(
-                        session_id,
-                        limit=limit,
-                    ),
+                    "recent": _recent_monitor_rows(session_id, limit),
                 },
             )
             if once:

--- a/backend/routers/sessions.py
+++ b/backend/routers/sessions.py
@@ -174,6 +174,10 @@ class SessionRunAllRequest(BaseModel):
     provider: str | None = None
 
 
+class SessionStepRunRequest(SessionRunAllRequest):
+    step_key: str
+
+
 class SessionRunStepResult(BaseModel):
     key: str
     label: str
@@ -231,6 +235,7 @@ RUN_ALL_STEPS: tuple[tuple[str, str, str], ...] = (
     ("effort", "Aufwand berechnen", "effort_ready"),
     ("total_cost", "Gesamtkosten berechnen", "total_cost_ready"),
 )
+RUN_ALL_STEP_BY_KEY = {key: (label, status_flag) for key, label, status_flag in RUN_ALL_STEPS}
 
 _RUN_ALL_LOCKS: dict[str, asyncio.Lock] = {}
 
@@ -1034,6 +1039,148 @@ async def _execute_run_all_steps(
     return step_results, final_status, ok
 
 
+async def _execute_single_step(
+    *,
+    step_key: str,
+    payload: SessionRunAllRequest,
+    api_keys: ApiKeys,
+    model: str,
+    event_hook: Callable[[str, dict], Awaitable[None] | None] | None = None,
+) -> tuple[list[SessionRunStepResult], SessionStatusResponse, bool]:
+    step_definition = RUN_ALL_STEP_BY_KEY.get(step_key)
+    if step_definition is None:
+        raise HTTPException(status_code=400, detail=f"Unknown step: {step_key}")
+    step_label, status_flag = step_definition
+    current_status = db.get_session_status(payload.app_session_id)
+    if not current_status:
+        raise HTTPException(status_code=404, detail="Session not found")
+    if bool(current_status.get(status_flag)):
+        step_result = SessionRunStepResult(
+            key=step_key,
+            label=step_label,
+            status="skipped",
+            message="Step already complete",
+        )
+        final_status = _as_session_status_response(payload.app_session_id)
+        await _emit_event(
+            event_hook,
+            "step_skipped",
+            {
+                "key": step_key,
+                "label": step_label,
+                "step": step_result.model_dump(),
+                "session_status": final_status.model_dump(),
+            },
+        )
+        await _emit_event(
+            event_hook,
+            "run_completed",
+            {
+                "ok": True,
+                "steps": [step_result.model_dump()],
+                "final_status": final_status.model_dump(),
+            },
+        )
+        return [step_result], final_status, True
+
+    await _emit_event(event_hook, "step_started", {"key": step_key, "label": step_label})
+    try:
+        await _run_single_step(
+            step_key,
+            payload,
+            api_keys,
+            model,
+            event_hook=event_hook,
+        )
+    except Exception as exc:
+        step_result = SessionRunStepResult(
+            key=step_key,
+            label=step_label,
+            status="failed",
+            message=_step_error_message(exc),
+        )
+        final_status = _as_session_status_response(payload.app_session_id)
+        await _emit_event(
+            event_hook,
+            "step_failed",
+            {
+                "key": step_key,
+                "label": step_label,
+                "step": step_result.model_dump(),
+                "session_status": final_status.model_dump(),
+            },
+        )
+        await _emit_event(
+            event_hook,
+            "run_failed",
+            {
+                "ok": False,
+                "steps": [step_result.model_dump()],
+                "final_status": final_status.model_dump(),
+                "message": step_result.message,
+            },
+        )
+        return [step_result], final_status, False
+
+    updated_status = db.get_session_status(payload.app_session_id)
+    if updated_status and bool(updated_status.get(status_flag)):
+        step_result = SessionRunStepResult(
+            key=step_key,
+            label=step_label,
+            status="completed",
+        )
+        final_status = _as_session_status_response(payload.app_session_id)
+        await _emit_event(
+            event_hook,
+            "step_completed",
+            {
+                "key": step_key,
+                "label": step_label,
+                "step": step_result.model_dump(),
+                "session_status": final_status.model_dump(),
+            },
+        )
+        await _emit_event(
+            event_hook,
+            "run_completed",
+            {
+                "ok": True,
+                "steps": [step_result.model_dump()],
+                "final_status": final_status.model_dump(),
+            },
+        )
+        return [step_result], final_status, True
+
+    step_result = SessionRunStepResult(
+        key=step_key,
+        label=step_label,
+        status="failed",
+        message="Step did not update session state as expected",
+    )
+    final_status = _as_session_status_response(payload.app_session_id)
+    await _emit_event(
+        event_hook,
+        "step_failed",
+        {
+            "key": step_key,
+            "label": step_label,
+            "step": step_result.model_dump(),
+            "session_status": final_status.model_dump(),
+        },
+    )
+    await _emit_event(
+        event_hook,
+        "run_failed",
+        {
+            "ok": False,
+            "steps": [step_result.model_dump()],
+            "final_status": final_status.model_dump(),
+            "message": step_result.message,
+        },
+    )
+    return [step_result], final_status, False
+
+
 @router.post("", response_model=SessionUpsertResponse)
 async def upsert_session(payload: SessionUpsertRequest) -> SessionUpsertResponse:
     _, created = db.upsert_session(payload.app_session_id, payload.llm_model)
@@ -1120,11 +1267,16 @@ def _research_settings_response(app_session_id: str) -> CaseGroupResearchSetting
         raise HTTPException(status_code=404, detail="Session not found")
     session_id = int(session["session_id"])
     status = db.get_latest_deep_research_run_status(session_id, "case_group_metrics")
+    session_status = db.get_session_status(app_session_id) or {}
     return CaseGroupResearchSettingsResponse(
         app_session_id=app_session_id,
         enabled=bool(session.get("case_group_research_enabled")),
         status=status,
-        locked=status not in {"idle", "failed", "cancelled"},
+        locked=(
+            status not in {"idle", "failed", "cancelled"}
+            or bool(session_status.get("effort_ready"))
+            or bool(session_status.get("total_cost_ready"))
+        ),
         elapsed_seconds=db.get_latest_deep_research_run_elapsed_seconds(
             session_id,
             CASE_GROUP_RESEARCH_PURPOSE,
@@ -1147,6 +1299,15 @@ async def case_group_research_settings_update(
     if not session:
         raise HTTPException(status_code=404, detail="Session not found")
     session_id = int(session["session_id"])
+    current_enabled = bool(session.get("case_group_research_enabled"))
+    if current_enabled == payload.enabled:
+        return _research_settings_response(payload.app_session_id)
+    session_status = db.get_session_status(payload.app_session_id) or {}
+    if bool(session_status.get("effort_ready")) or bool(session_status.get("total_cost_ready")):
+        raise HTTPException(
+            status_code=409,
+            detail="Deep Research mode is locked after effort has been calculated. Revert effort to change it.",
+        )
     status = db.get_latest_deep_research_run_status(session_id, "case_group_metrics")
     if status not in {"idle", "failed", "cancelled"}:
         raise HTTPException(
@@ -1558,6 +1719,46 @@ async def undo_last_step(payload: SessionUndoRequest) -> SessionUndoResponse:
     )
 
 
+async def _mark_background_run_terminal(
+    *,
+    run_id: str,
+    app_session_id: str,
+    status: Literal["failed", "cancelled"],
+    event_name: Literal["run_failed", "run_cancelled"],
+    message: str,
+) -> None:
+    final_status: SessionStatusResponse | None = None
+    try:
+        final_status = _as_session_status_response(app_session_id)
+    except HTTPException:
+        final_status = None
+
+    async with _RUN_REGISTRY_LOCK:
+        record = _RUNS_BY_ID.get(run_id)
+        if record is not None:
+            record.status = status
+            record.ok = False
+            record.updated_at = time.time()
+            record.final_status = final_status
+            if _ACTIVE_RUN_BY_SESSION.get(record.app_session_id) == run_id:
+                _ACTIVE_RUN_BY_SESSION.pop(record.app_session_id, None)
+            steps = [step.model_dump() for step in record.steps]
+        else:
+            steps = []
+
+    await _publish_run_event(
+        run_id,
+        event_name,
+        {
+            "ok": False,
+            "steps": steps,
+            "final_status": final_status.model_dump() if final_status else None,
+            "message": message,
+        },
+    )
+    await _trim_finished_runs()
+
+
 async def _run_all_background(
     run_id: str,
     payload: SessionRunAllRequest,
@@ -1588,41 +1789,13 @@ async def _run_all_background(
                 event_hook=lambda event, data: _publish_run_event(run_id, event, data),
             )
     except asyncio.CancelledError:
-        async with _RUN_REGISTRY_LOCK:
-            record = _RUNS_BY_ID.get(run_id)
-            if record is not None:
-                if _ACTIVE_RUN_BY_SESSION.get(record.app_session_id) == run_id:
-                    _ACTIVE_RUN_BY_SESSION.pop(record.app_session_id, None)
-
-        final_status: SessionStatusResponse | None = None
-        try:
-            final_status = _as_session_status_response(payload.app_session_id)
-        except HTTPException:
-            final_status = None
-        async with _RUN_REGISTRY_LOCK:
-            record = _RUNS_BY_ID.get(run_id)
-            if record is not None:
-                record.status = "cancelled"
-                record.ok = False
-                record.updated_at = time.time()
-                record.final_status = final_status
-                if _ACTIVE_RUN_BY_SESSION.get(record.app_session_id) == run_id:
-                    _ACTIVE_RUN_BY_SESSION.pop(record.app_session_id, None)
-                steps = [step.model_dump() for step in record.steps]
-            else:
-                steps = []
-
-        await _publish_run_event(
-            run_id,
-            "run_cancelled",
-            {
-                "ok": False,
-                "steps": steps,
-                "final_status": final_status.model_dump() if final_status else None,
-                "message": "Run cancelled by user",
-            },
+        await _mark_background_run_terminal(
+            run_id=run_id,
+            app_session_id=payload.app_session_id,
+            status="cancelled",
+            event_name="run_cancelled",
+            message="Run cancelled by user",
         )
-        await _trim_finished_runs()
         if trace_token is not None:
             try:
                 llm_trace.flush_run(trace_token, status_code=499)
@@ -1630,34 +1803,13 @@ async def _run_all_background(
                 pass
         return
     except Exception as exc:
-        final_status: SessionStatusResponse | None = None
-        try:
-            final_status = _as_session_status_response(payload.app_session_id)
-        except HTTPException:
-            final_status = None
-        async with _RUN_REGISTRY_LOCK:
-            record = _RUNS_BY_ID.get(run_id)
-            if record is not None:
-                record.status = "failed"
-                record.ok = False
-                record.updated_at = time.time()
-                record.final_status = final_status
-                if _ACTIVE_RUN_BY_SESSION.get(record.app_session_id) == run_id:
-                    _ACTIVE_RUN_BY_SESSION.pop(record.app_session_id, None)
-                steps = [step.model_dump() for step in record.steps]
-            else:
-                steps = []
-        await _publish_run_event(
-            run_id,
-            "run_failed",
-            {
-                "ok": False,
-                "steps": steps,
-                "final_status": final_status.model_dump() if final_status else None,
-                "message": _step_error_message(exc),
-            },
+        await _mark_background_run_terminal(
+            run_id=run_id,
+            app_session_id=payload.app_session_id,
+            status="failed",
+            event_name="run_failed",
+            message=_step_error_message(exc),
         )
-        await _trim_finished_runs()
         if trace_token is not None:
             try:
                 llm_trace.flush_run(trace_token, status_code=500)
@@ -1688,6 +1840,144 @@ async def _run_all_background(
             llm_trace.flush_run(trace_token, status_code=200 if ok else 500)
         except Exception:
             pass
+
+
+async def _run_single_step_background(
+    run_id: str,
+    step_key: str,
+    payload: SessionRunAllRequest,
+    api_keys: ApiKeys,
+    model: str,
+) -> None:
+    lock = _get_run_all_lock(payload.app_session_id)
+    try:
+        start_record = await _get_run_record(run_id)
+        await _publish_run_event(
+            run_id,
+            "snapshot",
+            _run_snapshot_payload(start_record),
+        )
+        async with lock:
+            steps, final_status, ok = await _execute_single_step(
+                step_key=step_key,
+                payload=payload,
+                api_keys=api_keys,
+                model=model,
+                event_hook=lambda event, data: _publish_run_event(run_id, event, data),
+            )
+    except asyncio.CancelledError:
+        await _mark_background_run_terminal(
+            run_id=run_id,
+            app_session_id=payload.app_session_id,
+            status="cancelled",
+            event_name="run_cancelled",
+            message="Run cancelled by user",
+        )
+        return
+    except Exception as exc:
+        await _mark_background_run_terminal(
+            run_id=run_id,
+            app_session_id=payload.app_session_id,
+            status="failed",
+            event_name="run_failed",
+            message=_step_error_message(exc),
+        )
+        return
+
+    async with _RUN_REGISTRY_LOCK:
+        record = _RUNS_BY_ID.get(run_id)
+        if record is not None:
+            record.steps = steps
+            record.final_status = final_status
+            record.ok = ok
+            record.status = "completed" if ok else "failed"
+            record.updated_at = time.time()
+            if _ACTIVE_RUN_BY_SESSION.get(record.app_session_id) == run_id:
+                _ACTIVE_RUN_BY_SESSION.pop(record.app_session_id, None)
+
+    record_after = await _get_run_record(run_id)
+    await _publish_run_event(
+        run_id,
+        "snapshot",
+        _run_snapshot_payload(record_after),
+    )
+    await _trim_finished_runs()
+
+
+@router.post("/step-runs/start", response_model=SessionRunAllStartResponse)
+async def start_step_run(
+    payload: SessionStepRunRequest,
+    api_keys: ApiKeys = Depends(get_api_keys),
+) -> SessionRunAllStartResponse:
+    if payload.step_key not in RUN_ALL_STEP_BY_KEY:
+        raise HTTPException(status_code=400, detail=f"Unknown step: {payload.step_key}")
+    _session_id, _created, model = ensure_session_or_400(
+        payload.app_session_id,
+        payload.model,
+    )
+
+    async with _RUN_REGISTRY_LOCK:
+        active_run_id = _ACTIVE_RUN_BY_SESSION.get(payload.app_session_id)
+        if active_run_id:
+            active = _RUNS_BY_ID.get(active_run_id)
+            if active and active.status == "running":
+                return SessionRunAllStartResponse(
+                    app_session_id=payload.app_session_id,
+                    run_id=active_run_id,
+                    started=False,
+                    status="running",
+                )
+            _ACTIVE_RUN_BY_SESSION.pop(payload.app_session_id, None)
+
+        run_id = uuid.uuid4().hex
+        record = _RunRecord(
+            run_id=run_id,
+            app_session_id=payload.app_session_id,
+        )
+        _RUNS_BY_ID[run_id] = record
+        _ACTIVE_RUN_BY_SESSION[payload.app_session_id] = run_id
+
+    run_payload = SessionRunAllRequest(
+        app_session_id=payload.app_session_id,
+        current_filename=payload.current_filename,
+        proposed_filename=payload.proposed_filename,
+        model=payload.model,
+        provider=payload.provider,
+    )
+    task = asyncio.create_task(
+        _run_single_step_background(
+            run_id,
+            payload.step_key,
+            run_payload,
+            api_keys,
+            model,
+        )
+    )
+    async with _RUN_REGISTRY_LOCK:
+        active = _RUNS_BY_ID.get(run_id)
+        if active is not None:
+            active.task = task
+    return SessionRunAllStartResponse(
+        app_session_id=payload.app_session_id,
+        run_id=run_id,
+        started=True,
+        status="running",
+    )
+
+
+@router.get("/step-runs/{run_id}", response_model=SessionRunStatusResponse)
+async def get_step_run_status(run_id: str) -> SessionRunStatusResponse:
+    return await get_run_all_status(run_id)
+
+
+@router.post("/step-runs/{run_id}/cancel", response_model=SessionRunCancelResponse)
+async def cancel_step_run(run_id: str) -> SessionRunCancelResponse:
+    return await cancel_run_all(run_id)
+
+
+@router.get("/step-runs/{run_id}/events")
+async def stream_step_run_events(run_id: str, request: Request) -> StreamingResponse:
+    return await stream_run_all_events(run_id, request)
 
 
 @router.post("/run-all/start", response_model=SessionRunAllStartResponse)

--- a/backend/routers/sessions.py
+++ b/backend/routers/sessions.py
@@ -103,6 +103,9 @@ class SessionStatusResponse(BaseModel):
     case_group_research_elapsed_seconds: int | None = None
     last_completed_step: str | None = None
     last_completed_label: str | None = None
+    last_failed_step: str | None = None
+    last_failed_label: str | None = None
+    last_failed_message: str | None = None
 
 
 class SessionPayRatesUpdateRequest(BaseModel):
@@ -384,11 +387,80 @@ def _as_session_status_response(app_session_id: str) -> SessionStatusResponse:
     if not status:
         raise HTTPException(status_code=404, detail="Session not found")
     step = get_last_completed_step(status)
+    failed = _get_latest_failed_step_status(app_session_id, status)
     return SessionStatusResponse(
         **status,
         last_completed_step=step.key if step else None,
         last_completed_label=step.label if step else None,
+        last_failed_step=failed["step"] if failed else None,
+        last_failed_label=failed["label"] if failed else None,
+        last_failed_message=failed["message"] if failed else None,
     )
+
+
+_FAILED_PROMPT_STEP: dict[str, tuple[str, str, str]] = {
+    "law_summary": ("summary", "CCC starten", "summary_ready"),
+    "regulations_identification": (
+        "regulations",
+        "Vorgaben bestimmen",
+        "regulations_ready",
+    ),
+    "process_compilation": ("processes", "Prozesse bündeln", "processes_ready"),
+    "case_group_development": (
+        "case_groups",
+        "Fallgruppen entwickeln",
+        "case_groups_ready",
+    ),
+    "process_step_analysis": (
+        "process_steps",
+        "Prozessschritte bestimmen",
+        "process_steps_ready",
+    ),
+    "cases_calculation": ("effort", "Aufwand berechnen", "effort_ready"),
+    "effort_calculation": ("effort", "Aufwand berechnen", "effort_ready"),
+}
+
+
+def _format_failed_answer_message(row: dict) -> str | None:
+    reason = str(row.get("state_reason") or "").strip()
+    error = str(row.get("error") or "").strip()
+    if reason.startswith("session_update_failed:"):
+        return reason.split(":", 1)[1].strip() or None
+    if reason == "query_failed" and error:
+        return error
+    if reason and reason not in {
+        "session_reverted",
+        "superseded_by_new_attempt",
+        "superseded_by_reuse",
+        "session_updated",
+        "waiting_for_session_update",
+        "querying",
+    }:
+        return reason
+    return None
+
+
+def _get_latest_failed_step_status(
+    app_session_id: str,
+    status: dict,
+) -> dict[str, str] | None:
+    session_id = db.get_session_id_by_app_id(app_session_id)
+    if session_id is None:
+        return None
+    for row in db.list_recent_llm_answers_for_session(session_id, limit=50):
+        if row.get("answer_state") != "invalid":
+            continue
+        mapping = _FAILED_PROMPT_STEP.get(str(row.get("prompt_id") or ""))
+        if mapping is None:
+            continue
+        step_key, label, ready_flag = mapping
+        if bool(status.get(ready_flag)):
+            continue
+        message = _format_failed_answer_message(row)
+        if not message:
+            continue
+        return {"step": step_key, "label": label, "message": message}
+    return None
 
 
 def _as_session_pay_rates_response(
@@ -1200,15 +1272,7 @@ async def list_sessions(limit: int = Query(default=50, ge=1, le=200)) -> Session
 async def session_status(
     app_session_id: str = APP_SESSION_ID_QUERY_VALIDATION
 ) -> SessionStatusResponse:
-    status = db.get_session_status(app_session_id)
-    if not status:
-        raise HTTPException(status_code=404, detail="Session not found")
-    step = get_last_completed_step(status)
-    return SessionStatusResponse(
-        **status,
-        last_completed_step=step.key if step else None,
-        last_completed_label=step.label if step else None,
-    )
+    return _as_session_status_response(app_session_id)
 
 
 @router.get("/pay-rates", response_model=SessionPayRatesResponse)
@@ -1704,6 +1768,20 @@ async def undo_last_step(payload: SessionUndoRequest) -> SessionUndoResponse:
     if not status:
         raise HTTPException(status_code=404, detail="Session not found")
     session_id = int(session["session_id"])
+
+    async with _RUN_REGISTRY_LOCK:
+        active_run_id = _ACTIVE_RUN_BY_SESSION.get(payload.app_session_id)
+        if active_run_id:
+            active = _RUNS_BY_ID.get(active_run_id)
+            if active and active.status == "running":
+                raise HTTPException(
+                    status_code=409,
+                    detail=(
+                        "Zurücksetzen ist während einer laufenden Ausführung nicht "
+                        "möglich. Bitte den Lauf zuerst abbrechen."
+                    ),
+                )
+            _ACTIVE_RUN_BY_SESSION.pop(payload.app_session_id, None)
 
     step = get_last_completed_step(status)
     if not step:

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -247,18 +247,6 @@ body {
   border-top-color: rgba(15, 23, 42, 0.24);
 }
 
-.tile-node .tile-actions button {
-  width: 18px;
-  height: 18px;
-  padding: 0;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 11px;
-  line-height: 1;
-  flex: 0 0 auto;
-}
-
 .tile-node .tile-actions {
   display: flex;
   align-items: center;

--- a/frontend/src/components/CaseGroupsPanel.tsx
+++ b/frontend/src/components/CaseGroupsPanel.tsx
@@ -3,16 +3,36 @@
 import { useState } from "react";
 
 import { useApp } from "@/contexts/AppContext";
-import { apiClient, buildLlmRequestOptions } from "@/lib/api";
-import { runPerAddressee } from "@/lib/runPerAddressee";
+import { buildLlmRequestOptions } from "@/lib/api";
 import { useRunAllStepBusy } from "@/lib/runAllStepEvents";
+import { useCancellableStepRun } from "@/lib/useCancellableStepRun";
 
 export default function CaseGroupsPanel() {
   const { state, setCurrentTab, setCaseGroupsReady } = useApp();
   const [status, setStatus] = useState<string | null>(null);
-  const [isRunning, setIsRunning] = useState(false);
   const isRunAllBusy = useRunAllStepBusy("case_groups");
-  const isBusy = isRunning || isRunAllBusy;
+  const llm = buildLlmRequestOptions({
+    selectedModel: state.selectedModel,
+    availableModels: state.availableModels,
+  });
+  const stepRun = useCancellableStepRun({
+    appSessionId: state.appSessionId,
+    stepKey: "case_groups",
+    stepLabel: "Fallgruppen entwickeln",
+    model: llm.model,
+    provider: llm.provider,
+    keys: llm.keys,
+    logScope: "CaseGroupsPanel.developCaseGroups",
+    onCompleted: () => {
+      window.dispatchEvent(new Event("tiles-updated"));
+      setCaseGroupsReady(true);
+      setCurrentTab(4);
+    },
+    onCancelled: () => {
+      window.dispatchEvent(new Event("tiles-updated"));
+    },
+  });
+  const isBusy = stepRun.isRunning || isRunAllBusy;
 
   const canRun =
     state.processesReady &&
@@ -29,42 +49,42 @@ export default function CaseGroupsPanel() {
       return;
     }
     setStatus(null);
-    setIsRunning(true);
-    const llm = buildLlmRequestOptions({
-      selectedModel: state.selectedModel,
-      availableModels: state.availableModels,
-    });
     try {
-      const outcome = await runPerAddressee({
-        logScope: "CaseGroupsPanel.developCaseGroups",
-        logContext: { appSessionId: state.appSessionId },
-        operationLabel: "Fallgruppen entwickeln",
-        run: (normAddressee) =>
-          apiClient.developCaseGroups({
-            appSessionId: state.appSessionId,
-            normAddressee,
-            model: llm.model,
-            provider: llm.provider,
-            keys: llm.keys,
-          }),
-      });
-      window.dispatchEvent(new Event("tiles-updated"));
-      if (outcome.allSucceeded) {
-        setCaseGroupsReady(true);
-        setCurrentTab(4);
-      } else {
-        setStatus(outcome.statusMessage);
-      }
-    } finally {
-      setIsRunning(false);
+      await stepRun.start();
+    } catch {
+      setStatus("Fallgruppen konnten nicht gestartet werden.");
     }
   };
+  const handleButtonClick = async () => {
+    if (stepRun.isRunning) {
+      await stepRun.cancel();
+      return;
+    }
+    await handleDevelop();
+  };
+  const buttonLabel = stepRun.isRunning
+    ? stepRun.isCancelling
+      ? "Abbruch wird ausgeführt..."
+      : "Abbrechen"
+    : isRunAllBusy
+      ? "Abbrechen"
+      : "Fallgruppen entwickeln";
+  const buttonClass =
+    stepRun.isRunning || isRunAllBusy
+      ? stepRun.isCancelling
+        ? "cursor-not-allowed border border-rose-100 bg-rose-100 text-rose-400"
+        : "border border-rose-200 bg-rose-50 text-rose-700 hover:bg-rose-100"
+      : canRun
+        ? "bg-slate-900 text-white"
+        : "cursor-not-allowed bg-slate-200 text-slate-500";
+  const buttonDisabled = isRunAllBusy || stepRun.isCancelling || (!stepRun.isRunning && !canRun);
+  const visibleStepRunStatus = stepRun.isRunning ? null : stepRun.statusText;
 
   return (
     <section className="w-full border-b border-white/60 bg-white/80 px-6 py-4 backdrop-blur">
       <div className="mx-auto max-w-6xl space-y-4">
-        <div className="flex flex-wrap items-center justify-between gap-4">
-          <p className="text-xs text-slate-600">
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start">
+          <p className="text-xs leading-5 text-slate-600">
             Wenn Prozesse auf unterschiedlichen Wegen erfüllt werden, werden
             Fallgruppen gebildet. Jede Fallgruppe beschreibt eine typische
             Ausprägung der Ausführung, damit der Erfüllungsaufwand getrennt
@@ -74,21 +94,20 @@ export default function CaseGroupsPanel() {
             die Sicht des ausgewählten Normadressaten.
           </p>
           <button
-            onClick={handleDevelop}
-            disabled={!canRun}
-            className={`rounded-full px-4 py-2 text-sm font-semibold transition ${
-              canRun
-                ? "bg-slate-900 text-white"
-                : "cursor-not-allowed bg-slate-200 text-slate-500"
-            }`}
+            onClick={handleButtonClick}
+            disabled={buttonDisabled}
+            className={`inline-flex items-center gap-2 justify-self-start whitespace-nowrap rounded-full px-4 py-2 text-sm font-semibold transition sm:justify-self-end ${buttonClass}`}
           >
-            {isBusy ? "Bitte warten..." : "Fallgruppen entwickeln"}
+            {(stepRun.isRunning || isRunAllBusy) && (
+              <span className="h-3 w-3 animate-spin rounded-full border-2 border-current border-t-transparent" />
+            )}
+            {buttonLabel}
           </button>
         </div>
 
-        {status && (
+        {(status || visibleStepRunStatus) && (
           <div className="rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-xs font-semibold text-amber-800">
-            {status}
+            {visibleStepRunStatus || status}
           </div>
         )}
       </div>

--- a/frontend/src/components/CaseGroupsPanel.tsx
+++ b/frontend/src/components/CaseGroupsPanel.tsx
@@ -4,13 +4,20 @@ import { useState } from "react";
 
 import { useApp } from "@/contexts/AppContext";
 import { buildLlmRequestOptions } from "@/lib/api";
-import { useRunAllStepBusy } from "@/lib/runAllStepEvents";
+import { getVisibleFailedStepStatus } from "@/lib/sessionStatus";
 import { useCancellableStepRun } from "@/lib/useCancellableStepRun";
+import { useRunAllStepCancel } from "@/lib/useRunAllStepCancel";
 
 export default function CaseGroupsPanel() {
   const { state, setCurrentTab, setCaseGroupsReady } = useApp();
   const [status, setStatus] = useState<string | null>(null);
-  const isRunAllBusy = useRunAllStepBusy("case_groups");
+  const runAllCancel = useRunAllStepCancel({
+    stepKey: "case_groups",
+    appSessionId: state.appSessionId,
+    setStatus,
+    logScope: "CaseGroupsPanel.cancelRunAll",
+  });
+  const isRunAllBusy = runAllCancel.isRunAllBusy;
   const llm = buildLlmRequestOptions({
     selectedModel: state.selectedModel,
     availableModels: state.availableModels,
@@ -60,6 +67,10 @@ export default function CaseGroupsPanel() {
       await stepRun.cancel();
       return;
     }
+    if (isRunAllBusy) {
+      await runAllCancel.cancelRunAllForStep();
+      return;
+    }
     await handleDevelop();
   };
   const buttonLabel = stepRun.isRunning
@@ -67,18 +78,29 @@ export default function CaseGroupsPanel() {
       ? "Abbruch wird ausgeführt..."
       : "Abbrechen"
     : isRunAllBusy
-      ? "Abbrechen"
+      ? runAllCancel.isCancellingRunAll
+        ? "Abbruch wird ausgeführt..."
+        : "Abbrechen"
       : "Fallgruppen entwickeln";
   const buttonClass =
     stepRun.isRunning || isRunAllBusy
-      ? stepRun.isCancelling
+      ? stepRun.isCancelling || runAllCancel.isCancellingRunAll
         ? "cursor-not-allowed border border-rose-100 bg-rose-100 text-rose-400"
         : "border border-rose-200 bg-rose-50 text-rose-700 hover:bg-rose-100"
       : canRun
         ? "bg-slate-900 text-white"
         : "cursor-not-allowed bg-slate-200 text-slate-500";
-  const buttonDisabled = isRunAllBusy || stepRun.isCancelling || (!stepRun.isRunning && !canRun);
+  const buttonDisabled =
+    stepRun.isCancelling ||
+    runAllCancel.isCancellingRunAll ||
+    (isRunAllBusy ? !runAllCancel.runAllRunId : !stepRun.isRunning && !canRun);
   const visibleStepRunStatus = stepRun.isRunning ? null : stepRun.statusText;
+  const failedStepStatus = getVisibleFailedStepStatus(
+    state,
+    "case_groups",
+    state.caseGroupsReady,
+    visibleStepRunStatus
+  );
 
   return (
     <section className="w-full border-b border-white/60 bg-white/80 px-6 py-4 backdrop-blur">
@@ -105,9 +127,9 @@ export default function CaseGroupsPanel() {
           </button>
         </div>
 
-        {(status || visibleStepRunStatus) && (
+        {(status || visibleStepRunStatus || failedStepStatus) && (
           <div className="rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-xs font-semibold text-amber-800">
-            {visibleStepRunStatus || status}
+            {visibleStepRunStatus || status || failedStepStatus}
           </div>
         )}
       </div>

--- a/frontend/src/components/EffortPanel.tsx
+++ b/frontend/src/components/EffortPanel.tsx
@@ -3,16 +3,37 @@
 import { useState } from "react";
 
 import { useApp } from "@/contexts/AppContext";
-import { apiClient, buildLlmRequestOptions } from "@/lib/api";
-import { runPerAddressee } from "@/lib/runPerAddressee";
+import { buildLlmRequestOptions } from "@/lib/api";
 import { useRunAllStepBusy } from "@/lib/runAllStepEvents";
+import { useCancellableStepRun } from "@/lib/useCancellableStepRun";
 
 export default function EffortPanel() {
   const { state, setCurrentTab, setEffortReady } = useApp();
   const [status, setStatus] = useState<string | null>(null);
-  const [isRunning, setIsRunning] = useState(false);
   const isRunAllBusy = useRunAllStepBusy("effort");
-  const isBusy = isRunning || isRunAllBusy;
+  const llm = buildLlmRequestOptions({
+    selectedModel: state.selectedModel,
+    availableModels: state.availableModels,
+  });
+  const stepRun = useCancellableStepRun({
+    appSessionId: state.appSessionId,
+    stepKey: "effort",
+    stepLabel: "Aufwand berechnen",
+    model: llm.model,
+    provider: llm.provider,
+    keys: llm.keys,
+    logScope: "EffortPanel.calculateEffort",
+    onCompleted: () => {
+      window.dispatchEvent(new Event("tiles-updated"));
+      setEffortReady(true);
+      setStatus("Aufwand fuer Verwaltung, Wirtschaft und Buerger berechnet.");
+      setCurrentTab(6);
+    },
+    onCancelled: () => {
+      window.dispatchEvent(new Event("tiles-updated"));
+    },
+  });
+  const isBusy = stepRun.isRunning || isRunAllBusy;
 
   const canRun =
     state.processStepsReady &&
@@ -29,54 +50,50 @@ export default function EffortPanel() {
       return;
     }
     setStatus(null);
-    setIsRunning(true);
-    const llm = buildLlmRequestOptions({
-      selectedModel: state.selectedModel,
-      availableModels: state.availableModels,
-    });
     try {
-      const outcome = await runPerAddressee({
-        logScope: "EffortPanel.calculateEffort",
-        logContext: { appSessionId: state.appSessionId },
-        operationLabel: "Aufwand berechnen",
-        run: (normAddressee) =>
-          apiClient.calculateEffort({
-            appSessionId: state.appSessionId,
-            normAddressee,
-            model: llm.model,
-            provider: llm.provider,
-            keys: llm.keys,
-          }),
-      });
-      if (!outcome.allSucceeded) {
-        setStatus(outcome.statusMessage);
-        return;
-      }
-      const allExisting = outcome.successes.every(
-        ({ result }) => result.status === "existing"
-      );
-      if (allExisting) {
-        setStatus(
-          "Aufwand fuer Verwaltung, Wirtschaft und Buerger wurde bereits berechnet."
-        );
-        setEffortReady(true);
-        setCurrentTab(6);
-        return;
-      }
-      window.dispatchEvent(new Event("tiles-updated"));
-      setEffortReady(true);
-      setStatus("Aufwand fuer Verwaltung, Wirtschaft und Buerger berechnet.");
-      setCurrentTab(6);
-    } finally {
-      setIsRunning(false);
+      await stepRun.start();
+    } catch {
+      setStatus("Aufwand konnte nicht gestartet werden.");
     }
   };
+
+  const handleButtonClick = async () => {
+    if (stepRun.isRunning) {
+      await stepRun.cancel();
+      return;
+    }
+    await handleCalculate();
+  };
+
+  const buttonLabel = (() => {
+    if (stepRun.isRunning) {
+      return stepRun.isCancelling ? "Abbruch wird ausgeführt..." : "Abbrechen";
+    }
+    if (isRunAllBusy) {
+      return "Abbrechen";
+    }
+    return "Aufwand berechnen";
+  })();
+
+  const buttonClass = (() => {
+    if (stepRun.isRunning || isRunAllBusy) {
+      return stepRun.isCancelling
+        ? "cursor-not-allowed border border-rose-100 bg-rose-100 text-rose-400"
+        : "border border-rose-200 bg-rose-50 text-rose-700 hover:bg-rose-100";
+    }
+    return canRun
+      ? "bg-slate-900 text-white"
+      : "cursor-not-allowed bg-slate-200 text-slate-500";
+  })();
+
+  const buttonDisabled = isRunAllBusy || stepRun.isCancelling || (!stepRun.isRunning && !canRun);
+  const visibleStepRunStatus = stepRun.isRunning ? null : stepRun.statusText;
 
   return (
     <section className="w-full border-b border-white/60 bg-white/80 px-6 py-4 backdrop-blur">
       <div className="mx-auto max-w-6xl space-y-4">
-        <div className="flex flex-wrap items-center justify-between gap-4">
-          <p className="text-xs text-slate-600">
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start">
+          <p className="text-xs leading-5 text-slate-600">
             Beim Klick auf „Aufwand berechnen“ werden Fallzahlen je Fallgruppe sowie
             Lohnsatz-, Zeit- und Sachaufwände je Prozessschritt ermittelt. Der Lauf
             berechnet die Werte in einem Durchgang für Verwaltung, Wirtschaft und
@@ -84,21 +101,20 @@ export default function EffortPanel() {
             Umschalter zeigt die Sicht des ausgewählten Normadressaten.
           </p>
           <button
-            onClick={handleCalculate}
-            disabled={!canRun}
-            className={`rounded-full px-4 py-2 text-sm font-semibold transition ${
-              canRun
-                ? "bg-slate-900 text-white"
-                : "cursor-not-allowed bg-slate-200 text-slate-500"
-            }`}
+            onClick={handleButtonClick}
+            disabled={buttonDisabled}
+            className={`inline-flex items-center gap-2 justify-self-start whitespace-nowrap rounded-full px-4 py-2 text-sm font-semibold transition sm:justify-self-end ${buttonClass}`}
           >
-            {isBusy ? "Bitte warten..." : "Aufwand berechnen"}
+            {(stepRun.isRunning || isRunAllBusy) && (
+              <span className="h-3 w-3 animate-spin rounded-full border-2 border-current border-t-transparent" />
+            )}
+            {buttonLabel}
           </button>
         </div>
 
-        {status && (
+        {(status || visibleStepRunStatus) && (
           <div className="rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-xs font-semibold text-amber-800">
-            {status}
+            {visibleStepRunStatus || status}
           </div>
         )}
       </div>

--- a/frontend/src/components/EffortPanel.tsx
+++ b/frontend/src/components/EffortPanel.tsx
@@ -4,13 +4,20 @@ import { useState } from "react";
 
 import { useApp } from "@/contexts/AppContext";
 import { buildLlmRequestOptions } from "@/lib/api";
-import { useRunAllStepBusy } from "@/lib/runAllStepEvents";
+import { getVisibleFailedStepStatus } from "@/lib/sessionStatus";
 import { useCancellableStepRun } from "@/lib/useCancellableStepRun";
+import { useRunAllStepCancel } from "@/lib/useRunAllStepCancel";
 
 export default function EffortPanel() {
   const { state, setCurrentTab, setEffortReady } = useApp();
   const [status, setStatus] = useState<string | null>(null);
-  const isRunAllBusy = useRunAllStepBusy("effort");
+  const runAllCancel = useRunAllStepCancel({
+    stepKey: "effort",
+    appSessionId: state.appSessionId,
+    setStatus,
+    logScope: "EffortPanel.cancelRunAll",
+  });
+  const isRunAllBusy = runAllCancel.isRunAllBusy;
   const llm = buildLlmRequestOptions({
     selectedModel: state.selectedModel,
     availableModels: state.availableModels,
@@ -62,6 +69,10 @@ export default function EffortPanel() {
       await stepRun.cancel();
       return;
     }
+    if (isRunAllBusy) {
+      await runAllCancel.cancelRunAllForStep();
+      return;
+    }
     await handleCalculate();
   };
 
@@ -70,14 +81,16 @@ export default function EffortPanel() {
       return stepRun.isCancelling ? "Abbruch wird ausgeführt..." : "Abbrechen";
     }
     if (isRunAllBusy) {
-      return "Abbrechen";
+      return runAllCancel.isCancellingRunAll
+        ? "Abbruch wird ausgeführt..."
+        : "Abbrechen";
     }
     return "Aufwand berechnen";
   })();
 
   const buttonClass = (() => {
     if (stepRun.isRunning || isRunAllBusy) {
-      return stepRun.isCancelling
+      return stepRun.isCancelling || runAllCancel.isCancellingRunAll
         ? "cursor-not-allowed border border-rose-100 bg-rose-100 text-rose-400"
         : "border border-rose-200 bg-rose-50 text-rose-700 hover:bg-rose-100";
     }
@@ -86,8 +99,17 @@ export default function EffortPanel() {
       : "cursor-not-allowed bg-slate-200 text-slate-500";
   })();
 
-  const buttonDisabled = isRunAllBusy || stepRun.isCancelling || (!stepRun.isRunning && !canRun);
+  const buttonDisabled =
+    stepRun.isCancelling ||
+    runAllCancel.isCancellingRunAll ||
+    (isRunAllBusy ? !runAllCancel.runAllRunId : !stepRun.isRunning && !canRun);
   const visibleStepRunStatus = stepRun.isRunning ? null : stepRun.statusText;
+  const failedStepStatus = getVisibleFailedStepStatus(
+    state,
+    "effort",
+    state.effortReady,
+    visibleStepRunStatus
+  );
 
   return (
     <section className="w-full border-b border-white/60 bg-white/80 px-6 py-4 backdrop-blur">
@@ -112,9 +134,9 @@ export default function EffortPanel() {
           </button>
         </div>
 
-        {(status || visibleStepRunStatus) && (
+        {(status || visibleStepRunStatus || failedStepStatus) && (
           <div className="rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-xs font-semibold text-amber-800">
-            {visibleStepRunStatus || status}
+            {visibleStepRunStatus || status || failedStepStatus}
           </div>
         )}
       </div>

--- a/frontend/src/components/GraphCanvas.tsx
+++ b/frontend/src/components/GraphCanvas.tsx
@@ -345,26 +345,6 @@ function GraphCanvasInner() {
     };
   }, [refreshTiles]);
 
-  const handleDelete = useCallback(
-    async (tileId: string) => {
-      try {
-        await apiClient.deleteTile(
-          tileId,
-          state.appSessionId,
-          state.selectedNormAddressee
-        );
-        setTiles((prev) => prev.filter((tile) => tile.id !== tileId));
-      } catch (err) {
-        logClientError("GraphCanvas.deleteTile", err, {
-          appSessionId: state.appSessionId,
-          tileId,
-        });
-        setError("Tile konnte nicht gelöscht werden.");
-      }
-    },
-    [state.appSessionId, state.selectedNormAddressee]
-  );
-
   const relatedNodeIds = useMemo(() => {
     if (!focusedNodeId) {
       return new Set<string>();
@@ -571,13 +551,11 @@ function GraphCanvasInner() {
         data: {
           title: tile.title,
           text: buildTileBodyText(tile),
-          deletable: tile.deletable,
           headerMetricLeft: metrics.left,
           headerMetricRight: metrics.right,
           metricTable: buildTileMetricTable(tile, state.selectedNormAddressee),
           onBodyRef: registerBodyRef,
           onNodeRef: registerNodeRef,
-          onDelete: () => handleDelete(tile.id),
           onToggleExpand: () =>
             setExpandedNodeIds((prev) => ({
               ...prev,
@@ -600,7 +578,6 @@ function GraphCanvasInner() {
     });
   }, [
     tiles,
-    handleDelete,
     canvasHeight,
     focusedNodeId,
     relatedNodeIds,

--- a/frontend/src/components/LlmMonitorConsole.tsx
+++ b/frontend/src/components/LlmMonitorConsole.tsx
@@ -71,6 +71,9 @@ function recentRowKey(row: LlmMonitorRecentCall): string {
   if (typeof row.answer_id === "number" && row.answer_id > 0) {
     return `answer:${row.answer_id}`;
   }
+  if (row.attempt_id) {
+    return `attempt:${row.attempt_id}`;
+  }
   return [
     "synthetic",
     row.attempt_id || "-",

--- a/frontend/src/components/ProcessStepsPanel.tsx
+++ b/frontend/src/components/ProcessStepsPanel.tsx
@@ -3,16 +3,36 @@
 import { useState } from "react";
 
 import { useApp } from "@/contexts/AppContext";
-import { apiClient, buildLlmRequestOptions } from "@/lib/api";
-import { runPerAddressee } from "@/lib/runPerAddressee";
+import { buildLlmRequestOptions } from "@/lib/api";
 import { useRunAllStepBusy } from "@/lib/runAllStepEvents";
+import { useCancellableStepRun } from "@/lib/useCancellableStepRun";
 
 export default function ProcessStepsPanel() {
   const { state, setCurrentTab, setProcessStepsReady } = useApp();
   const [status, setStatus] = useState<string | null>(null);
-  const [isRunning, setIsRunning] = useState(false);
   const isRunAllBusy = useRunAllStepBusy("process_steps");
-  const isBusy = isRunning || isRunAllBusy;
+  const llm = buildLlmRequestOptions({
+    selectedModel: state.selectedModel,
+    availableModels: state.availableModels,
+  });
+  const stepRun = useCancellableStepRun({
+    appSessionId: state.appSessionId,
+    stepKey: "process_steps",
+    stepLabel: "Prozessschritte bestimmen",
+    model: llm.model,
+    provider: llm.provider,
+    keys: llm.keys,
+    logScope: "ProcessStepsPanel.analyzeProcessSteps",
+    onCompleted: () => {
+      window.dispatchEvent(new Event("tiles-updated"));
+      setProcessStepsReady(true);
+      setCurrentTab(5);
+    },
+    onCancelled: () => {
+      window.dispatchEvent(new Event("tiles-updated"));
+    },
+  });
+  const isBusy = stepRun.isRunning || isRunAllBusy;
 
   const canRun =
     state.caseGroupsReady &&
@@ -29,42 +49,42 @@ export default function ProcessStepsPanel() {
       return;
     }
     setStatus(null);
-    setIsRunning(true);
-    const llm = buildLlmRequestOptions({
-      selectedModel: state.selectedModel,
-      availableModels: state.availableModels,
-    });
     try {
-      const outcome = await runPerAddressee({
-        logScope: "ProcessStepsPanel.analyzeProcessSteps",
-        logContext: { appSessionId: state.appSessionId },
-        operationLabel: "Prozessschritte bestimmen",
-        run: (normAddressee) =>
-          apiClient.analyzeProcessSteps({
-            appSessionId: state.appSessionId,
-            normAddressee,
-            model: llm.model,
-            provider: llm.provider,
-            keys: llm.keys,
-          }),
-      });
-      window.dispatchEvent(new Event("tiles-updated"));
-      if (outcome.allSucceeded) {
-        setProcessStepsReady(true);
-        setCurrentTab(5);
-      } else {
-        setStatus(outcome.statusMessage);
-      }
-    } finally {
-      setIsRunning(false);
+      await stepRun.start();
+    } catch {
+      setStatus("Prozessschritte konnten nicht gestartet werden.");
     }
   };
+  const handleButtonClick = async () => {
+    if (stepRun.isRunning) {
+      await stepRun.cancel();
+      return;
+    }
+    await handleAnalyze();
+  };
+  const buttonLabel = stepRun.isRunning
+    ? stepRun.isCancelling
+      ? "Abbruch wird ausgeführt..."
+      : "Abbrechen"
+    : isRunAllBusy
+      ? "Abbrechen"
+      : "Prozessschritte bestimmen";
+  const buttonClass =
+    stepRun.isRunning || isRunAllBusy
+      ? stepRun.isCancelling
+        ? "cursor-not-allowed border border-rose-100 bg-rose-100 text-rose-400"
+        : "border border-rose-200 bg-rose-50 text-rose-700 hover:bg-rose-100"
+      : canRun
+        ? "bg-slate-900 text-white"
+        : "cursor-not-allowed bg-slate-200 text-slate-500";
+  const buttonDisabled = isRunAllBusy || stepRun.isCancelling || (!stepRun.isRunning && !canRun);
+  const visibleStepRunStatus = stepRun.isRunning ? null : stepRun.statusText;
 
   return (
     <section className="w-full border-b border-white/60 bg-white/80 px-6 py-4 backdrop-blur">
       <div className="mx-auto max-w-6xl space-y-4">
-        <div className="flex flex-wrap items-center justify-between gap-4">
-          <p className="text-xs text-slate-600">
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start">
+          <p className="text-xs leading-5 text-slate-600">
             Für jede Fallgruppe werden die notwendigen Tätigkeiten identifiziert
             und als Prozessschritte erfasst. Der Lauf bestimmt die Prozessschritte
             in einem Durchgang für Verwaltung, Wirtschaft und Bürger, erzeugt dabei
@@ -72,21 +92,20 @@ export default function ProcessStepsPanel() {
             des ausgewählten Normadressaten.
           </p>
           <button
-            onClick={handleAnalyze}
-            disabled={!canRun}
-            className={`rounded-full px-4 py-2 text-sm font-semibold transition ${
-              canRun
-                ? "bg-slate-900 text-white"
-                : "cursor-not-allowed bg-slate-200 text-slate-500"
-            }`}
+            onClick={handleButtonClick}
+            disabled={buttonDisabled}
+            className={`inline-flex items-center gap-2 justify-self-start whitespace-nowrap rounded-full px-4 py-2 text-sm font-semibold transition sm:justify-self-end ${buttonClass}`}
           >
-            {isBusy ? "Bitte warten..." : "Prozessschritte bestimmen"}
+            {(stepRun.isRunning || isRunAllBusy) && (
+              <span className="h-3 w-3 animate-spin rounded-full border-2 border-current border-t-transparent" />
+            )}
+            {buttonLabel}
           </button>
         </div>
 
-        {status && (
+        {(status || visibleStepRunStatus) && (
           <div className="rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-xs font-semibold text-amber-800">
-            {status}
+            {visibleStepRunStatus || status}
           </div>
         )}
       </div>

--- a/frontend/src/components/ProcessStepsPanel.tsx
+++ b/frontend/src/components/ProcessStepsPanel.tsx
@@ -4,13 +4,20 @@ import { useState } from "react";
 
 import { useApp } from "@/contexts/AppContext";
 import { buildLlmRequestOptions } from "@/lib/api";
-import { useRunAllStepBusy } from "@/lib/runAllStepEvents";
+import { getVisibleFailedStepStatus } from "@/lib/sessionStatus";
 import { useCancellableStepRun } from "@/lib/useCancellableStepRun";
+import { useRunAllStepCancel } from "@/lib/useRunAllStepCancel";
 
 export default function ProcessStepsPanel() {
   const { state, setCurrentTab, setProcessStepsReady } = useApp();
   const [status, setStatus] = useState<string | null>(null);
-  const isRunAllBusy = useRunAllStepBusy("process_steps");
+  const runAllCancel = useRunAllStepCancel({
+    stepKey: "process_steps",
+    appSessionId: state.appSessionId,
+    setStatus,
+    logScope: "ProcessStepsPanel.cancelRunAll",
+  });
+  const isRunAllBusy = runAllCancel.isRunAllBusy;
   const llm = buildLlmRequestOptions({
     selectedModel: state.selectedModel,
     availableModels: state.availableModels,
@@ -60,6 +67,10 @@ export default function ProcessStepsPanel() {
       await stepRun.cancel();
       return;
     }
+    if (isRunAllBusy) {
+      await runAllCancel.cancelRunAllForStep();
+      return;
+    }
     await handleAnalyze();
   };
   const buttonLabel = stepRun.isRunning
@@ -67,18 +78,29 @@ export default function ProcessStepsPanel() {
       ? "Abbruch wird ausgeführt..."
       : "Abbrechen"
     : isRunAllBusy
-      ? "Abbrechen"
+      ? runAllCancel.isCancellingRunAll
+        ? "Abbruch wird ausgeführt..."
+        : "Abbrechen"
       : "Prozessschritte bestimmen";
   const buttonClass =
     stepRun.isRunning || isRunAllBusy
-      ? stepRun.isCancelling
+      ? stepRun.isCancelling || runAllCancel.isCancellingRunAll
         ? "cursor-not-allowed border border-rose-100 bg-rose-100 text-rose-400"
         : "border border-rose-200 bg-rose-50 text-rose-700 hover:bg-rose-100"
       : canRun
         ? "bg-slate-900 text-white"
         : "cursor-not-allowed bg-slate-200 text-slate-500";
-  const buttonDisabled = isRunAllBusy || stepRun.isCancelling || (!stepRun.isRunning && !canRun);
+  const buttonDisabled =
+    stepRun.isCancelling ||
+    runAllCancel.isCancellingRunAll ||
+    (isRunAllBusy ? !runAllCancel.runAllRunId : !stepRun.isRunning && !canRun);
   const visibleStepRunStatus = stepRun.isRunning ? null : stepRun.statusText;
+  const failedStepStatus = getVisibleFailedStepStatus(
+    state,
+    "process_steps",
+    state.processStepsReady,
+    visibleStepRunStatus
+  );
 
   return (
     <section className="w-full border-b border-white/60 bg-white/80 px-6 py-4 backdrop-blur">
@@ -103,9 +125,9 @@ export default function ProcessStepsPanel() {
           </button>
         </div>
 
-        {(status || visibleStepRunStatus) && (
+        {(status || visibleStepRunStatus || failedStepStatus) && (
           <div className="rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-xs font-semibold text-amber-800">
-            {visibleStepRunStatus || status}
+            {visibleStepRunStatus || status || failedStepStatus}
           </div>
         )}
       </div>

--- a/frontend/src/components/ProcessesPanel.tsx
+++ b/frontend/src/components/ProcessesPanel.tsx
@@ -4,13 +4,20 @@ import { useState } from "react";
 
 import { useApp } from "@/contexts/AppContext";
 import { buildLlmRequestOptions } from "@/lib/api";
-import { useRunAllStepBusy } from "@/lib/runAllStepEvents";
+import { getVisibleFailedStepStatus } from "@/lib/sessionStatus";
 import { useCancellableStepRun } from "@/lib/useCancellableStepRun";
+import { useRunAllStepCancel } from "@/lib/useRunAllStepCancel";
 
 export default function ProcessesPanel() {
   const { state, setCurrentTab, setProcessesReady } = useApp();
   const [status, setStatus] = useState<string | null>(null);
-  const isRunAllBusy = useRunAllStepBusy("processes");
+  const runAllCancel = useRunAllStepCancel({
+    stepKey: "processes",
+    appSessionId: state.appSessionId,
+    setStatus,
+    logScope: "ProcessesPanel.cancelRunAll",
+  });
+  const isRunAllBusy = runAllCancel.isRunAllBusy;
   const llm = buildLlmRequestOptions({
     selectedModel: state.selectedModel,
     availableModels: state.availableModels,
@@ -60,6 +67,10 @@ export default function ProcessesPanel() {
       await stepRun.cancel();
       return;
     }
+    if (isRunAllBusy) {
+      await runAllCancel.cancelRunAllForStep();
+      return;
+    }
     await handleCompile();
   };
   const buttonLabel = stepRun.isRunning
@@ -67,18 +78,29 @@ export default function ProcessesPanel() {
       ? "Abbruch wird ausgeführt..."
       : "Abbrechen"
     : isRunAllBusy
-      ? "Abbrechen"
+      ? runAllCancel.isCancellingRunAll
+        ? "Abbruch wird ausgeführt..."
+        : "Abbrechen"
       : "Prozesse bündeln";
   const buttonClass =
     stepRun.isRunning || isRunAllBusy
-      ? stepRun.isCancelling
+      ? stepRun.isCancelling || runAllCancel.isCancellingRunAll
         ? "cursor-not-allowed border border-rose-100 bg-rose-100 text-rose-400"
         : "border border-rose-200 bg-rose-50 text-rose-700 hover:bg-rose-100"
       : canRun
         ? "bg-slate-900 text-white"
         : "cursor-not-allowed bg-slate-200 text-slate-500";
-  const buttonDisabled = isRunAllBusy || stepRun.isCancelling || (!stepRun.isRunning && !canRun);
+  const buttonDisabled =
+    stepRun.isCancelling ||
+    runAllCancel.isCancellingRunAll ||
+    (isRunAllBusy ? !runAllCancel.runAllRunId : !stepRun.isRunning && !canRun);
   const visibleStepRunStatus = stepRun.isRunning ? null : stepRun.statusText;
+  const failedStepStatus = getVisibleFailedStepStatus(
+    state,
+    "processes",
+    state.processesReady,
+    visibleStepRunStatus
+  );
 
   return (
     <section className="w-full border-b border-white/60 bg-white/80 px-6 py-4 backdrop-blur">
@@ -103,9 +125,9 @@ export default function ProcessesPanel() {
           </button>
         </div>
 
-        {(status || visibleStepRunStatus) && (
+        {(status || visibleStepRunStatus || failedStepStatus) && (
           <div className="rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-xs font-semibold text-amber-800">
-            {visibleStepRunStatus || status}
+            {visibleStepRunStatus || status || failedStepStatus}
           </div>
         )}
       </div>

--- a/frontend/src/components/ProcessesPanel.tsx
+++ b/frontend/src/components/ProcessesPanel.tsx
@@ -3,16 +3,36 @@
 import { useState } from "react";
 
 import { useApp } from "@/contexts/AppContext";
-import { apiClient, buildLlmRequestOptions } from "@/lib/api";
-import { runPerAddressee } from "@/lib/runPerAddressee";
+import { buildLlmRequestOptions } from "@/lib/api";
 import { useRunAllStepBusy } from "@/lib/runAllStepEvents";
+import { useCancellableStepRun } from "@/lib/useCancellableStepRun";
 
 export default function ProcessesPanel() {
   const { state, setCurrentTab, setProcessesReady } = useApp();
   const [status, setStatus] = useState<string | null>(null);
-  const [isRunning, setIsRunning] = useState(false);
   const isRunAllBusy = useRunAllStepBusy("processes");
-  const isBusy = isRunning || isRunAllBusy;
+  const llm = buildLlmRequestOptions({
+    selectedModel: state.selectedModel,
+    availableModels: state.availableModels,
+  });
+  const stepRun = useCancellableStepRun({
+    appSessionId: state.appSessionId,
+    stepKey: "processes",
+    stepLabel: "Prozesse bündeln",
+    model: llm.model,
+    provider: llm.provider,
+    keys: llm.keys,
+    logScope: "ProcessesPanel.compileProcesses",
+    onCompleted: () => {
+      window.dispatchEvent(new Event("tiles-updated"));
+      setProcessesReady(true);
+      setCurrentTab(3);
+    },
+    onCancelled: () => {
+      window.dispatchEvent(new Event("tiles-updated"));
+    },
+  });
+  const isBusy = stepRun.isRunning || isRunAllBusy;
 
   const canRun =
     state.regulationsReady &&
@@ -29,42 +49,42 @@ export default function ProcessesPanel() {
       return;
     }
     setStatus(null);
-    setIsRunning(true);
-    const llm = buildLlmRequestOptions({
-      selectedModel: state.selectedModel,
-      availableModels: state.availableModels,
-    });
     try {
-      const outcome = await runPerAddressee({
-        logScope: "ProcessesPanel.compileProcesses",
-        logContext: { appSessionId: state.appSessionId },
-        operationLabel: "Prozesse buendeln",
-        run: (normAddressee) =>
-          apiClient.compileProcesses({
-            appSessionId: state.appSessionId,
-            normAddressee,
-            model: llm.model,
-            provider: llm.provider,
-            keys: llm.keys,
-          }),
-      });
-      window.dispatchEvent(new Event("tiles-updated"));
-      if (outcome.allSucceeded) {
-        setProcessesReady(true);
-        setCurrentTab(3);
-      } else {
-        setStatus(outcome.statusMessage);
-      }
-    } finally {
-      setIsRunning(false);
+      await stepRun.start();
+    } catch {
+      setStatus("Prozesse konnten nicht gestartet werden.");
     }
   };
+  const handleButtonClick = async () => {
+    if (stepRun.isRunning) {
+      await stepRun.cancel();
+      return;
+    }
+    await handleCompile();
+  };
+  const buttonLabel = stepRun.isRunning
+    ? stepRun.isCancelling
+      ? "Abbruch wird ausgeführt..."
+      : "Abbrechen"
+    : isRunAllBusy
+      ? "Abbrechen"
+      : "Prozesse bündeln";
+  const buttonClass =
+    stepRun.isRunning || isRunAllBusy
+      ? stepRun.isCancelling
+        ? "cursor-not-allowed border border-rose-100 bg-rose-100 text-rose-400"
+        : "border border-rose-200 bg-rose-50 text-rose-700 hover:bg-rose-100"
+      : canRun
+        ? "bg-slate-900 text-white"
+        : "cursor-not-allowed bg-slate-200 text-slate-500";
+  const buttonDisabled = isRunAllBusy || stepRun.isCancelling || (!stepRun.isRunning && !canRun);
+  const visibleStepRunStatus = stepRun.isRunning ? null : stepRun.statusText;
 
   return (
     <section className="w-full border-b border-white/60 bg-white/80 px-6 py-4 backdrop-blur">
       <div className="mx-auto max-w-6xl space-y-4">
-        <div className="flex flex-wrap items-center justify-between gap-4">
-          <p className="text-xs text-slate-600">
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start">
+          <p className="text-xs leading-5 text-slate-600">
             Vorgaben, die in der Praxis in einem Zusammenhang erfüllt werden, werden
             zu gemeinsamen Prozessen gebündelt. Der Lauf bündelt die Vorgaben in einem
             Durchgang für Verwaltung, Wirtschaft und Bürger, erzeugt dabei aber je
@@ -72,21 +92,20 @@ export default function ProcessesPanel() {
             ausgewählten Normadressaten.
           </p>
           <button
-            onClick={handleCompile}
-            disabled={!canRun}
-            className={`rounded-full px-4 py-2 text-sm font-semibold transition ${
-              canRun
-                ? "bg-slate-900 text-white"
-                : "cursor-not-allowed bg-slate-200 text-slate-500"
-            }`}
+            onClick={handleButtonClick}
+            disabled={buttonDisabled}
+            className={`inline-flex items-center gap-2 justify-self-start whitespace-nowrap rounded-full px-4 py-2 text-sm font-semibold transition sm:justify-self-end ${buttonClass}`}
           >
-            {isBusy ? "Bitte warten..." : "Prozesse bündeln"}
+            {(stepRun.isRunning || isRunAllBusy) && (
+              <span className="h-3 w-3 animate-spin rounded-full border-2 border-current border-t-transparent" />
+            )}
+            {buttonLabel}
           </button>
         </div>
 
-        {status && (
+        {(status || visibleStepRunStatus) && (
           <div className="rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-xs font-semibold text-amber-800">
-            {status}
+            {visibleStepRunStatus || status}
           </div>
         )}
       </div>

--- a/frontend/src/components/RegulationsPanel.tsx
+++ b/frontend/src/components/RegulationsPanel.tsx
@@ -3,16 +3,37 @@
 import { useState } from "react";
 
 import { useApp } from "@/contexts/AppContext";
-import { apiClient, buildLlmRequestOptions } from "@/lib/api";
-import { formatActionErrorMessage, logClientError } from "@/lib/errorFeedback";
+import { buildLlmRequestOptions } from "@/lib/api";
 import { useRunAllStepBusy } from "@/lib/runAllStepEvents";
+import { useCancellableStepRun } from "@/lib/useCancellableStepRun";
 
 export default function RegulationsPanel() {
   const { state, setCurrentTab, setRegulationsReady, setProcessesReady } = useApp();
   const [status, setStatus] = useState<string | null>(null);
-  const [isRunning, setIsRunning] = useState(false);
   const isRunAllBusy = useRunAllStepBusy("regulations");
-  const isBusy = isRunning || isRunAllBusy;
+  const llm = buildLlmRequestOptions({
+    selectedModel: state.selectedModel,
+    availableModels: state.availableModels,
+  });
+  const stepRun = useCancellableStepRun({
+    appSessionId: state.appSessionId,
+    stepKey: "regulations",
+    stepLabel: "Vorgaben bestimmen",
+    model: llm.model,
+    provider: llm.provider,
+    keys: llm.keys,
+    logScope: "RegulationsPanel.identifyRegulations",
+    onCompleted: () => {
+      window.dispatchEvent(new Event("tiles-updated"));
+      setRegulationsReady(true);
+      setProcessesReady(false);
+      setCurrentTab(2);
+    },
+    onCancelled: () => {
+      window.dispatchEvent(new Event("tiles-updated"));
+    },
+  });
+  const isBusy = stepRun.isRunning || isRunAllBusy;
 
   const canRun =
     state.summaryReady &&
@@ -29,58 +50,62 @@ export default function RegulationsPanel() {
       return;
     }
     setStatus(null);
-    setIsRunning(true);
-    const llm = buildLlmRequestOptions({
-      selectedModel: state.selectedModel,
-      availableModels: state.availableModels,
-    });
     try {
-      await apiClient.identifyRegulations({
-        appSessionId: state.appSessionId,
-        model: llm.model,
-        provider: llm.provider,
-        keys: llm.keys,
-      });
-      window.dispatchEvent(new Event("tiles-updated"));
-      setRegulationsReady(true);
-      setProcessesReady(false);
-      setCurrentTab(2);
-    } catch (error) {
-      logClientError("RegulationsPanel.identifyRegulations", error, {
-        appSessionId: state.appSessionId,
-      });
-      setStatus(formatActionErrorMessage("Vorgaben konnten nicht bestimmt werden", error));
-    } finally {
-      setIsRunning(false);
+      await stepRun.start();
+    } catch {
+      setStatus("Vorgaben konnten nicht gestartet werden.");
     }
   };
+  const handleButtonClick = async () => {
+    if (stepRun.isRunning) {
+      await stepRun.cancel();
+      return;
+    }
+    await handleIdentify();
+  };
+  const buttonLabel = stepRun.isRunning
+    ? stepRun.isCancelling
+      ? "Abbruch wird ausgeführt..."
+      : "Abbrechen"
+    : isRunAllBusy
+      ? "Abbrechen"
+      : "Vorgaben bestimmen";
+  const buttonClass =
+    stepRun.isRunning || isRunAllBusy
+      ? stepRun.isCancelling
+        ? "cursor-not-allowed border border-rose-100 bg-rose-100 text-rose-400"
+        : "border border-rose-200 bg-rose-50 text-rose-700 hover:bg-rose-100"
+      : canRun
+        ? "bg-slate-900 text-white"
+        : "cursor-not-allowed bg-slate-200 text-slate-500";
+  const buttonDisabled = isRunAllBusy || stepRun.isCancelling || (!stepRun.isRunning && !canRun);
+  const visibleStepRunStatus = stepRun.isRunning ? null : stepRun.statusText;
 
   return (
     <section className="w-full border-b border-white/60 bg-white/80 px-6 py-4 backdrop-blur">
       <div className="mx-auto max-w-6xl space-y-4">
-        <div className="flex flex-wrap items-center justify-between gap-4">
-          <p className="text-xs text-slate-600">
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start">
+          <p className="text-xs leading-5 text-slate-600">
             Beim Klick auf &quot;Vorgaben bestimmen&quot; werden die zwei gewählten
             Gesetzestexte analysiert und die relevanten Vorgaben ermittelt. Die
             angezeigten Daten beziehen sich jeweils auf den ausgewählten
             Normadressaten.
           </p>
           <button
-            onClick={handleIdentify}
-            disabled={!canRun}
-            className={`rounded-full px-4 py-2 text-sm font-semibold transition ${
-              canRun
-                ? "bg-slate-900 text-white"
-                : "cursor-not-allowed bg-slate-200 text-slate-500"
-            }`}
+            onClick={handleButtonClick}
+            disabled={buttonDisabled}
+            className={`inline-flex items-center gap-2 justify-self-start whitespace-nowrap rounded-full px-4 py-2 text-sm font-semibold transition sm:justify-self-end ${buttonClass}`}
           >
-            {isBusy ? "Bitte warten..." : "Vorgaben bestimmen"}
+            {(stepRun.isRunning || isRunAllBusy) && (
+              <span className="h-3 w-3 animate-spin rounded-full border-2 border-current border-t-transparent" />
+            )}
+            {buttonLabel}
           </button>
         </div>
 
-        {status && (
+        {(status || visibleStepRunStatus) && (
           <div className="rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-xs font-semibold text-amber-800">
-            {status}
+            {visibleStepRunStatus || status}
           </div>
         )}
       </div>

--- a/frontend/src/components/RegulationsPanel.tsx
+++ b/frontend/src/components/RegulationsPanel.tsx
@@ -4,13 +4,20 @@ import { useState } from "react";
 
 import { useApp } from "@/contexts/AppContext";
 import { buildLlmRequestOptions } from "@/lib/api";
-import { useRunAllStepBusy } from "@/lib/runAllStepEvents";
+import { getVisibleFailedStepStatus } from "@/lib/sessionStatus";
 import { useCancellableStepRun } from "@/lib/useCancellableStepRun";
+import { useRunAllStepCancel } from "@/lib/useRunAllStepCancel";
 
 export default function RegulationsPanel() {
   const { state, setCurrentTab, setRegulationsReady, setProcessesReady } = useApp();
   const [status, setStatus] = useState<string | null>(null);
-  const isRunAllBusy = useRunAllStepBusy("regulations");
+  const runAllCancel = useRunAllStepCancel({
+    stepKey: "regulations",
+    appSessionId: state.appSessionId,
+    setStatus,
+    logScope: "RegulationsPanel.cancelRunAll",
+  });
+  const isRunAllBusy = runAllCancel.isRunAllBusy;
   const llm = buildLlmRequestOptions({
     selectedModel: state.selectedModel,
     availableModels: state.availableModels,
@@ -61,6 +68,10 @@ export default function RegulationsPanel() {
       await stepRun.cancel();
       return;
     }
+    if (isRunAllBusy) {
+      await runAllCancel.cancelRunAllForStep();
+      return;
+    }
     await handleIdentify();
   };
   const buttonLabel = stepRun.isRunning
@@ -68,18 +79,29 @@ export default function RegulationsPanel() {
       ? "Abbruch wird ausgeführt..."
       : "Abbrechen"
     : isRunAllBusy
-      ? "Abbrechen"
+      ? runAllCancel.isCancellingRunAll
+        ? "Abbruch wird ausgeführt..."
+        : "Abbrechen"
       : "Vorgaben bestimmen";
   const buttonClass =
     stepRun.isRunning || isRunAllBusy
-      ? stepRun.isCancelling
+      ? stepRun.isCancelling || runAllCancel.isCancellingRunAll
         ? "cursor-not-allowed border border-rose-100 bg-rose-100 text-rose-400"
         : "border border-rose-200 bg-rose-50 text-rose-700 hover:bg-rose-100"
       : canRun
         ? "bg-slate-900 text-white"
         : "cursor-not-allowed bg-slate-200 text-slate-500";
-  const buttonDisabled = isRunAllBusy || stepRun.isCancelling || (!stepRun.isRunning && !canRun);
+  const buttonDisabled =
+    stepRun.isCancelling ||
+    runAllCancel.isCancellingRunAll ||
+    (isRunAllBusy ? !runAllCancel.runAllRunId : !stepRun.isRunning && !canRun);
   const visibleStepRunStatus = stepRun.isRunning ? null : stepRun.statusText;
+  const failedStepStatus = getVisibleFailedStepStatus(
+    state,
+    "regulations",
+    state.regulationsReady,
+    visibleStepRunStatus
+  );
 
   return (
     <section className="w-full border-b border-white/60 bg-white/80 px-6 py-4 backdrop-blur">
@@ -103,9 +125,9 @@ export default function RegulationsPanel() {
           </button>
         </div>
 
-        {(status || visibleStepRunStatus) && (
+        {(status || visibleStepRunStatus || failedStepStatus) && (
           <div className="rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-xs font-semibold text-amber-800">
-            {visibleStepRunStatus || status}
+            {visibleStepRunStatus || status || failedStepStatus}
           </div>
         )}
       </div>

--- a/frontend/src/components/SessionMenu.tsx
+++ b/frontend/src/components/SessionMenu.tsx
@@ -72,6 +72,11 @@ export default function SessionMenu({ compact }: SessionMenuProps) {
   const [selectedSession, setSelectedSession] = useState("");
   const [status, setStatus] = useState<string | null>(null);
   const [isUndoing, setIsUndoing] = useState(false);
+  const [researchEnabled, setResearchEnabled] = useState(false);
+  const [researchStatus, setResearchStatus] = useState("idle");
+  const [researchLocked, setResearchLocked] = useState(false);
+  const [isUpdatingResearch, setIsUpdatingResearch] = useState(false);
+  const [isDownloadingResearch, setIsDownloadingResearch] = useState(false);
   const [isRunningAll, setIsRunningAll] = useState(false);
   const [currentRunId, setCurrentRunId] = useState<string | null>(null);
   const [isCancellingRun, setIsCancellingRun] = useState(false);
@@ -119,11 +124,28 @@ export default function SessionMenu({ compact }: SessionMenuProps) {
         }
       }
     };
+    const loadResearchSettings = async () => {
+      try {
+        const research = await apiClient.getCaseGroupResearchSettings(
+          state.appSessionId
+        );
+        if (!cancelled) {
+          setResearchEnabled(research.enabled);
+          setResearchStatus(research.status);
+          setResearchLocked(research.locked);
+        }
+      } catch (error) {
+        logClientError("SessionMenu.loadResearchSettings", error, {
+          appSessionId: state.appSessionId,
+        });
+      }
+    };
     loadSessions();
+    loadResearchSettings();
     return () => {
       cancelled = true;
     };
-  }, [isOpen]);
+  }, [isOpen, state.appSessionId]);
 
   const formattedSessions = useMemo(() => {
     return sessions.map((session) => {
@@ -178,7 +200,7 @@ export default function SessionMenu({ compact }: SessionMenuProps) {
       return;
     }
     const updatePosition = () => {
-      const width = 320;
+      const width = 360;
       const padding = 16;
       if (!triggerRef.current) {
         setMenuPos({ top: 96, left: padding });
@@ -207,23 +229,6 @@ export default function SessionMenu({ compact }: SessionMenuProps) {
       window.removeEventListener("scroll", updatePosition, true);
     };
   }, [isOpen]);
-
-  const handleRebuildCurrent = async () => {
-    try {
-      resetStatus();
-      await apiClient.rebuildTiles(
-        state.appSessionId,
-        state.selectedNormAddressee
-      );
-      window.dispatchEvent(new Event("tiles-updated"));
-      setStatus("Tiles der Session wurden neu geladen.");
-    } catch (error) {
-      logClientError("SessionMenu.rebuildTiles", error, {
-        appSessionId: state.appSessionId,
-      });
-      setStatus("Tiles konnten nicht neu geladen werden.");
-    }
-  };
 
   const handleNewSession = () => {
     sessionStorage.clear();
@@ -269,6 +274,8 @@ export default function SessionMenu({ compact }: SessionMenuProps) {
         state.appSessionId,
         state.selectedNormAddressee
       );
+      const sessionStatus = await apiClient.getSessionStatus(state.appSessionId);
+      applySessionStatus(sessionStatus);
       window.dispatchEvent(new Event("tiles-updated"));
       setStatus(`Letzter Schritt zurückgesetzt: ${result.undone_label || lastStepLabel}`);
     } catch (error) {
@@ -304,11 +311,71 @@ export default function SessionMenu({ compact }: SessionMenuProps) {
     }
   };
 
+  const handleToggleDeepResearch = async () => {
+    if (isUpdatingResearch || researchLocked) {
+      return;
+    }
+    try {
+      resetStatus();
+      setIsUpdatingResearch(true);
+      const result = await apiClient.updateCaseGroupResearchSettings(
+        state.appSessionId,
+        !researchEnabled
+      );
+      setResearchEnabled(result.enabled);
+      setResearchStatus(result.status);
+      setResearchLocked(result.locked);
+      setStatus(
+        result.enabled
+          ? "Deep Research für Fallzahlen aktiviert."
+          : "Deep Research für Fallzahlen deaktiviert."
+      );
+    } catch (error) {
+      logClientError("SessionMenu.toggleDeepResearch", error, {
+        appSessionId: state.appSessionId,
+      });
+      setStatus("Deep-Research-Einstellung konnte nicht gespeichert werden.");
+    } finally {
+      setIsUpdatingResearch(false);
+    }
+  };
+
+  const handleDownloadDeepResearchReport = async () => {
+    try {
+      resetStatus();
+      setIsDownloadingResearch(true);
+      const blob = await apiClient.downloadDeepResearchReport(state.appSessionId);
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = `ccc_deep_research_${state.appSessionId}.pdf`;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      URL.revokeObjectURL(url);
+      setStatus("Deep-Research-Bericht heruntergeladen.");
+    } catch (error) {
+      logClientError("SessionMenu.downloadDeepResearchReport", error, {
+        appSessionId: state.appSessionId,
+      });
+      setStatus("Deep-Research-Bericht ist noch nicht verfügbar.");
+    } finally {
+      setIsDownloadingResearch(false);
+    }
+  };
+
   const applySessionStatus = (sessionStatus: SessionStatus) => {
     setSummaryReady(sessionStatus.summary_ready);
     setRegulationsReady(sessionStatus.regulations_ready);
     setLastCompletedStep(sessionStatus.last_completed_step ?? null);
     setLastCompletedLabel(sessionStatus.last_completed_label ?? null);
+    setResearchEnabled(Boolean(sessionStatus.case_group_research_enabled));
+    setResearchStatus(sessionStatus.case_group_research_status || "idle");
+    setResearchLocked(
+      !["idle", "failed", "cancelled"].includes(
+        sessionStatus.case_group_research_status || "idle"
+      )
+    );
     setCurrentTab(deriveTabFromStatus(sessionStatus));
     window.dispatchEvent(new Event("tiles-updated"));
   };
@@ -600,7 +667,7 @@ export default function SessionMenu({ compact }: SessionMenuProps) {
 
   const menuContent = (
     <div
-      className="fixed z-[60] w-80 rounded-2xl border border-slate-200 bg-white p-4 text-xs text-slate-700 shadow-2xl"
+      className="fixed z-[60] w-[360px] rounded-2xl border border-slate-200 bg-white p-4 text-xs text-slate-700 shadow-2xl"
       style={{ top: menuPos.top, left: menuPos.left }}
     >
       <div className="flex items-center justify-between">
@@ -613,23 +680,14 @@ export default function SessionMenu({ compact }: SessionMenuProps) {
         </button>
       </div>
       <div className="mt-4 space-y-2">
+        <div className="text-[10px] font-semibold uppercase tracking-wide text-slate-400">
+          Session
+        </div>
         <button
           onClick={handleNewSession}
           className="w-full rounded-xl bg-slate-900 px-3 py-2 text-left text-xs font-semibold text-white"
         >
           Neue Session starten
-        </button>
-        <button
-          onClick={handleRebuildCurrent}
-          className="w-full rounded-xl bg-slate-900 px-3 py-2 text-left text-xs font-semibold text-white"
-        >
-          Kacheln dieser Session neu laden
-        </button>
-        <button
-          onClick={handleExportSession}
-          className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-left text-xs font-semibold text-slate-700 hover:bg-slate-50"
-        >
-          Session exportieren (Mermaid)
         </button>
         <button
           onClick={handleRunAllSteps}
@@ -658,6 +716,59 @@ export default function SessionMenu({ compact }: SessionMenuProps) {
           {isUndoing
             ? "Bitte warten..."
             : `\"${lastStepLabel || "Letzten Schritt"}\" zurücksetzen`}
+        </button>
+      </div>
+      <div className="mt-4 space-y-2 border-t border-slate-100 pt-3">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <div className="text-[10px] font-semibold uppercase tracking-wide text-slate-400">
+              Fallzahlen
+            </div>
+            <div className="mt-1 font-semibold text-slate-900">
+              Deep Research für Fallzahlen
+            </div>
+            <div className="mt-1 text-[11px] text-slate-500">
+              Status: {researchStatus}
+            </div>
+          </div>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={researchEnabled}
+            disabled={researchLocked || isUpdatingResearch || isRunningAll}
+            onClick={handleToggleDeepResearch}
+            className={`mt-1 h-6 w-11 rounded-full border p-0.5 transition disabled:cursor-not-allowed disabled:opacity-50 ${
+              researchEnabled
+                ? "border-slate-900 bg-slate-900"
+                : "border-slate-300 bg-slate-100"
+            }`}
+          >
+            <span
+              className={`block h-4 w-4 rounded-full bg-white transition ${
+                researchEnabled ? "translate-x-5" : "translate-x-0"
+              }`}
+            />
+          </button>
+        </div>
+        <button
+          onClick={handleDownloadDeepResearchReport}
+          disabled={isDownloadingResearch || researchStatus !== "parsed"}
+          className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-left text-xs font-semibold text-slate-700 hover:bg-slate-50 disabled:cursor-not-allowed disabled:bg-slate-100 disabled:text-slate-400"
+        >
+          {isDownloadingResearch
+            ? "Bericht wird geladen..."
+            : "Deep-Research-Bericht herunterladen"}
+        </button>
+      </div>
+      <div className="mt-4 space-y-2 border-t border-slate-100 pt-3">
+        <div className="text-[10px] font-semibold uppercase tracking-wide text-slate-400">
+          Export
+        </div>
+        <button
+          onClick={handleExportSession}
+          className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-left text-xs font-semibold text-slate-700 hover:bg-slate-50"
+        >
+          Sessiongraph exportieren (Mermaid)
         </button>
       </div>
       <div className="mt-4">

--- a/frontend/src/components/SessionMenu.tsx
+++ b/frontend/src/components/SessionMenu.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
 import { useApp } from "@/contexts/AppContext";
@@ -10,6 +10,7 @@ import {
   emitRunAllStepCleared,
   emitRunAllStepStarted,
   type RunAllStepKey,
+  useActiveWorkflowRun,
 } from "@/lib/runAllStepEvents";
 import {
   formatSessionStartError,
@@ -17,7 +18,7 @@ import {
   prepareSessionDocuments,
 } from "@/lib/sessionStart";
 import { deriveTabFromStatus } from "@/lib/sessionStatus";
-import { SessionStatus, SessionSummary } from "@/types";
+import { RunAllStatusResponse, SessionStatus, SessionSummary } from "@/types";
 
 type SessionMenuProps = {
   compact?: boolean;
@@ -72,6 +73,9 @@ export default function SessionMenu({ compact }: SessionMenuProps) {
     setRegulationsReady,
     setLastCompletedStep,
     setLastCompletedLabel,
+    setLastFailedStep,
+    setLastFailedLabel,
+    setLastFailedMessage,
   } = useApp();
   const [isOpen, setIsOpen] = useState(false);
   const [sessions, setSessions] = useState<SessionSummary[]>([]);
@@ -93,6 +97,8 @@ export default function SessionMenu({ compact }: SessionMenuProps) {
   const [isRunningAll, setIsRunningAll] = useState(false);
   const [currentRunId, setCurrentRunId] = useState<string | null>(null);
   const [isCancellingRun, setIsCancellingRun] = useState(false);
+  const isCancellingRunRef = useRef(false);
+  const activeWorkflowRun = useActiveWorkflowRun();
   const runEventSourceRef = useRef<EventSource | null>(null);
   const runPollTimerRef = useRef<number | null>(null);
   const [isMounted, setIsMounted] = useState(false);
@@ -105,6 +111,31 @@ export default function SessionMenu({ compact }: SessionMenuProps) {
   useEffect(() => {
     setIsMounted(true);
   }, []);
+
+  const refreshResearchSettings = useCallback(
+    async (options: { ignoreCancelled?: () => boolean } = {}) => {
+      try {
+        const research = await apiClient.getCaseGroupResearchSettings(
+          state.appSessionId
+        );
+        if (options.ignoreCancelled?.()) {
+          return;
+        }
+        setResearchEnabled(research.enabled);
+        setResearchStatus(research.status);
+        setResearchLocked(research.locked);
+        setResearchElapsedSeconds(research.elapsed_seconds ?? null);
+        setResearchElapsedLoadedAt(
+          typeof research.elapsed_seconds === "number" ? Date.now() : null
+        );
+      } catch (error) {
+        logClientError("SessionMenu.loadResearchSettings", error, {
+          appSessionId: state.appSessionId,
+        });
+      }
+    },
+    [state.appSessionId]
+  );
 
   useEffect(() => {
     return () => {
@@ -123,6 +154,7 @@ export default function SessionMenu({ compact }: SessionMenuProps) {
     if (!isOpen) {
       return;
     }
+    setSelectedSession(state.appSessionId);
     let cancelled = false;
     const loadSessions = async () => {
       try {
@@ -137,32 +169,12 @@ export default function SessionMenu({ compact }: SessionMenuProps) {
         }
       }
     };
-    const loadResearchSettings = async () => {
-      try {
-        const research = await apiClient.getCaseGroupResearchSettings(
-          state.appSessionId
-        );
-        if (!cancelled) {
-          setResearchEnabled(research.enabled);
-          setResearchStatus(research.status);
-          setResearchLocked(research.locked);
-          setResearchElapsedSeconds(research.elapsed_seconds ?? null);
-          setResearchElapsedLoadedAt(
-            typeof research.elapsed_seconds === "number" ? Date.now() : null
-          );
-        }
-      } catch (error) {
-        logClientError("SessionMenu.loadResearchSettings", error, {
-          appSessionId: state.appSessionId,
-        });
-      }
-    };
     loadSessions();
-    loadResearchSettings();
+    void refreshResearchSettings({ ignoreCancelled: () => cancelled });
     return () => {
       cancelled = true;
     };
-  }, [isOpen, state.appSessionId]);
+  }, [isOpen, refreshResearchSettings, state.appSessionId]);
 
   useEffect(() => {
     if (!isOpen || researchStatus !== "running") {
@@ -219,6 +231,7 @@ export default function SessionMenu({ compact }: SessionMenuProps) {
   };
 
   const lastStepLabel = state.lastCompletedLabel;
+  const hasActiveWorkflowRun = activeWorkflowRun.isActive || isRunningAll;
 
   useEffect(() => {
     if (!isOpen) {
@@ -284,7 +297,7 @@ export default function SessionMenu({ compact }: SessionMenuProps) {
   };
 
   const handleUndoLastStep = async () => {
-    if (!lastStepLabel || isUndoing) {
+    if (!lastStepLabel || isUndoing || hasActiveWorkflowRun) {
       return;
     }
     try {
@@ -337,7 +350,7 @@ export default function SessionMenu({ compact }: SessionMenuProps) {
   };
 
   const handleToggleDeepResearch = async () => {
-    if (isUpdatingResearch || researchLocked) {
+    if (isUpdatingResearch || researchLocked || hasActiveWorkflowRun) {
       return;
     }
     try {
@@ -398,6 +411,9 @@ export default function SessionMenu({ compact }: SessionMenuProps) {
     setRegulationsReady(sessionStatus.regulations_ready);
     setLastCompletedStep(sessionStatus.last_completed_step ?? null);
     setLastCompletedLabel(sessionStatus.last_completed_label ?? null);
+    setLastFailedStep(sessionStatus.last_failed_step ?? null);
+    setLastFailedLabel(sessionStatus.last_failed_label ?? null);
+    setLastFailedMessage(sessionStatus.last_failed_message ?? null);
     setResearchEnabled(Boolean(sessionStatus.case_group_research_enabled));
     setResearchStatus(sessionStatus.case_group_research_status || "idle");
     setResearchElapsedSeconds(
@@ -409,6 +425,8 @@ export default function SessionMenu({ compact }: SessionMenuProps) {
         : null
     );
     setResearchLocked(
+      sessionStatus.effort_ready ||
+        sessionStatus.total_cost_ready ||
       !["idle", "failed", "cancelled"].includes(
         sessionStatus.case_group_research_status || "idle"
       )
@@ -448,6 +466,7 @@ export default function SessionMenu({ compact }: SessionMenuProps) {
     setIsRunningAll(false);
     setCurrentRunId(null);
     setIsCancellingRun(false);
+    isCancellingRunRef.current = false;
     emitRunAllStepCleared();
     stopRunMonitoring();
   };
@@ -481,10 +500,14 @@ export default function SessionMenu({ compact }: SessionMenuProps) {
           applySessionStatus(progress.final_status);
         }
         if (progress.status === "running") {
+          if (progress.current_step) {
+            emitRunAllStepStarted(progress.current_step, runId);
+          }
           pollRunStatus(runId);
           return;
         }
         resetRunUiState();
+        void refreshResearchSettings();
         if (progress.status === "completed" && progress.ok) {
           setStatus("Alle Schritte wurden ausgeführt.");
         } else if (progress.status === "cancelled") {
@@ -515,11 +538,28 @@ export default function SessionMenu({ compact }: SessionMenuProps) {
     const source = new EventSource(apiClient.getRunAllEventsUrl(runId));
     runEventSourceRef.current = source;
 
+    source.addEventListener("snapshot", (event) => {
+      try {
+        const payload = JSON.parse((event as MessageEvent).data) as RunAllStatusResponse;
+        if (payload.final_status) {
+          applySessionStatus(payload.final_status);
+        }
+        if (payload.status === "running" && payload.current_step) {
+          emitRunAllStepStarted(payload.current_step, runId);
+          if (payload.current_label && !isCancellingRunRef.current) {
+            setStatus(`Läuft: ${payload.current_label}`);
+          }
+        }
+      } catch (error) {
+        logClientError("SessionMenu.snapshotEvent", error, { runId });
+      }
+    });
+
     source.addEventListener("step_started", (event) => {
       try {
         const payload = JSON.parse((event as MessageEvent).data) as RunStepStartedEvent;
-        emitRunAllStepStarted(payload.key);
-        if (payload.label) {
+        emitRunAllStepStarted(payload.key, runId);
+        if (payload.label && !isCancellingRunRef.current) {
           setStatus(`Läuft: ${payload.label}`);
         }
       } catch (error) {
@@ -535,7 +575,7 @@ export default function SessionMenu({ compact }: SessionMenuProps) {
           applySessionStatus(payload.session_status);
           const inferredStep = deriveRunAllStepKeyFromStatus(payload.session_status);
           if (inferredStep) {
-            emitRunAllStepStarted(inferredStep);
+            emitRunAllStepStarted(inferredStep, runId);
           }
         }
       } catch (error) {
@@ -548,6 +588,8 @@ export default function SessionMenu({ compact }: SessionMenuProps) {
     source.addEventListener("step_skipped", applyEventStatus);
     source.addEventListener("step_failed", applyEventStatus);
     source.addEventListener("run_cancelling", () => {
+      isCancellingRunRef.current = true;
+      setIsCancellingRun(true);
       setStatus("Abbruch angefordert...");
     });
 
@@ -565,8 +607,10 @@ export default function SessionMenu({ compact }: SessionMenuProps) {
         setIsRunningAll(false);
         setCurrentRunId(null);
         setIsCancellingRun(false);
+        isCancellingRunRef.current = false;
         emitRunAllStepCleared();
         stopRunMonitoring();
+        void refreshResearchSettings();
       }
     });
 
@@ -589,8 +633,10 @@ export default function SessionMenu({ compact }: SessionMenuProps) {
         setIsRunningAll(false);
         setCurrentRunId(null);
         setIsCancellingRun(false);
+        isCancellingRunRef.current = false;
         emitRunAllStepCleared();
         stopRunMonitoring();
+        void refreshResearchSettings();
       }
     });
     source.addEventListener("run_cancelled", (event) => {
@@ -612,8 +658,10 @@ export default function SessionMenu({ compact }: SessionMenuProps) {
         setIsRunningAll(false);
         setCurrentRunId(null);
         setIsCancellingRun(false);
+        isCancellingRunRef.current = false;
         emitRunAllStepCleared();
         stopRunMonitoring();
+        void refreshResearchSettings();
       }
     });
 
@@ -630,11 +678,12 @@ export default function SessionMenu({ compact }: SessionMenuProps) {
         setStatus("Lauf läuft bereits.");
         return;
       }
-      if (isCancellingRun) {
+      if (isCancellingRunRef.current) {
         setStatus("Abbruch läuft bereits...");
         return;
       }
       try {
+        isCancellingRunRef.current = true;
         setIsCancellingRun(true);
         setStatus("Abbruch angefordert...");
         await apiClient.cancelRunAll(currentRunId);
@@ -647,6 +696,7 @@ export default function SessionMenu({ compact }: SessionMenuProps) {
           runId: currentRunId,
         });
         const err = error as Error;
+        isCancellingRunRef.current = false;
         setIsCancellingRun(false);
         setStatus(err?.message || "Abbruch konnte nicht angefordert werden.");
       }
@@ -662,6 +712,7 @@ export default function SessionMenu({ compact }: SessionMenuProps) {
     }
     resetStatus();
     setIsRunningAll(true);
+    isCancellingRunRef.current = false;
     setStatus("Schritte werden vorbereitet...");
     emitRunAllStepCleared();
     try {
@@ -713,6 +764,7 @@ export default function SessionMenu({ compact }: SessionMenuProps) {
       setIsRunningAll(false);
       setCurrentRunId(null);
       setIsCancellingRun(false);
+      isCancellingRunRef.current = false;
       emitRunAllStepCleared();
       stopRunMonitoring();
     }
@@ -759,9 +811,9 @@ export default function SessionMenu({ compact }: SessionMenuProps) {
         </button>
         <button
           onClick={handleUndoLastStep}
-          disabled={!lastStepLabel || isUndoing}
+          disabled={!lastStepLabel || isUndoing || hasActiveWorkflowRun}
           className={`w-full rounded-xl px-3 py-2 text-left text-xs font-semibold transition ${
-            lastStepLabel && !isUndoing
+            lastStepLabel && !isUndoing && !hasActiveWorkflowRun
               ? "border border-slate-200 bg-white text-slate-700 hover:bg-slate-50"
               : "cursor-not-allowed border border-slate-100 bg-slate-100 text-slate-400"
           }`}
@@ -789,7 +841,9 @@ export default function SessionMenu({ compact }: SessionMenuProps) {
             type="button"
             role="switch"
             aria-checked={researchEnabled}
-            disabled={researchLocked || isUpdatingResearch || isRunningAll}
+            disabled={
+              researchLocked || isUpdatingResearch || hasActiveWorkflowRun
+            }
             onClick={handleToggleDeepResearch}
             className={`relative mt-1 h-6 w-14 rounded-full border p-0.5 text-[10px] font-bold leading-none transition disabled:cursor-not-allowed disabled:opacity-50 ${
               researchEnabled

--- a/frontend/src/components/SessionMenu.tsx
+++ b/frontend/src/components/SessionMenu.tsx
@@ -50,6 +50,12 @@ function deriveRunAllStepKeyFromStatus(
   return null;
 }
 
+function formatElapsedDuration(totalSeconds: number): string {
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${String(seconds).padStart(2, "0")} min`;
+}
+
 export default function SessionMenu({ compact }: SessionMenuProps) {
   const {
     state,
@@ -74,6 +80,13 @@ export default function SessionMenu({ compact }: SessionMenuProps) {
   const [isUndoing, setIsUndoing] = useState(false);
   const [researchEnabled, setResearchEnabled] = useState(false);
   const [researchStatus, setResearchStatus] = useState("idle");
+  const [researchElapsedSeconds, setResearchElapsedSeconds] = useState<
+    number | null
+  >(null);
+  const [researchElapsedLoadedAt, setResearchElapsedLoadedAt] = useState<
+    number | null
+  >(null);
+  const [nowMs, setNowMs] = useState(() => Date.now());
   const [researchLocked, setResearchLocked] = useState(false);
   const [isUpdatingResearch, setIsUpdatingResearch] = useState(false);
   const [isDownloadingResearch, setIsDownloadingResearch] = useState(false);
@@ -133,6 +146,10 @@ export default function SessionMenu({ compact }: SessionMenuProps) {
           setResearchEnabled(research.enabled);
           setResearchStatus(research.status);
           setResearchLocked(research.locked);
+          setResearchElapsedSeconds(research.elapsed_seconds ?? null);
+          setResearchElapsedLoadedAt(
+            typeof research.elapsed_seconds === "number" ? Date.now() : null
+          );
         }
       } catch (error) {
         logClientError("SessionMenu.loadResearchSettings", error, {
@@ -146,6 +163,14 @@ export default function SessionMenu({ compact }: SessionMenuProps) {
       cancelled = true;
     };
   }, [isOpen, state.appSessionId]);
+
+  useEffect(() => {
+    if (!isOpen || researchStatus !== "running") {
+      return;
+    }
+    const timer = window.setInterval(() => setNowMs(Date.now()), 1000);
+    return () => window.clearInterval(timer);
+  }, [isOpen, researchStatus]);
 
   const formattedSessions = useMemo(() => {
     return sessions.map((session) => {
@@ -325,6 +350,10 @@ export default function SessionMenu({ compact }: SessionMenuProps) {
       setResearchEnabled(result.enabled);
       setResearchStatus(result.status);
       setResearchLocked(result.locked);
+      setResearchElapsedSeconds(result.elapsed_seconds ?? null);
+      setResearchElapsedLoadedAt(
+        typeof result.elapsed_seconds === "number" ? Date.now() : null
+      );
       setStatus(
         result.enabled
           ? "Deep Research für Fallzahlen aktiviert."
@@ -371,6 +400,14 @@ export default function SessionMenu({ compact }: SessionMenuProps) {
     setLastCompletedLabel(sessionStatus.last_completed_label ?? null);
     setResearchEnabled(Boolean(sessionStatus.case_group_research_enabled));
     setResearchStatus(sessionStatus.case_group_research_status || "idle");
+    setResearchElapsedSeconds(
+      sessionStatus.case_group_research_elapsed_seconds ?? null
+    );
+    setResearchElapsedLoadedAt(
+      typeof sessionStatus.case_group_research_elapsed_seconds === "number"
+        ? Date.now()
+        : null
+    );
     setResearchLocked(
       !["idle", "failed", "cancelled"].includes(
         sessionStatus.case_group_research_status || "idle"
@@ -379,6 +416,22 @@ export default function SessionMenu({ compact }: SessionMenuProps) {
     setCurrentTab(deriveTabFromStatus(sessionStatus));
     window.dispatchEvent(new Event("tiles-updated"));
   };
+
+  const researchElapsedDisplay = useMemo(() => {
+    if (researchStatus !== "running" || researchElapsedSeconds === null) {
+      return null;
+    }
+    const clientElapsedSeconds =
+      researchElapsedLoadedAt === null
+        ? 0
+        : Math.max(0, Math.floor((nowMs - researchElapsedLoadedAt) / 1000));
+    return formatElapsedDuration(researchElapsedSeconds + clientElapsedSeconds);
+  }, [
+    nowMs,
+    researchElapsedLoadedAt,
+    researchElapsedSeconds,
+    researchStatus,
+  ]);
 
   const stopRunMonitoring = () => {
     if (runEventSourceRef.current) {
@@ -729,6 +782,7 @@ export default function SessionMenu({ compact }: SessionMenuProps) {
             </div>
             <div className="mt-1 text-[11px] text-slate-500">
               Status: {researchStatus}
+              {researchElapsedDisplay ? ` · läuft seit ${researchElapsedDisplay}` : ""}
             </div>
           </div>
           <button
@@ -737,15 +791,22 @@ export default function SessionMenu({ compact }: SessionMenuProps) {
             aria-checked={researchEnabled}
             disabled={researchLocked || isUpdatingResearch || isRunningAll}
             onClick={handleToggleDeepResearch}
-            className={`mt-1 h-6 w-11 rounded-full border p-0.5 transition disabled:cursor-not-allowed disabled:opacity-50 ${
+            className={`relative mt-1 h-6 w-14 rounded-full border p-0.5 text-[10px] font-bold leading-none transition disabled:cursor-not-allowed disabled:opacity-50 ${
               researchEnabled
-                ? "border-slate-900 bg-slate-900"
-                : "border-slate-300 bg-slate-100"
+                ? "border-slate-900 bg-slate-900 text-white"
+                : "border-slate-300 bg-slate-100 text-slate-500"
             }`}
           >
             <span
-              className={`block h-4 w-4 rounded-full bg-white transition ${
-                researchEnabled ? "translate-x-5" : "translate-x-0"
+              className={`absolute top-1/2 -translate-y-1/2 ${
+                researchEnabled ? "left-2" : "right-2"
+              }`}
+            >
+              {researchEnabled ? "An" : "Aus"}
+            </span>
+            <span
+              className={`block h-4 w-4 rounded-full bg-white shadow-sm transition ${
+                researchEnabled ? "translate-x-8" : "translate-x-0"
               }`}
             />
           </button>

--- a/frontend/src/components/TileNode.tsx
+++ b/frontend/src/components/TileNode.tsx
@@ -8,13 +8,11 @@ import { TileMetricTable } from "@/components/tileMetrics";
 export interface TileNodeData {
   title: string;
   text: string;
-  deletable: boolean;
   headerMetricLeft?: string | null;
   headerMetricRight?: string | null;
   metricTable?: TileMetricTable | null;
   onBodyRef: (id: string, element: HTMLParagraphElement | null) => void;
   onNodeRef: (id: string, element: HTMLDivElement | null) => void;
-  onDelete: () => void;
   onToggleExpand: () => void;
   isExpanded: boolean;
   textHasOverflow: boolean;
@@ -52,7 +50,7 @@ export function TileNode({ data, id }: NodeProps<TileNodeData>) {
     <div ref={setNodeRef} className={`tile-node ${highlightClass}`}>
       <Handle type="target" position={Position.Left} />
       <div className="tile-header">
-        {(data.changeStatus || data.deletable || data.headerMetricLeft || data.headerMetricRight) && (
+        {(data.changeStatus || data.headerMetricLeft || data.headerMetricRight) && (
           <div className="tile-meta-row">
             {data.changeStatus ? (
               <span className={`tile-status tile-status-${data.changeStatus}`}>
@@ -61,20 +59,11 @@ export function TileNode({ data, id }: NodeProps<TileNodeData>) {
             ) : (
               <span />
             )}
-            {(data.deletable || data.headerMetricLeft || data.headerMetricRight) && (
+            {(data.headerMetricLeft || data.headerMetricRight) && (
               <div className="tile-actions">
                 {data.headerMetricLeft && (
                   <span className="tile-metric tile-metric-left">{data.headerMetricLeft}</span>
                 )}
-                <button
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    data.onDelete();
-                  }}
-                  disabled={!data.deletable}
-                >
-                  ×
-                </button>
                 {data.headerMetricRight && (
                   <span className="tile-metric tile-metric-right">{data.headerMetricRight}</span>
                 )}

--- a/frontend/src/components/TileNode.tsx
+++ b/frontend/src/components/TileNode.tsx
@@ -121,8 +121,8 @@ export function TileNode({ data, id }: NodeProps<TileNodeData>) {
             <thead>
               <tr>
                 <th scope="col" />
-                <th scope="col">Gültig</th>
-                <th scope="col">Vorschlag</th>
+                <th scope="col">Aktuell</th>
+                <th scope="col">Entwurf</th>
               </tr>
             </thead>
             <tbody>

--- a/frontend/src/components/TotalCostPanel.tsx
+++ b/frontend/src/components/TotalCostPanel.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { useApp } from "@/contexts/AppContext";
 import { apiClient } from "@/lib/api";
 import { formatActionErrorMessage, logClientError } from "@/lib/errorFeedback";
-import { useRunAllStepBusy } from "@/lib/runAllStepEvents";
+import { useRunAllStepCancel } from "@/lib/useRunAllStepCancel";
 
 function formatEuro(value: number | null | undefined): string {
   return typeof value === "number" ? `${value.toFixed(2)} EUR` : "n. v.";
@@ -16,8 +16,20 @@ export default function TotalCostPanel() {
   const [status, setStatus] = useState<string | null>(null);
   const [statusTone, setStatusTone] = useState<"success" | "error">("success");
   const [isRunning, setIsRunning] = useState(false);
-  const isRunAllBusy = useRunAllStepBusy("total_cost");
+  const runAllCancel = useRunAllStepCancel({
+    stepKey: "total_cost",
+    appSessionId: state.appSessionId,
+    setStatus,
+    logScope: "TotalCostPanel.cancelRunAll",
+  });
+  const isRunAllBusy = runAllCancel.isRunAllBusy;
   const isBusy = isRunning || isRunAllBusy;
+
+  useEffect(() => {
+    if (runAllCancel.isCancellingRunAll) {
+      setStatusTone("error");
+    }
+  }, [runAllCancel.isCancellingRunAll]);
 
   const canRun =
     state.processStepsReady &&
@@ -27,11 +39,20 @@ export default function TotalCostPanel() {
 
   const label = state.totalCostReady
     ? "Bereits berechnet"
-    : isBusy
-      ? "Bitte warten..."
+    : isRunAllBusy
+      ? runAllCancel.isCancellingRunAll
+        ? "Abbruch wird ausgeführt..."
+        : "Abbrechen"
+      : isRunning
+        ? "Bitte warten..."
       : "Gesamtkosten berechnen";
 
   const handleCompute = async () => {
+    if (isRunAllBusy) {
+      setStatusTone("error");
+      await runAllCancel.cancelRunAllForStep();
+      return;
+    }
     if (!canRun) {
       return;
     }
@@ -130,13 +151,23 @@ export default function TotalCostPanel() {
           </p>
           <button
             onClick={handleCompute}
-            disabled={!canRun}
-            className={`justify-self-start whitespace-nowrap rounded-full px-4 py-2 text-sm font-semibold transition sm:justify-self-end ${
-              canRun
-                ? "bg-slate-900 text-white"
-                : "cursor-not-allowed bg-slate-200 text-slate-500"
+            disabled={
+              runAllCancel.isCancellingRunAll ||
+              (isRunAllBusy ? !runAllCancel.runAllRunId : !canRun)
+            }
+            className={`inline-flex items-center gap-2 justify-self-start whitespace-nowrap rounded-full px-4 py-2 text-sm font-semibold transition sm:justify-self-end ${
+              isRunAllBusy
+                ? runAllCancel.isCancellingRunAll
+                  ? "cursor-not-allowed border border-rose-100 bg-rose-100 text-rose-400"
+                  : "border border-rose-200 bg-rose-50 text-rose-700 hover:bg-rose-100"
+                : canRun
+                  ? "bg-slate-900 text-white"
+                  : "cursor-not-allowed bg-slate-200 text-slate-500"
             }`}
           >
+            {isRunAllBusy && (
+              <span className="h-3 w-3 animate-spin rounded-full border-2 border-current border-t-transparent" />
+            )}
             {label}
           </button>
         </div>

--- a/frontend/src/components/TotalCostPanel.tsx
+++ b/frontend/src/components/TotalCostPanel.tsx
@@ -121,8 +121,8 @@ export default function TotalCostPanel() {
   return (
     <section className="w-full border-b border-white/60 bg-white/80 px-6 py-4 backdrop-blur">
       <div className="mx-auto max-w-6xl space-y-4">
-        <div className="flex flex-wrap items-center justify-between gap-4">
-          <p className="text-xs text-slate-600">
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start">
+          <p className="text-xs leading-5 text-slate-600">
             Beim Klick auf „Gesamtkosten berechnen“ werden Schritt-, Fallgruppen-
             und Prozesskosten in einem Durchgang für Verwaltung, Wirtschaft und
             Bürger berechnet, dabei aber je Normadressat eigene Kostensichten
@@ -131,7 +131,7 @@ export default function TotalCostPanel() {
           <button
             onClick={handleCompute}
             disabled={!canRun}
-            className={`rounded-full px-4 py-2 text-sm font-semibold transition ${
+            className={`justify-self-start whitespace-nowrap rounded-full px-4 py-2 text-sm font-semibold transition sm:justify-self-end ${
               canRun
                 ? "bg-slate-900 text-white"
                 : "cursor-not-allowed bg-slate-200 text-slate-500"

--- a/frontend/src/components/UploadPanel.tsx
+++ b/frontend/src/components/UploadPanel.tsx
@@ -3,14 +3,15 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { useApp } from "@/contexts/AppContext";
-import { apiClient } from "@/lib/api";
+import { apiClient, buildLlmRequestOptions } from "@/lib/api";
 import { logClientError } from "@/lib/errorFeedback";
 import {
   formatSessionStartError,
   logSessionStartError,
-  prepareSessionDocumentsAndStartSummary,
+  prepareSessionDocuments,
 } from "@/lib/sessionStart";
 import { useRunAllStepBusy } from "@/lib/runAllStepEvents";
+import { useCancellableStepRun } from "@/lib/useCancellableStepRun";
 
 type UploadTarget = "current" | "proposed";
 
@@ -38,9 +39,32 @@ export default function UploadPanel() {
     current: false,
     proposed: false,
   });
-  const [isSummarizing, setIsSummarizing] = useState(false);
   const isRunAllBusy = useRunAllStepBusy("summary");
-  const isBusy = isSummarizing || isRunAllBusy;
+  const llm = buildLlmRequestOptions({
+    selectedModel: state.selectedModel,
+    availableModels: state.availableModels,
+  });
+  const stepRun = useCancellableStepRun({
+    appSessionId: state.appSessionId,
+    stepKey: "summary",
+    stepLabel: "CCC starten",
+    model: llm.model,
+    provider: llm.provider,
+    keys: llm.keys,
+    logScope: "UploadPanel.startSummary",
+    onCompleted: () => {
+      window.dispatchEvent(new Event("tiles-updated"));
+      setSummaryReady(true);
+      setRegulationsReady(false);
+      setProcessesReady(false);
+      setCurrentTab(1);
+    },
+    onCancelled: () => {
+      window.dispatchEvent(new Event("tiles-updated"));
+      setSummaryReady(false);
+    },
+  });
+  const isBusy = stepRun.isRunning || isRunAllBusy;
 
   const pendingUploads = useMemo(
     () => ({
@@ -176,9 +200,8 @@ export default function UploadPanel() {
     }
     setStatus(null);
     setSummaryReady(false);
-    setIsSummarizing(true);
     try {
-      await prepareSessionDocumentsAndStartSummary({
+      const { currentFilename, proposedFilename } = await prepareSessionDocuments({
         appSessionId: state.appSessionId,
         selectedModel: state.selectedModel,
         availableModels: state.availableModels,
@@ -194,21 +217,43 @@ export default function UploadPanel() {
         setPendingCurrentUploadName,
         setPendingProposedUploadName,
         setAvailableRegulations,
-        setSummaryReady,
-        setRegulationsReady,
-        setProcessesReady,
-        setCurrentTab,
       });
+      await stepRun.start({ currentFilename, proposedFilename });
     } catch (error) {
       logSessionStartError("UploadPanel.handleStart", error, {
         appSessionId: state.appSessionId,
       });
       setStatus(formatSessionStartError(error));
       setSummaryReady(false);
-    } finally {
-      setIsSummarizing(false);
     }
   };
+
+  const handleStartButton = async () => {
+    if (stepRun.isRunning) {
+      await stepRun.cancel();
+      return;
+    }
+    await handleStart();
+  };
+
+  const startButtonLabel = stepRun.isRunning
+    ? stepRun.isCancelling
+      ? "Abbruch wird ausgeführt..."
+      : "Abbrechen"
+    : isRunAllBusy
+      ? "Abbrechen"
+      : "CCC starten";
+  const startButtonClass =
+    stepRun.isRunning || isRunAllBusy
+      ? stepRun.isCancelling
+        ? "cursor-not-allowed border border-rose-100 bg-rose-100 text-rose-400"
+        : "border border-rose-200 bg-rose-50 text-rose-700 hover:bg-rose-100"
+      : canStart
+        ? "bg-slate-900 text-white"
+        : "cursor-not-allowed bg-slate-200 text-slate-500";
+  const startButtonDisabled =
+    isRunAllBusy || stepRun.isCancelling || (!stepRun.isRunning && !canStart);
+  const visibleStepRunStatus = stepRun.isRunning ? null : stepRun.statusText;
 
   return (
     <section className="w-full border-b border-white/60 bg-white/80 px-6 py-4 backdrop-blur">
@@ -419,22 +464,21 @@ export default function UploadPanel() {
           </div>
           <div className="flex items-end justify-start lg:justify-center">
             <button
-              onClick={handleStart}
-              disabled={!canStart}
-              className={`rounded-full px-4 py-2 text-sm font-semibold transition ${
-                canStart
-                  ? "bg-slate-900 text-white"
-                  : "cursor-not-allowed bg-slate-200 text-slate-500"
-              }`}
+              onClick={handleStartButton}
+              disabled={startButtonDisabled}
+              className={`inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-semibold transition ${startButtonClass}`}
             >
-              {isBusy ? "Bitte warten..." : "CCC starten"}
+              {(stepRun.isRunning || isRunAllBusy) && (
+                <span className="h-3 w-3 animate-spin rounded-full border-2 border-current border-t-transparent" />
+              )}
+              {startButtonLabel}
             </button>
           </div>
         </div>
 
-        {status && (
+        {(status || visibleStepRunStatus) && (
           <div className="rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-xs font-semibold text-amber-800">
-            {status}
+            {visibleStepRunStatus || status}
           </div>
         )}
       </div>

--- a/frontend/src/components/UploadPanel.tsx
+++ b/frontend/src/components/UploadPanel.tsx
@@ -5,13 +5,14 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useApp } from "@/contexts/AppContext";
 import { apiClient, buildLlmRequestOptions } from "@/lib/api";
 import { logClientError } from "@/lib/errorFeedback";
+import { getVisibleFailedStepStatus } from "@/lib/sessionStatus";
 import {
   formatSessionStartError,
   logSessionStartError,
   prepareSessionDocuments,
 } from "@/lib/sessionStart";
-import { useRunAllStepBusy } from "@/lib/runAllStepEvents";
 import { useCancellableStepRun } from "@/lib/useCancellableStepRun";
+import { useRunAllStepCancel } from "@/lib/useRunAllStepCancel";
 
 type UploadTarget = "current" | "proposed";
 
@@ -39,7 +40,13 @@ export default function UploadPanel() {
     current: false,
     proposed: false,
   });
-  const isRunAllBusy = useRunAllStepBusy("summary");
+  const runAllCancel = useRunAllStepCancel({
+    stepKey: "summary",
+    appSessionId: state.appSessionId,
+    setStatus,
+    logScope: "UploadPanel.cancelRunAll",
+  });
+  const isRunAllBusy = runAllCancel.isRunAllBusy;
   const llm = buildLlmRequestOptions({
     selectedModel: state.selectedModel,
     availableModels: state.availableModels,
@@ -233,6 +240,10 @@ export default function UploadPanel() {
       await stepRun.cancel();
       return;
     }
+    if (isRunAllBusy) {
+      await runAllCancel.cancelRunAllForStep();
+      return;
+    }
     await handleStart();
   };
 
@@ -241,19 +252,29 @@ export default function UploadPanel() {
       ? "Abbruch wird ausgeführt..."
       : "Abbrechen"
     : isRunAllBusy
-      ? "Abbrechen"
+      ? runAllCancel.isCancellingRunAll
+        ? "Abbruch wird ausgeführt..."
+        : "Abbrechen"
       : "CCC starten";
   const startButtonClass =
     stepRun.isRunning || isRunAllBusy
-      ? stepRun.isCancelling
+      ? stepRun.isCancelling || runAllCancel.isCancellingRunAll
         ? "cursor-not-allowed border border-rose-100 bg-rose-100 text-rose-400"
         : "border border-rose-200 bg-rose-50 text-rose-700 hover:bg-rose-100"
       : canStart
         ? "bg-slate-900 text-white"
         : "cursor-not-allowed bg-slate-200 text-slate-500";
   const startButtonDisabled =
-    isRunAllBusy || stepRun.isCancelling || (!stepRun.isRunning && !canStart);
+    stepRun.isCancelling ||
+    runAllCancel.isCancellingRunAll ||
+    (isRunAllBusy ? !runAllCancel.runAllRunId : !stepRun.isRunning && !canStart);
   const visibleStepRunStatus = stepRun.isRunning ? null : stepRun.statusText;
+  const failedStepStatus = getVisibleFailedStepStatus(
+    state,
+    "summary",
+    state.summaryReady,
+    visibleStepRunStatus
+  );
 
   return (
     <section className="w-full border-b border-white/60 bg-white/80 px-6 py-4 backdrop-blur">
@@ -476,9 +497,9 @@ export default function UploadPanel() {
           </div>
         </div>
 
-        {(status || visibleStepRunStatus) && (
+        {(status || visibleStepRunStatus || failedStepStatus) && (
           <div className="rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-xs font-semibold text-amber-800">
-            {visibleStepRunStatus || status}
+            {visibleStepRunStatus || status || failedStepStatus}
           </div>
         )}
       </div>

--- a/frontend/src/components/__tests__/EffortPanel.test.tsx
+++ b/frontend/src/components/__tests__/EffortPanel.test.tsx
@@ -9,7 +9,9 @@ import { useApp } from "@/contexts/AppContext";
 
 jest.mock("@/lib/api", () => ({
   apiClient: {
-    calculateEffort: jest.fn(),
+    startStepRun: jest.fn(),
+    getStepRunStatus: jest.fn(),
+    cancelStepRun: jest.fn(),
   },
   buildLlmRequestOptions: ({
     selectedModel,
@@ -38,7 +40,8 @@ jest.mock("@/contexts/AppContext", () => ({
 }));
 
 const mockUseApp = useApp as jest.Mock;
-const mockCalculateEffort = apiClient.calculateEffort as jest.Mock;
+const mockStartStepRun = apiClient.startStepRun as jest.Mock;
+const mockGetStepRunStatus = apiClient.getStepRunStatus as jest.Mock;
 
 const baseState = {
   currentTab: 5,
@@ -62,7 +65,8 @@ const baseState = {
 
 describe("EffortPanel", () => {
   beforeEach(() => {
-    mockCalculateEffort.mockReset();
+    mockStartStepRun.mockReset();
+    mockGetStepRunStatus.mockReset();
     localStorage.clear();
   });
 
@@ -88,7 +92,20 @@ describe("EffortPanel", () => {
       setEffortReady,
     });
     localStorage.setItem("openai_api_key", "sk-test");
-    mockCalculateEffort.mockResolvedValue({ case_groups_updated: 1, steps_updated: 1 });
+    mockStartStepRun.mockResolvedValue({
+      app_session_id: "ABC123",
+      run_id: "run-1",
+      started: true,
+      status: "running",
+    });
+    mockGetStepRunStatus.mockResolvedValue({
+      run_id: "run-1",
+      app_session_id: "ABC123",
+      status: "completed",
+      ok: true,
+      steps: [{ key: "effort", label: "Aufwand berechnen", status: "completed" }],
+      final_status: { ...baseState, effort_ready: true },
+    });
 
     render(<EffortPanel />);
     const user = userEvent.setup();
@@ -96,11 +113,11 @@ describe("EffortPanel", () => {
     await user.click(screen.getByRole("button", { name: /Aufwand berechnen/i }));
 
     await waitFor(() => {
-      expect(mockCalculateEffort).toHaveBeenCalledTimes(3);
+      expect(mockStartStepRun).toHaveBeenCalledTimes(1);
     });
-    expect(mockCalculateEffort).toHaveBeenNthCalledWith(1, {
+    expect(mockStartStepRun).toHaveBeenCalledWith({
       appSessionId: "ABC123",
-      normAddressee: "administration",
+      stepKey: "effort",
       model: "gpt-5",
       provider: "openai",
       keys: {
@@ -109,30 +126,11 @@ describe("EffortPanel", () => {
         geminiApiKey: undefined,
       },
     });
-    expect(mockCalculateEffort).toHaveBeenNthCalledWith(2, {
-      appSessionId: "ABC123",
-      normAddressee: "business",
-      model: "gpt-5",
-      provider: "openai",
-      keys: {
-        openaiApiKey: "sk-test",
-        deepinfraApiKey: undefined,
-        geminiApiKey: undefined,
-      },
+    await waitFor(() => {
+      expect(mockGetStepRunStatus).toHaveBeenCalledWith("run-1");
+      expect(setCurrentTab).toHaveBeenCalledWith(6);
+      expect(setEffortReady).toHaveBeenCalledWith(true);
     });
-    expect(mockCalculateEffort).toHaveBeenNthCalledWith(3, {
-      appSessionId: "ABC123",
-      normAddressee: "citizens",
-      model: "gpt-5",
-      provider: "openai",
-      keys: {
-        openaiApiKey: "sk-test",
-        deepinfraApiKey: undefined,
-        geminiApiKey: undefined,
-      },
-    });
-    expect(setCurrentTab).toHaveBeenCalledWith(6);
-    expect(setEffortReady).toHaveBeenCalledWith(true);
   });
 
   it("shows an error when the API fails", async () => {
@@ -143,7 +141,7 @@ describe("EffortPanel", () => {
       setCurrentTab,
       setEffortReady,
     });
-    mockCalculateEffort.mockRejectedValue(new Error("boom"));
+    mockStartStepRun.mockRejectedValue(new Error("boom"));
 
     render(<EffortPanel />);
     const user = userEvent.setup();
@@ -151,9 +149,7 @@ describe("EffortPanel", () => {
     await user.click(screen.getByRole("button", { name: /Aufwand berechnen/i }));
 
     expect(
-      await screen.findByText(
-        /Aufwand berechnen fehlgeschlagen fuer alle Normadressaten.*Verwaltung.*Wirtschaft.*Buerger/
-      )
+      await screen.findByText("Aufwand konnte nicht gestartet werden.")
     ).toBeInTheDocument();
     expect(setCurrentTab).not.toHaveBeenCalled();
   });
@@ -166,10 +162,26 @@ describe("EffortPanel", () => {
       setCurrentTab,
       setEffortReady,
     });
-    mockCalculateEffort.mockResolvedValue({
-      status: "existing",
-      case_groups_updated: 0,
-      steps_updated: 0,
+    mockStartStepRun.mockResolvedValue({
+      app_session_id: "ABC123",
+      run_id: "run-existing",
+      started: true,
+      status: "running",
+    });
+    mockGetStepRunStatus.mockResolvedValue({
+      run_id: "run-existing",
+      app_session_id: "ABC123",
+      status: "completed",
+      ok: true,
+      steps: [
+        {
+          key: "effort",
+          label: "Aufwand berechnen",
+          status: "skipped",
+          message: "Step already complete",
+        },
+      ],
+      final_status: { ...baseState, effort_ready: true },
     });
 
     render(<EffortPanel />);
@@ -179,10 +191,12 @@ describe("EffortPanel", () => {
 
     expect(
       await screen.findByText(
-        "Aufwand fuer Verwaltung, Wirtschaft und Buerger wurde bereits berechnet."
+        "Aufwand fuer Verwaltung, Wirtschaft und Buerger berechnet.",
+        {},
+        { timeout: 2000 }
       )
     ).toBeInTheDocument();
-    expect(mockCalculateEffort).toHaveBeenCalledTimes(3);
+    expect(mockStartStepRun).toHaveBeenCalledTimes(1);
     expect(setEffortReady).toHaveBeenCalledWith(true);
     expect(setCurrentTab).toHaveBeenCalledWith(6);
   });

--- a/frontend/src/components/__tests__/EffortPanel.test.tsx
+++ b/frontend/src/components/__tests__/EffortPanel.test.tsx
@@ -1,17 +1,20 @@
-"use client";
-
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import EffortPanel from "@/components/EffortPanel";
 import { apiClient } from "@/lib/api";
 import { useApp } from "@/contexts/AppContext";
+import {
+  emitRunAllStepCleared,
+  emitRunAllStepStarted,
+} from "@/lib/runAllStepEvents";
 
 jest.mock("@/lib/api", () => ({
   apiClient: {
     startStepRun: jest.fn(),
     getStepRunStatus: jest.fn(),
     cancelStepRun: jest.fn(),
+    cancelRunAll: jest.fn(),
   },
   buildLlmRequestOptions: ({
     selectedModel,
@@ -42,6 +45,8 @@ jest.mock("@/contexts/AppContext", () => ({
 const mockUseApp = useApp as jest.Mock;
 const mockStartStepRun = apiClient.startStepRun as jest.Mock;
 const mockGetStepRunStatus = apiClient.getStepRunStatus as jest.Mock;
+const mockCancelStepRun = apiClient.cancelStepRun as jest.Mock;
+const mockCancelRunAll = apiClient.cancelRunAll as jest.Mock;
 
 const baseState = {
   currentTab: 5,
@@ -67,6 +72,9 @@ describe("EffortPanel", () => {
   beforeEach(() => {
     mockStartStepRun.mockReset();
     mockGetStepRunStatus.mockReset();
+    mockCancelStepRun.mockReset();
+    mockCancelRunAll.mockReset();
+    emitRunAllStepCleared();
     localStorage.clear();
   });
 
@@ -199,5 +207,101 @@ describe("EffortPanel", () => {
     expect(mockStartStepRun).toHaveBeenCalledTimes(1);
     expect(setEffortReady).toHaveBeenCalledWith(true);
     expect(setCurrentTab).toHaveBeenCalledWith(6);
+  });
+
+  it("cancels the active run-all when run-all is executing effort", async () => {
+    mockUseApp.mockReturnValue({
+      state: baseState,
+      setCurrentTab: jest.fn(),
+      setEffortReady: jest.fn(),
+    });
+    mockCancelRunAll.mockResolvedValue({
+      run_id: "run-all-1",
+      app_session_id: "ABC123",
+      status: "cancelling",
+      accepted: true,
+      message: "Cancellation requested",
+    });
+
+    render(<EffortPanel />);
+    act(() => {
+      emitRunAllStepStarted("effort", "run-all-1");
+    });
+    const user = userEvent.setup();
+
+    const button = screen.getByRole("button", { name: /abbrechen/i });
+    expect(button).not.toBeDisabled();
+    await user.click(button);
+
+    expect(mockCancelRunAll).toHaveBeenCalledWith("run-all-1");
+    expect(apiClient.cancelStepRun).not.toHaveBeenCalled();
+    expect(await screen.findByText("Abbruch angefordert...")).toBeInTheDocument();
+  });
+
+  it("does not send duplicate run-all cancel requests after cancellation starts", async () => {
+    mockUseApp.mockReturnValue({
+      state: baseState,
+      setCurrentTab: jest.fn(),
+      setEffortReady: jest.fn(),
+    });
+    mockCancelRunAll.mockResolvedValue({
+      run_id: "run-all-1",
+      app_session_id: "ABC123",
+      status: "cancelling",
+      accepted: true,
+      message: "Cancellation requested",
+    });
+
+    render(<EffortPanel />);
+    act(() => {
+      emitRunAllStepStarted("effort", "run-all-1");
+    });
+
+    const button = screen.getByRole("button", { name: /abbrechen/i });
+    fireEvent.click(button);
+    fireEvent.click(button);
+    await screen.findByText("Abbruch angefordert...");
+
+    expect(mockCancelRunAll).toHaveBeenCalledTimes(1);
+    expect(mockCancelStepRun).not.toHaveBeenCalled();
+  });
+
+  it("cancels a manual effort run via the step-run endpoint, not run-all", async () => {
+    mockUseApp.mockReturnValue({
+      state: baseState,
+      setCurrentTab: jest.fn(),
+      setEffortReady: jest.fn(),
+    });
+    mockStartStepRun.mockResolvedValue({
+      app_session_id: "ABC123",
+      run_id: "manual-run-1",
+      started: true,
+      status: "running",
+    });
+    mockGetStepRunStatus.mockResolvedValue({
+      run_id: "manual-run-1",
+      app_session_id: "ABC123",
+      status: "running",
+      ok: null,
+      current_label: "Aufwand berechnen",
+      steps: [{ key: "effort", label: "Aufwand berechnen", status: "running" }],
+    });
+    mockCancelStepRun.mockResolvedValue({
+      run_id: "manual-run-1",
+      app_session_id: "ABC123",
+      status: "cancelling",
+      accepted: true,
+      message: "Cancellation requested",
+    });
+
+    render(<EffortPanel />);
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole("button", { name: /aufwand berechnen/i }));
+    const cancelButton = await screen.findByRole("button", { name: /abbrechen/i });
+    await user.click(cancelButton);
+
+    expect(mockCancelStepRun).toHaveBeenCalledWith("manual-run-1");
+    expect(mockCancelRunAll).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/__tests__/GraphCanvas.test.tsx
+++ b/frontend/src/components/__tests__/GraphCanvas.test.tsx
@@ -12,7 +12,6 @@ jest.mock("@/lib/api", () => ({
   apiClient: {
     fetchTiles: jest.fn(),
     upsertTile: jest.fn(),
-    deleteTile: jest.fn(),
   },
 }));
 

--- a/frontend/src/components/__tests__/ProcessesPanel.test.tsx
+++ b/frontend/src/components/__tests__/ProcessesPanel.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from "@testing-library/react";
+
+import ProcessesPanel from "@/components/ProcessesPanel";
+import { useApp } from "@/contexts/AppContext";
+import { emitRunAllStepCleared } from "@/lib/runAllStepEvents";
+
+jest.mock("@/contexts/AppContext", () => ({
+  useApp: jest.fn(),
+}));
+
+jest.mock("@/lib/api", () => ({
+  apiClient: {
+    startStepRun: jest.fn(),
+    getStepRunStatus: jest.fn(),
+    cancelStepRun: jest.fn(),
+    cancelRunAll: jest.fn(),
+  },
+  buildLlmRequestOptions: jest.fn(() => ({
+    model: "test-model",
+    provider: "gemini",
+    keys: {},
+  })),
+}));
+
+const mockUseApp = useApp as jest.Mock;
+
+describe("ProcessesPanel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    emitRunAllStepCleared();
+  });
+
+  it("shows a persisted failed Step 3 message from session status", () => {
+    mockUseApp.mockReturnValue({
+      state: {
+        appSessionId: "PRIDJF",
+        selectedNormAddressee: "administration",
+        selectedModel: "gemini-3.5-flash",
+        availableModels: [],
+        summaryReady: true,
+        regulationsReady: true,
+        processesReady: false,
+        caseGroupsReady: false,
+        processStepsReady: false,
+        effortReady: false,
+        totalCostReady: false,
+        lastFailedStep: "processes",
+        lastFailedLabel: "Prozesse bündeln",
+        lastFailedMessage: "Vorgabe 295 linked to multiple processes",
+      },
+      setCurrentTab: jest.fn(),
+      setProcessesReady: jest.fn(),
+    });
+
+    render(<ProcessesPanel />);
+
+    expect(
+      screen.getByText("Vorgabe 295 linked to multiple processes")
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/__tests__/SessionMenu.test.tsx
+++ b/frontend/src/components/__tests__/SessionMenu.test.tsx
@@ -17,6 +17,9 @@ jest.mock("@/lib/api", () => ({
     getSessionStatus: jest.fn(),
     undoLastStep: jest.fn(),
     exportSession: jest.fn(),
+    getCaseGroupResearchSettings: jest.fn(),
+    updateCaseGroupResearchSettings: jest.fn(),
+    downloadDeepResearchReport: jest.fn(),
     startRunAllSteps: jest.fn(),
     cancelRunAll: jest.fn(),
     getRunAllStatus: jest.fn(),
@@ -40,6 +43,8 @@ const mockRebuildTiles = apiClient.rebuildTiles as jest.Mock;
 const mockListSessions = apiClient.listSessions as jest.Mock;
 const mockGetSessionStatus = apiClient.getSessionStatus as jest.Mock;
 const mockUndoLastStep = apiClient.undoLastStep as jest.Mock;
+const mockGetCaseGroupResearchSettings =
+  apiClient.getCaseGroupResearchSettings as jest.Mock;
 const mockStartRunAllSteps = apiClient.startRunAllSteps as jest.Mock;
 const mockPrepareSessionDocuments = prepareSessionDocuments as jest.Mock;
 
@@ -123,6 +128,13 @@ describe("SessionMenu", () => {
       status: "ok",
       undone_step: "effort",
       undone_label: "Aufwand berechnen",
+    });
+    mockGetCaseGroupResearchSettings.mockResolvedValue({
+      app_session_id: "ABC123",
+      enabled: true,
+      status: "idle",
+      locked: false,
+      elapsed_seconds: null,
     });
     mockStartRunAllSteps.mockResolvedValue({
       run_id: "run-123",
@@ -249,5 +261,21 @@ describe("SessionMenu", () => {
         keys: { openaiApiKey: "key" },
       })
     );
+  });
+
+  it("shows elapsed Deep Research runtime while running", async () => {
+    mockGetCaseGroupResearchSettings.mockResolvedValue({
+      app_session_id: "ABC123",
+      enabled: true,
+      status: "running",
+      locked: true,
+      elapsed_seconds: 125,
+    });
+
+    await openMenu();
+
+    expect(
+      await screen.findByText(/Status: running · läuft seit 2:05 min/i)
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/__tests__/SessionMenu.test.tsx
+++ b/frontend/src/components/__tests__/SessionMenu.test.tsx
@@ -154,20 +154,6 @@ describe("SessionMenu", () => {
     return user;
   }
 
-  it("rebuilds the currently selected norm addressee", async () => {
-    const user = await openMenu();
-
-    await user.click(
-      screen.getByRole("button", {
-        name: /kacheln dieser session neu laden/i,
-      })
-    );
-
-    await waitFor(() =>
-      expect(mockRebuildTiles).toHaveBeenCalledWith("ABC123", "business")
-    );
-  });
-
   it("rebuilds the selected norm addressee after loading another session", async () => {
     const user = await openMenu();
 

--- a/frontend/src/components/__tests__/SessionMenu.test.tsx
+++ b/frontend/src/components/__tests__/SessionMenu.test.tsx
@@ -1,9 +1,13 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import SessionMenu from "@/components/SessionMenu";
 import { useApp } from "@/contexts/AppContext";
 import { apiClient } from "@/lib/api";
+import {
+  emitRunAllStepCleared,
+  emitRunAllStepStarted,
+} from "@/lib/runAllStepEvents";
 import { prepareSessionDocuments } from "@/lib/sessionStart";
 
 jest.mock("@/contexts/AppContext", () => ({
@@ -62,9 +66,13 @@ describe("SessionMenu", () => {
   const setRegulationsReady = jest.fn();
   const setLastCompletedStep = jest.fn();
   const setLastCompletedLabel = jest.fn();
+  const setLastFailedStep = jest.fn();
+  const setLastFailedLabel = jest.fn();
+  const setLastFailedMessage = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
+    emitRunAllStepCleared();
     mockUseApp.mockReturnValue({
       state: {
         appSessionId: "ABC123",
@@ -101,10 +109,19 @@ describe("SessionMenu", () => {
       setRegulationsReady,
       setLastCompletedStep,
       setLastCompletedLabel,
+      setLastFailedStep,
+      setLastFailedLabel,
+      setLastFailedMessage,
     });
     mockRebuildTiles.mockResolvedValue({ ok: true });
     mockListSessions.mockResolvedValue({
       sessions: [
+        {
+          app_session_id: "ABC123",
+          created_at: "2026-04-14T08:00:00Z",
+          llm_model: "gpt-5.4",
+          used_llm_models: "gpt-5.4",
+        },
         {
           app_session_id: "XYZ789",
           created_at: "2026-04-14T09:00:00Z",
@@ -233,6 +250,9 @@ describe("SessionMenu", () => {
       setRegulationsReady,
       setLastCompletedStep,
       setLastCompletedLabel,
+      setLastFailedStep,
+      setLastFailedLabel,
+      setLastFailedMessage,
     });
 
     const user = await openMenu();
@@ -277,5 +297,97 @@ describe("SessionMenu", () => {
     expect(
       await screen.findByText(/Status: running · läuft seit 2:05 min/i)
     ).toBeInTheDocument();
+  });
+
+  it("disables reset while a workflow run is active", async () => {
+    const user = await openMenu();
+
+    act(() => {
+      emitRunAllStepStarted("regulations", "run-1", "run_all");
+    });
+
+    const resetButton = screen.getByRole("button", {
+      name: /aufwand berechnen.*zurücksetzen/i,
+    });
+    expect(resetButton).toBeDisabled();
+
+    await user.click(resetButton);
+
+    expect(mockUndoLastStep).not.toHaveBeenCalled();
+  });
+
+  it("re-enables the Deep Research toggle after a pre-effort run is cleared", async () => {
+    const user = await openMenu();
+    const toggle = await screen.findByRole("switch");
+
+    act(() => {
+      emitRunAllStepStarted("regulations", "run-1", "run_all");
+    });
+    expect(toggle).toBeDisabled();
+
+    act(() => {
+      emitRunAllStepCleared();
+    });
+    expect(toggle).not.toBeDisabled();
+
+    await user.click(toggle);
+
+    expect(apiClient.updateCaseGroupResearchSettings).toHaveBeenCalledWith(
+      "ABC123",
+      false
+    );
+  });
+
+  it("does not toggle Deep Research while run-all is being prepared", async () => {
+    const user = await openMenu();
+
+    await user.click(
+      screen.getByRole("button", { name: /alle schritte ausführen/i })
+    );
+    const toggle = await screen.findByRole("switch");
+    expect(toggle).toBeDisabled();
+
+    await user.click(toggle);
+
+    expect(apiClient.updateCaseGroupResearchSettings).not.toHaveBeenCalled();
+  });
+
+  it("does not load a selected session when the modal is closed before Wechseln", async () => {
+    const user = await openMenu();
+
+    await waitFor(() => expect(mockListSessions).toHaveBeenCalled());
+    const select = screen.getByRole("combobox");
+    expect(select).toHaveValue("ABC123");
+
+    await user.selectOptions(select, "XYZ789");
+    expect(select).toHaveValue("XYZ789");
+    await user.click(screen.getByRole("button", { name: /schließen/i }));
+
+    expect(mockGetSessionStatus).not.toHaveBeenCalledWith("XYZ789");
+    expect(mockRebuildTiles).not.toHaveBeenCalledWith("XYZ789", "business");
+    expect(setAppSessionId).not.toHaveBeenCalledWith("XYZ789");
+
+    await user.click(screen.getByTitle("Session Aktionen"));
+    await screen.findByText("Session Aktionen");
+    expect(screen.getByRole("combobox")).toHaveValue("ABC123");
+  });
+
+  it("sends only one cancellation request when run-all cancel is clicked repeatedly", async () => {
+    const user = await openMenu();
+
+    await user.click(
+      screen.getByRole("button", { name: /alle schritte ausführen/i })
+    );
+    const cancelButton = await screen.findByRole("button", {
+      name: /ausführung abbrechen/i,
+    });
+    fireEvent.click(cancelButton);
+    fireEvent.click(cancelButton);
+    await screen.findByRole("button", {
+      name: /abbruch wird ausgeführt/i,
+    });
+
+    expect(apiClient.cancelRunAll).toHaveBeenCalledTimes(1);
+    expect(apiClient.cancelRunAll).toHaveBeenCalledWith("run-123");
   });
 });

--- a/frontend/src/components/__tests__/TileNode.test.tsx
+++ b/frontend/src/components/__tests__/TileNode.test.tsx
@@ -32,10 +32,8 @@ function buildTileNodeProps(
     data: {
       title: "Regelung",
       text: "Kurztext",
-      deletable: false,
       onBodyRef: jest.fn(),
       onNodeRef: jest.fn(),
-      onDelete: jest.fn(),
       onToggleExpand: jest.fn(),
       isExpanded: false,
       textHasOverflow: false,
@@ -111,11 +109,10 @@ describe("TileNode", () => {
     expect(bodyNullCall).toBeUndefined();
   });
 
-  it("renders header metrics around the delete action", () => {
+  it("renders header metrics without a delete action", () => {
     render(
       <TileNode
         {...buildTileNodeProps("step_4", {
-          deletable: true,
           headerMetricLeft: "Δ 120 €",
           headerMetricRight: "Δ Fälle/Jahr +5",
         })}
@@ -124,7 +121,7 @@ describe("TileNode", () => {
 
     expect(screen.getByText("Δ 120 €")).toBeInTheDocument();
     expect(screen.getByText("Δ Fälle/Jahr +5")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "×" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "×" })).not.toBeInTheDocument();
   });
 
   it("renders a step matrix as a table", () => {

--- a/frontend/src/components/__tests__/TileNode.test.tsx
+++ b/frontend/src/components/__tests__/TileNode.test.tsx
@@ -149,8 +149,8 @@ describe("TileNode", () => {
       />
     );
 
-    expect(screen.getByRole("columnheader", { name: "Gültig" })).toBeInTheDocument();
-    expect(screen.getByRole("columnheader", { name: "Vorschlag" })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Aktuell" })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Entwurf" })).toBeInTheDocument();
     expect(screen.getByRole("rowheader", { name: "eD/mD" })).toBeInTheDocument();
     expect(screen.getByText("12 min")).toBeInTheDocument();
     expect(screen.getByText("15 min")).toBeInTheDocument();
@@ -204,6 +204,6 @@ describe("TileNode", () => {
     );
 
     expect(screen.getByTitle("Text ausklappen")).toBeInTheDocument();
-    expect(screen.queryByRole("columnheader", { name: "Gültig" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("columnheader", { name: "Aktuell" })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/__tests__/UploadPanel.test.tsx
+++ b/frontend/src/components/__tests__/UploadPanel.test.tsx
@@ -5,7 +5,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import UploadPanel from "@/components/UploadPanel";
 import { useApp } from "@/contexts/AppContext";
 import { apiClient } from "@/lib/api";
-import { prepareSessionDocumentsAndStartSummary } from "@/lib/sessionStart";
+import { prepareSessionDocuments } from "@/lib/sessionStart";
 
 jest.mock("@/contexts/AppContext", () => ({
   useApp: jest.fn(),
@@ -14,11 +14,19 @@ jest.mock("@/contexts/AppContext", () => ({
 jest.mock("@/lib/api", () => ({
   apiClient: {
     fetchRegulations: jest.fn(),
+    startStepRun: jest.fn(),
+    getStepRunStatus: jest.fn(),
+    cancelStepRun: jest.fn(),
   },
+  buildLlmRequestOptions: () => ({
+    model: "gpt-5.4",
+    provider: "openai",
+    keys: {},
+  }),
 }));
 
 jest.mock("@/lib/sessionStart", () => ({
-  prepareSessionDocumentsAndStartSummary: jest.fn(),
+  prepareSessionDocuments: jest.fn(),
   formatSessionStartError: jest.fn(() => "Fehler"),
   logSessionStartError: jest.fn(),
 }));
@@ -29,7 +37,7 @@ jest.mock("@/lib/runAllStepEvents", () => ({
 
 const mockUseApp = useApp as jest.Mock;
 const mockFetchRegulations = apiClient.fetchRegulations as jest.Mock;
-const mockPrepareAndStart = prepareSessionDocumentsAndStartSummary as jest.Mock;
+const mockPrepareSessionDocuments = prepareSessionDocuments as jest.Mock;
 
 function createAppValue(overrides: Record<string, unknown> = {}) {
   return {
@@ -64,7 +72,10 @@ describe("UploadPanel", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockFetchRegulations.mockResolvedValue({ files: [] });
-    mockPrepareAndStart.mockResolvedValue(undefined);
+    mockPrepareSessionDocuments.mockResolvedValue({
+      proposedFilename: "proposed.txt",
+      llm: { model: "gpt-5.4", provider: "openai", keys: {} },
+    });
     mockUseApp.mockReturnValue(createAppValue());
   });
 

--- a/frontend/src/components/__tests__/UploadPanel.test.tsx
+++ b/frontend/src/components/__tests__/UploadPanel.test.tsx
@@ -17,6 +17,7 @@ jest.mock("@/lib/api", () => ({
     startStepRun: jest.fn(),
     getStepRunStatus: jest.fn(),
     cancelStepRun: jest.fn(),
+    cancelRunAll: jest.fn(),
   },
   buildLlmRequestOptions: () => ({
     model: "gpt-5.4",
@@ -32,7 +33,11 @@ jest.mock("@/lib/sessionStart", () => ({
 }));
 
 jest.mock("@/lib/runAllStepEvents", () => ({
-  useRunAllStepBusy: jest.fn(() => false),
+  useRunAllStepRun: jest.fn(() => ({
+    isBusy: false,
+    runId: null,
+    runKind: null,
+  })),
 }));
 
 const mockUseApp = useApp as jest.Mock;

--- a/frontend/src/components/ea_edit/EaCaseMetricsTab.tsx
+++ b/frontend/src/components/ea_edit/EaCaseMetricsTab.tsx
@@ -34,32 +34,36 @@ const CASE_FIELDS = [
     editedKey: "addressees_current_edited",
     effectiveKey: "addressees_current_effective",
     side: "current",
+    researchKey: "anzahl_betroffene_gueltig",
     columnLabel: "Betroffene",
-    reviewLabel: "Gültig Betroffene",
+    reviewLabel: "Aktuelles Gesetz Betroffene",
   },
   {
     key: "annual_frequency_current",
     editedKey: "annual_frequency_current_edited",
     effectiveKey: "annual_frequency_current_effective",
     side: "current",
+    researchKey: "haeufigkeit_pro_jahr_gueltig",
     columnLabel: "Häufigkeit",
-    reviewLabel: "Gültig Häufigkeit",
+    reviewLabel: "Aktuelles Gesetz Häufigkeit",
   },
   {
     key: "addressees_proposed",
     editedKey: "addressees_proposed_edited",
     effectiveKey: "addressees_proposed_effective",
     side: "proposed",
+    researchKey: "anzahl_betroffene_vorschlag",
     columnLabel: "Betroffene",
-    reviewLabel: "Vorschlag Betroffene",
+    reviewLabel: "Gesetzesentwurf Betroffene",
   },
   {
     key: "annual_frequency_proposed",
     editedKey: "annual_frequency_proposed_edited",
     effectiveKey: "annual_frequency_proposed_effective",
     side: "proposed",
+    researchKey: "haeufigkeit_pro_jahr_vorschlag",
     columnLabel: "Häufigkeit",
-    reviewLabel: "Vorschlag Häufigkeit",
+    reviewLabel: "Gesetzesentwurf Häufigkeit",
   },
 ] as const;
 
@@ -69,6 +73,78 @@ type CaseDraftRow = Record<CaseFieldKey, string>;
 type CaseDraft = Record<number, CaseDraftRow>;
 type CaseParsedValues = Record<CaseFieldKey, number | null>;
 type CaseChangedCells = Record<CaseFieldKey, boolean>;
+type ResearchEvidence = {
+  confidence?: string;
+  explanation?: string;
+};
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function parseResearchMetadata(
+  raw: EditableCaseGroupRow["case_metric_research_json"]
+): Record<string, ResearchEvidence> {
+  const parsed = typeof raw === "string" ? safeJsonParse(raw) : raw;
+  const metadata = asRecord(parsed);
+  if (!metadata) {
+    return {};
+  }
+  const confidence = asRecord(metadata.confidence);
+  const explanations = asRecord(metadata.erklaerungen);
+  const result: Record<string, ResearchEvidence> = {};
+  for (const field of CASE_FIELDS) {
+    const key = field.researchKey;
+    const explanation = explanations?.[key];
+    const confidenceValue = confidence?.[key];
+    result[key] = {
+      confidence: typeof confidenceValue === "string" ? confidenceValue : undefined,
+      explanation: typeof explanation === "string" ? explanation : undefined,
+    };
+  }
+  return result;
+}
+
+function safeJsonParse(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+}
+
+function EvidenceDisclosure({
+  evidence,
+  dimmed,
+}: {
+  evidence?: ResearchEvidence;
+  dimmed: boolean;
+}) {
+  if (!evidence?.confidence && !evidence?.explanation) {
+    return null;
+  }
+  const confidence = evidence.confidence || "unbekannt";
+  return (
+    <details className={`mt-1 text-[10px] ${dimmed ? "opacity-40" : ""}`}>
+      <summary className="inline-flex cursor-pointer list-none items-center gap-1 rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 font-semibold text-slate-600">
+        <span>{confidence}</span>
+        <span aria-hidden="true">▾</span>
+      </summary>
+      {evidence.explanation && (
+        <div className="mt-1 max-w-[13rem] rounded-lg border border-slate-200 bg-slate-50 px-2 py-1 leading-snug text-slate-600">
+          {dimmed && (
+            <div className="mb-1 font-semibold text-slate-500">
+              Hinweis zum Modellwert
+            </div>
+          )}
+          {evidence.explanation}
+        </div>
+      )}
+    </details>
+  );
+}
 
 function buildCaseDraftRow(row: EditableCaseGroupRow): CaseDraftRow {
   const draft = {} as CaseDraftRow;
@@ -311,13 +387,13 @@ export default function EaCaseMetricsTab({
               <tr className="border-b border-slate-200 text-left text-slate-600">
                 <th className="px-2 py-2">Fallgruppe</th>
                 <th className="bg-sky-50 px-2 py-2 text-sky-900" colSpan={3}>
-                  Gültig
+                  Aktuelles Gesetz
                 </th>
                 <th
                   className="border-l border-slate-200 bg-emerald-50 px-2 py-2 text-emerald-900"
                   colSpan={3}
                 >
-                  Vorschlag
+                  Gesetzesentwurf
                 </th>
               </tr>
               <tr className="border-b border-slate-200 text-left text-slate-500">
@@ -345,6 +421,7 @@ export default function EaCaseMetricsTab({
               {rows.map((row) => {
                 const draftRow = draft[row.case_group_id] || buildCaseDraftRow(row);
                 const changedCellsByField = changedByCaseGroupId.get(row.case_group_id);
+                const researchEvidence = parseResearchMetadata(row.case_metric_research_json);
                 const inputClass = (value: string) =>
                   `w-24 rounded px-2 py-1 ${
                     isValidNullableNumberInput(value)
@@ -374,6 +451,10 @@ export default function EaCaseMetricsTab({
                           onChange={(event) => updateField(field.key, event.target.value)}
                           className={inputClass(draftRow[field.key])}
                         />
+                        <EvidenceDisclosure
+                          evidence={researchEvidence[field.researchKey]}
+                          dimmed={Boolean(changedCellsByField?.[field.key])}
+                        />
                       </td>
                     ))}
                     <td
@@ -396,6 +477,10 @@ export default function EaCaseMetricsTab({
                           value={draftRow[field.key]}
                           onChange={(event) => updateField(field.key, event.target.value)}
                           className={inputClass(draftRow[field.key])}
+                        />
+                        <EvidenceDisclosure
+                          evidence={researchEvidence[field.researchKey]}
+                          dimmed={Boolean(changedCellsByField?.[field.key])}
                         />
                       </td>
                     ))}

--- a/frontend/src/components/ea_edit/EaEditDrawerShell.tsx
+++ b/frontend/src/components/ea_edit/EaEditDrawerShell.tsx
@@ -5,6 +5,7 @@ import { createPortal } from "react-dom";
 
 import { useApp } from "@/contexts/AppContext";
 import { useMounted } from "@/lib/useMounted";
+import type { NormAddressee } from "@/types";
 
 import EaCaseMetricsTab from "./EaCaseMetricsTab";
 import EaEffortMetricsTab from "./EaEffortMetricsTab";
@@ -18,6 +19,12 @@ type EaEditDrawerShellProps = {
 };
 
 type EditorTab = "pay_rates" | "case_metrics" | "effort_metrics";
+
+const NORM_ADDRESSEE_LABELS: Record<NormAddressee, string> = {
+  administration: "Verwaltung",
+  business: "Wirtschaft",
+  citizens: "Bürgerinnen und Bürger",
+};
 
 const TAB_COPY: Record<EditorTab, { title: string; hint: string }> = {
   pay_rates: {
@@ -70,6 +77,8 @@ export default function EaEditDrawerShell({ open, onClose }: EaEditDrawerShellPr
     return null;
   }
 
+  const normAddresseeLabel = NORM_ADDRESSEE_LABELS[state.selectedNormAddressee];
+
   const body = (
     <div className="pointer-events-none fixed inset-0 z-[85]">
       <div className="absolute inset-0 bg-slate-900/25" />
@@ -85,7 +94,9 @@ export default function EaEditDrawerShell({ open, onClose }: EaEditDrawerShellPr
         >
           <header className="border-b border-slate-200 bg-slate-50 px-4 py-3">
             <div className="flex items-center justify-between">
-              <div className="text-sm font-semibold text-slate-900">EA bearbeiten</div>
+              <div className="text-sm font-semibold text-slate-900">
+                Erfüllungsaufwand bearbeiten für {normAddresseeLabel}
+              </div>
               <button
                 onClick={requestClose}
                 className="rounded-full border border-slate-300 px-3 py-1 text-xs font-semibold text-slate-700"

--- a/frontend/src/components/ea_edit/EaEditDrawerShell.tsx
+++ b/frontend/src/components/ea_edit/EaEditDrawerShell.tsx
@@ -26,11 +26,11 @@ const TAB_COPY: Record<EditorTab, { title: string; hint: string }> = {
   },
   case_metrics: {
     title: "Fallzahlen",
-    hint: "Bearbeite Betroffene und Häufigkeit je Fallgruppe für Gültig und Vorschlag.",
+    hint: "Bearbeite Betroffene und Häufigkeit je Fallgruppe für aktuelles Gesetz und Gesetzesentwurf.",
   },
   effort_metrics: {
     title: "Schrittkosten",
-    hint: "Bearbeite Zeitaufwand und Sachaufwand je Prozessschritt für Gültig und Vorschlag.",
+    hint: "Bearbeite Zeitaufwand und Sachaufwand je Prozessschritt für aktuelles Gesetz und Gesetzesentwurf.",
   },
 };
 

--- a/frontend/src/components/ea_edit/EaEffortMetricsTab.tsx
+++ b/frontend/src/components/ea_edit/EaEffortMetricsTab.tsx
@@ -113,7 +113,7 @@ function getReviewLabel(
   slot: PayGradeSlot,
   side: "current" | "proposed",
 ): string {
-  const sidePrefix = side === "current" ? "Gültig" : "Vorschlag";
+  const sidePrefix = side === "current" ? "Aktuelles Gesetz" : "Gesetzesentwurf";
   if (slot === "expenses") {
     return `${sidePrefix} Sachaufwand`;
   }
@@ -689,13 +689,13 @@ export default function EaEffortMetricsTab({
               <tr className="border-b border-slate-200 text-left text-slate-600">
                 <th className="px-2 py-2">Schritt</th>
                 <th className="bg-sky-50 px-2 py-2 text-sky-900" colSpan={currentFields.length}>
-                  Gültig
+                  Aktuelles Gesetz
                 </th>
                 <th
                   className="border-l border-slate-200 bg-emerald-50 px-2 py-2 text-emerald-900"
                   colSpan={proposedFields.length}
                 >
-                  Vorschlag
+                  Gesetzesentwurf
                 </th>
               </tr>
               <tr className="border-b border-slate-200 text-left text-slate-500">

--- a/frontend/src/components/ea_edit/__tests__/EaCaseMetricsTab.test.tsx
+++ b/frontend/src/components/ea_edit/__tests__/EaCaseMetricsTab.test.tsx
@@ -74,7 +74,7 @@ describe("EaCaseMetricsTab", () => {
     await user.clear(inputs[0]);
     await user.type(inputs[0], "13");
     await user.click(screen.getByRole("button", { name: /prüfen/i }));
-    expect(screen.getByText("Gültig Betroffene")).toBeInTheDocument();
+    expect(screen.getByText("Aktuelles Gesetz Betroffene")).toBeInTheDocument();
     expect(screen.getAllByRole("cell", { name: "10" })).toHaveLength(2);
     expect(screen.getByRole("cell", { name: "13" })).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: /änderungen speichern/i }));
@@ -146,6 +146,73 @@ describe("EaCaseMetricsTab", () => {
 
     expect(inputs[0].closest("td")).toHaveClass("bg-amber-50");
     expect(inputs[1].closest("td")).not.toHaveClass("bg-amber-50");
+  });
+
+  it("shows research evidence and marks it as model evidence after edits", async () => {
+    mockGetEditableCaseGroups.mockResolvedValueOnce({
+      rows: [
+        {
+          case_group_id: 11,
+          norm_addressee: "administration",
+          process_id: 1,
+          case_group: "Fallgruppe A",
+          description: "Beschreibung",
+          change_status: "geaendert",
+          addressees_current: 10,
+          annual_frequency_current: 2,
+          cases_current: 20,
+          addressees_current_edited: null,
+          annual_frequency_current_edited: null,
+          cases_current_edited: null,
+          addressees_proposed: 12,
+          annual_frequency_proposed: 2,
+          cases_proposed: 24,
+          addressees_proposed_edited: null,
+          annual_frequency_proposed_edited: null,
+          cases_proposed_edited: null,
+          addressees_current_effective: 10,
+          annual_frequency_current_effective: 2,
+          cases_current_effective: 20,
+          addressees_proposed_effective: 12,
+          annual_frequency_proposed_effective: 2,
+          cases_proposed_effective: 24,
+          case_metric_research_json: {
+            confidence: {
+              anzahl_betroffene_gueltig: "high",
+            },
+            erklaerungen: {
+              anzahl_betroffene_gueltig:
+                "Destatis weist eine passende Grundgesamtheit aus.",
+            },
+          },
+        },
+      ],
+    });
+    render(
+      <EaCaseMetricsTab normAddressee="administration"
+        open
+        active
+        appSessionId="CASE-TAB"
+        runAutoRecompute={jest.fn()}
+      />
+    );
+    const row = await screen.findByText("Fallgruppe A");
+    const tr = row.closest("tr");
+    expect(tr).toBeTruthy();
+    const evidence = screen.getByText("high").closest("details");
+    expect(evidence).toBeTruthy();
+    expect(evidence).not.toHaveClass("opacity-40");
+    expect(
+      screen.getByText("Destatis weist eine passende Grundgesamtheit aus.")
+    ).toBeInTheDocument();
+
+    const user = userEvent.setup();
+    const inputs = within(tr as HTMLElement).getAllByRole("textbox");
+    await user.clear(inputs[0]);
+    await user.type(inputs[0], "13");
+
+    expect(screen.getByText("high").closest("details")).toHaveClass("opacity-40");
+    expect(screen.getByText("Hinweis zum Modellwert")).toBeInTheDocument();
   });
 
   it("renders zeros in a lighter text color", async () => {

--- a/frontend/src/components/ea_edit/__tests__/EaEditDrawerShell.test.tsx
+++ b/frontend/src/components/ea_edit/__tests__/EaEditDrawerShell.test.tsx
@@ -102,6 +102,7 @@ describe("EaEditDrawerShell", () => {
     mockUseApp.mockReturnValue({
       state: {
         appSessionId: "EA-TEST",
+        selectedNormAddressee: "administration",
       },
     });
   });
@@ -209,7 +210,9 @@ describe("EaEditDrawerShell", () => {
 
     const overlay = document.querySelector("div.pointer-events-none.fixed.inset-0.z-\\[85\\]");
     expect(overlay).toBeTruthy();
-    const panel = screen.getByText("EA bearbeiten").closest("section");
+    const panel = screen
+      .getByText("Erfüllungsaufwand bearbeiten für Verwaltung")
+      .closest("section");
     expect(panel).toHaveClass("pointer-events-auto");
   });
 

--- a/frontend/src/components/ea_edit/__tests__/EaEffortMetricsTab.test.tsx
+++ b/frontend/src/components/ea_edit/__tests__/EaEffortMetricsTab.test.tsx
@@ -99,7 +99,7 @@ describe("EaEffortMetricsTab", () => {
     await user.clear(inputs[0]);
     await user.type(inputs[0], "7");
     await user.click(screen.getByRole("button", { name: /prüfen/i }));
-    expect(screen.getByText("Gültig Zeit eD/mD")).toBeInTheDocument();
+    expect(screen.getByText("Aktuelles Gesetz Zeit eD/mD")).toBeInTheDocument();
     expect(screen.getAllByRole("cell", { name: "1" })).toHaveLength(2);
     expect(screen.getByRole("cell", { name: "7" })).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: /änderungen speichern/i }));

--- a/frontend/src/components/tileMetrics.ts
+++ b/frontend/src/components/tileMetrics.ts
@@ -144,7 +144,11 @@ function parseLegacyStepText(text: string): ParsedLegacyTable {
       continue;
     }
     const lower = line.toLowerCase();
-    if (lower.includes("gültig") && lower.includes("vorschlag") && line.includes("|")) {
+    if (
+      ((lower.includes("gültig") && lower.includes("vorschlag")) ||
+        (lower.includes("aktuell") && lower.includes("entwurf"))) &&
+      line.includes("|")
+    ) {
       continue;
     }
     const match = line.match(rowRegex);
@@ -182,11 +186,11 @@ function parseLegacyCaseText(text: string): ParsedLegacyTable {
       continue;
     }
     const lower = line.toLowerCase();
-    if (lower === "gültig:") {
+    if (lower === "gültig:" || lower === "gueltig:" || lower === "aktuell:") {
       section = "current";
       continue;
     }
-    if (lower === "vorschlag:") {
+    if (lower === "vorschlag:" || lower === "entwurf:") {
       section = "proposed";
       continue;
     }

--- a/frontend/src/contexts/AppContext.tsx
+++ b/frontend/src/contexts/AppContext.tsx
@@ -108,13 +108,7 @@ const APP_SESSION_STORAGE_KEY = "app_session_id";
 const LEGACY_SESSION_STORAGE_KEY = "session_id";
 const SELECTED_NORM_ADDRESSEE_STORAGE_KEY = "selected_norm_addressee";
 
-// Lazy-Initializer fuer selectedNormAddressee: liest den zuletzt gewaehlten
-// Adressaten aus SessionStorage, damit nach Reload keine Verwaltung-Flash
-// entsteht und die Anzeige konsistent mit dem vorherigen User-Zustand ist.
 function readStoredNormAddressee(): NormAddressee {
-  if (typeof window === "undefined") {
-    return "administration";
-  }
   try {
     const stored = sessionStorage.getItem(SELECTED_NORM_ADDRESSEE_STORAGE_KEY);
     if (stored === "administration" || stored === "business" || stored === "citizens") {
@@ -149,7 +143,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
   const [appSessionId, setAppSessionIdState] = useState("");
   const [isFreshAppSessionId, setIsFreshAppSessionId] = useState(false);
   const [selectedNormAddressee, setSelectedNormAddresseeState] =
-    useState<NormAddressee>(readStoredNormAddressee);
+    useState<NormAddressee>("administration");
   const [selectedModel, setSelectedModel] = useState("");
   const [selectedModelHydrated, setSelectedModelHydrated] = useState(false);
   const [availableModels, setAvailableModels] = useState<Model[]>([]);
@@ -285,6 +279,16 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     sessionStorage.setItem(APP_SESSION_STORAGE_KEY, appSessionId);
     sessionStorage.removeItem(LEGACY_SESSION_STORAGE_KEY);
   }, [appSessionId, readinessSetters, logDebug]);
+
+  useEffect(() => {
+    const storedNormAddressee = readStoredNormAddressee();
+    if (storedNormAddressee !== selectedNormAddressee) {
+      setSelectedNormAddresseeState(storedNormAddressee);
+    }
+    // Only run after hydration. Reading sessionStorage in the state initializer
+    // makes the first client render differ from the server-rendered header.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   useEffect(() => {
     sessionStorage.setItem(

--- a/frontend/src/contexts/AppContext.tsx
+++ b/frontend/src/contexts/AppContext.tsx
@@ -76,6 +76,9 @@ interface AppState {
   totalCostReady: boolean;
   lastCompletedStep: string | null;
   lastCompletedLabel: string | null;
+  lastFailedStep: string | null;
+  lastFailedLabel: string | null;
+  lastFailedMessage: string | null;
 }
 
 interface AppContextValue {
@@ -101,6 +104,9 @@ interface AppContextValue {
   setTotalCostReady: (ready: boolean) => void;
   setLastCompletedStep: (step: string | null) => void;
   setLastCompletedLabel: (label: string | null) => void;
+  setLastFailedStep: (step: string | null) => void;
+  setLastFailedLabel: (label: string | null) => void;
+  setLastFailedMessage: (message: string | null) => void;
 }
 
 const AppContext = createContext<AppContextValue | undefined>(undefined);
@@ -166,6 +172,9 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
   >(createDefaultAddresseeReadiness);
   const [lastCompletedStep, setLastCompletedStep] = useState<string | null>(null);
   const [lastCompletedLabel, setLastCompletedLabel] = useState<string | null>(null);
+  const [lastFailedStep, setLastFailedStep] = useState<string | null>(null);
+  const [lastFailedLabel, setLastFailedLabel] = useState<string | null>(null);
+  const [lastFailedMessage, setLastFailedMessage] = useState<string | null>(null);
   const appSessionIdAttempts = useRef(0);
   const readinessSetters = useMemo<
     Record<ReadinessStorageKey, (value: boolean) => void>
@@ -362,6 +371,9 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
         );
         setLastCompletedStep(status.last_completed_step ?? null);
         setLastCompletedLabel(status.last_completed_label ?? null);
+        setLastFailedStep(status.last_failed_step ?? null);
+        setLastFailedLabel(status.last_failed_label ?? null);
+        setLastFailedMessage(status.last_failed_message ?? null);
       } catch (error) {
         const status =
           typeof (error as { status?: unknown })?.status === "number"
@@ -576,6 +588,9 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
           totalCostReady,
           lastCompletedStep,
           lastCompletedLabel,
+          lastFailedStep,
+          lastFailedLabel,
+          lastFailedMessage,
         },
         setCurrentTab,
         setAppSessionId,
@@ -696,6 +711,9 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
           ),
         setLastCompletedStep,
         setLastCompletedLabel,
+        setLastFailedStep,
+        setLastFailedLabel,
+        setLastFailedMessage,
       }}
     >
       {children}

--- a/frontend/src/contexts/__tests__/AppContext.test.tsx
+++ b/frontend/src/contexts/__tests__/AppContext.test.tsx
@@ -1,5 +1,6 @@
 import { render, waitFor } from "@testing-library/react";
 import React from "react";
+import { renderToString } from "react-dom/server.node";
 
 import { AppProvider, useApp } from "@/contexts/AppContext";
 import { apiClient } from "@/lib/api";
@@ -118,5 +119,17 @@ describe("AppContext session status sync", () => {
       const node = getByTestId("state");
       expect(node.getAttribute("data-addressee")).toBe("citizens");
     });
+  });
+
+  it("keeps server-rendered norm addressee deterministic for hydration", () => {
+    sessionStorage.setItem("selected_norm_addressee", "citizens");
+
+    const html = renderToString(
+      <AppProvider>
+        <ContextProbe />
+      </AppProvider>
+    );
+
+    expect(html).toContain('data-addressee="administration"');
   });
 });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -244,26 +244,6 @@ export const apiClient = {
     return response.json();
   },
 
-  async deleteTile(
-    tileId: string,
-    appSessionId: string,
-    normAddressee?: NormAddressee
-  ): Promise<void> {
-    const params = new URLSearchParams({
-      app_session_id: appSessionId,
-    });
-    if (normAddressee && normAddressee !== "administration") {
-      params.set("norm_addressee", normAddressee);
-    }
-    const query = `?${params.toString()}`;
-    const response = await fetch(`${API_BASE_URL}/tiles/${tileId}${query}`, {
-      method: "DELETE",
-    });
-    if (!response.ok) {
-      await throwApiClientErrorFromResponse(response, "Failed to delete tile");
-    }
-  },
-
   async rebuildTiles(
     appSessionId: string,
     normAddressee?: NormAddressee

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -406,6 +406,61 @@ export const apiClient = {
     }
     return response.json();
   },
+  async startStepRun(
+    options: {
+      appSessionId: string;
+      stepKey: string;
+      currentFilename?: string;
+      proposedFilename?: string;
+      model?: string;
+      provider?: string;
+      keys?: ApiKeys;
+    }
+  ): Promise<RunAllStartResponse> {
+    const response = await fetch(`${API_BASE_URL}/sessions/step-runs/start`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...buildKeyHeaders(options.keys || {}),
+      },
+      body: JSON.stringify({
+        app_session_id: options.appSessionId,
+        step_key: options.stepKey,
+        current_filename: options.currentFilename,
+        proposed_filename: options.proposedFilename,
+        model: options.model,
+        provider: options.provider,
+      }),
+    });
+    if (!response.ok) {
+      await throwApiClientErrorFromResponse(response, "Failed to start step");
+    }
+    return response.json();
+  },
+  async getStepRunStatus(runId: string): Promise<RunAllStatusResponse> {
+    const response = await fetch(
+      `${API_BASE_URL}/sessions/step-runs/${encodeURIComponent(runId)}`
+    );
+    if (!response.ok) {
+      await throwApiClientErrorFromResponse(response, "Failed to load step status");
+    }
+    return response.json();
+  },
+  getStepRunEventsUrl(runId: string): string {
+    return `${API_BASE_URL}/sessions/step-runs/${encodeURIComponent(runId)}/events`;
+  },
+  async cancelStepRun(runId: string): Promise<RunAllCancelResponse> {
+    const response = await fetch(
+      `${API_BASE_URL}/sessions/step-runs/${encodeURIComponent(runId)}/cancel`,
+      {
+        method: "POST",
+      }
+    );
+    if (!response.ok) {
+      await throwApiClientErrorFromResponse(response, "Failed to cancel step");
+    }
+    return response.json();
+  },
   async getRunAllStatus(runId: string): Promise<RunAllStatusResponse> {
     const response = await fetch(
       `${API_BASE_URL}/sessions/run-all/${encodeURIComponent(runId)}`

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -23,6 +23,7 @@ import {
   EditableCaseGroupsResponse,
   EditableProcessStepsResponse,
   NormAddressee,
+  CaseGroupResearchSettingsResponse,
 } from "@/types";
 
 const API_BASE_URL =
@@ -343,6 +344,58 @@ export const apiClient = {
       await throwApiClientErrorFromResponse(response, "Failed to export session");
     }
     return response.json();
+  },
+  async getCaseGroupResearchSettings(
+    appSessionId: string
+  ): Promise<CaseGroupResearchSettingsResponse> {
+    const response = await fetch(
+      `${API_BASE_URL}/sessions/case-group-research?app_session_id=${encodeURIComponent(
+        appSessionId
+      )}`
+    );
+    if (!response.ok) {
+      await throwApiClientErrorFromResponse(
+        response,
+        "Failed to load Deep Research settings"
+      );
+    }
+    return response.json();
+  },
+  async updateCaseGroupResearchSettings(
+    appSessionId: string,
+    enabled: boolean
+  ): Promise<CaseGroupResearchSettingsResponse> {
+    const response = await fetch(`${API_BASE_URL}/sessions/case-group-research`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        app_session_id: appSessionId,
+        enabled,
+      }),
+    });
+    if (!response.ok) {
+      await throwApiClientErrorFromResponse(
+        response,
+        "Failed to update Deep Research settings"
+      );
+    }
+    return response.json();
+  },
+  async downloadDeepResearchReport(appSessionId: string): Promise<Blob> {
+    const response = await fetch(
+      `${API_BASE_URL}/sessions/deep-research-report?app_session_id=${encodeURIComponent(
+        appSessionId
+      )}&format=pdf`
+    );
+    if (!response.ok) {
+      await throwApiClientErrorFromResponse(
+        response,
+        "Failed to download Deep Research report"
+      );
+    }
+    return response.blob();
   },
   async startRunAllSteps(
     options: {

--- a/frontend/src/lib/runAllStepEvents.ts
+++ b/frontend/src/lib/runAllStepEvents.ts
@@ -13,20 +13,41 @@ export type RunAllStepKey =
 
 export const RUN_ALL_STEP_STARTED_EVENT = "run-all-step-started";
 export const RUN_ALL_STEP_CLEARED_EVENT = "run-all-step-cleared";
+export type WorkflowRunKind = "run_all" | "step";
+
 let currentRunAllStepKey: string | null = null;
+let currentRunAllRunId: string | null = null;
+let currentWorkflowRunKind: WorkflowRunKind | null = null;
+let currentWorkflowRunLabel: string | null = null;
 
 type RunAllStepStartedDetail = {
   key?: string;
+  runId?: string;
+  runKind?: WorkflowRunKind;
+  label?: string;
 };
 
-export function emitRunAllStepStarted(key?: string | null): void {
+export function emitRunAllStepStarted(
+  key?: string | null,
+  runId?: string | null,
+  runKind: WorkflowRunKind = "run_all",
+  label?: string | null
+): void {
   if (typeof window === "undefined") {
     return;
   }
   currentRunAllStepKey = key ? String(key) : null;
+  currentRunAllRunId = runId ? String(runId) : null;
+  currentWorkflowRunKind = runKind;
+  currentWorkflowRunLabel = label ? String(label) : null;
   window.dispatchEvent(
     new CustomEvent<RunAllStepStartedDetail>(RUN_ALL_STEP_STARTED_EVENT, {
-      detail: key ? { key } : {},
+      detail: {
+        ...(key ? { key } : {}),
+        ...(runId ? { runId } : {}),
+        runKind,
+        ...(label ? { label } : {}),
+      },
     })
   );
 }
@@ -36,20 +57,47 @@ export function emitRunAllStepCleared(): void {
     return;
   }
   currentRunAllStepKey = null;
+  currentRunAllRunId = null;
+  currentWorkflowRunKind = null;
+  currentWorkflowRunLabel = null;
   window.dispatchEvent(new Event(RUN_ALL_STEP_CLEARED_EVENT));
 }
 
-export function useRunAllStepBusy(stepKey: RunAllStepKey): boolean {
-  const [isBusy, setIsBusy] = useState(currentRunAllStepKey === stepKey);
+export type WorkflowRunState = {
+  isActive: boolean;
+  stepKey: string | null;
+  runId: string | null;
+  runKind: WorkflowRunKind | null;
+  label: string | null;
+};
+
+export function useRunAllStepRun(stepKey: RunAllStepKey): {
+  isBusy: boolean;
+  runId: string | null;
+  runKind: WorkflowRunKind | null;
+} {
+  const [state, setState] = useState({
+    isBusy: currentRunAllStepKey === stepKey,
+    runId: currentRunAllStepKey === stepKey ? currentRunAllRunId : null,
+    runKind: currentRunAllStepKey === stepKey ? currentWorkflowRunKind : null,
+  });
 
   useEffect(() => {
-    setIsBusy(currentRunAllStepKey === stepKey);
+    setState({
+      isBusy: currentRunAllStepKey === stepKey,
+      runId: currentRunAllStepKey === stepKey ? currentRunAllRunId : null,
+      runKind: currentRunAllStepKey === stepKey ? currentWorkflowRunKind : null,
+    });
     const handleStarted = (event: Event) => {
       const detail = (event as CustomEvent<RunAllStepStartedDetail>).detail;
-      setIsBusy(detail?.key === stepKey);
+      setState({
+        isBusy: detail?.key === stepKey,
+        runId: detail?.key === stepKey ? detail?.runId ?? null : null,
+        runKind: detail?.key === stepKey ? detail?.runKind ?? null : null,
+      });
     };
     const handleCleared = () => {
-      setIsBusy(false);
+      setState({ isBusy: false, runId: null, runKind: null });
     };
 
     window.addEventListener(RUN_ALL_STEP_STARTED_EVENT, handleStarted);
@@ -60,5 +108,57 @@ export function useRunAllStepBusy(stepKey: RunAllStepKey): boolean {
     };
   }, [stepKey]);
 
-  return isBusy;
+  return state;
+}
+
+export function useRunAllStepBusy(stepKey: RunAllStepKey): boolean {
+  return useRunAllStepRun(stepKey).isBusy;
+}
+
+export function useActiveWorkflowRun(): WorkflowRunState {
+  const [state, setState] = useState<WorkflowRunState>({
+    isActive: Boolean(currentRunAllRunId),
+    stepKey: currentRunAllStepKey,
+    runId: currentRunAllRunId,
+    runKind: currentWorkflowRunKind,
+    label: currentWorkflowRunLabel,
+  });
+
+  useEffect(() => {
+    setState({
+      isActive: Boolean(currentRunAllRunId),
+      stepKey: currentRunAllStepKey,
+      runId: currentRunAllRunId,
+      runKind: currentWorkflowRunKind,
+      label: currentWorkflowRunLabel,
+    });
+    const handleStarted = (event: Event) => {
+      const detail = (event as CustomEvent<RunAllStepStartedDetail>).detail;
+      setState({
+        isActive: Boolean(detail?.runId),
+        stepKey: detail?.key ?? null,
+        runId: detail?.runId ?? null,
+        runKind: detail?.runKind ?? null,
+        label: detail?.label ?? null,
+      });
+    };
+    const handleCleared = () => {
+      setState({
+        isActive: false,
+        stepKey: null,
+        runId: null,
+        runKind: null,
+        label: null,
+      });
+    };
+
+    window.addEventListener(RUN_ALL_STEP_STARTED_EVENT, handleStarted);
+    window.addEventListener(RUN_ALL_STEP_CLEARED_EVENT, handleCleared);
+    return () => {
+      window.removeEventListener(RUN_ALL_STEP_STARTED_EVENT, handleStarted);
+      window.removeEventListener(RUN_ALL_STEP_CLEARED_EVENT, handleCleared);
+    };
+  }, []);
+
+  return state;
 }

--- a/frontend/src/lib/sessionStatus.ts
+++ b/frontend/src/lib/sessionStatus.ts
@@ -8,6 +8,11 @@ export type SessionStatusFlags = {
   total_cost_ready: boolean;
 };
 
+export type FailedStepStatusSource = {
+  lastFailedStep?: string | null;
+  lastFailedMessage?: string | null;
+};
+
 export function deriveTabFromStatus(status: SessionStatusFlags): number {
   if (!status.summary_ready) return 0;
   if (!status.regulations_ready) return 1;
@@ -16,4 +21,16 @@ export function deriveTabFromStatus(status: SessionStatusFlags): number {
   if (!status.process_steps_ready) return 4;
   if (!status.effort_ready) return 5;
   return 6;
+}
+
+export function getVisibleFailedStepStatus(
+  status: FailedStepStatusSource,
+  stepKey: string,
+  isStepReady: boolean,
+  activeStatusText: string | null
+): string | null {
+  if (activeStatusText || isStepReady || status.lastFailedStep !== stepKey) {
+    return null;
+  }
+  return status.lastFailedMessage || null;
 }

--- a/frontend/src/lib/useCancellableStepRun.ts
+++ b/frontend/src/lib/useCancellableStepRun.ts
@@ -1,0 +1,168 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import { apiClient, ApiKeys } from "@/lib/api";
+import { logClientError } from "@/lib/errorFeedback";
+import { RunAllStatusResponse, SessionStatus } from "@/types";
+
+type UseCancellableStepRunOptions = {
+  appSessionId: string;
+  stepKey: string;
+  stepLabel: string;
+  model?: string;
+  provider?: string;
+  keys?: ApiKeys;
+  onFinalStatus?: (status: SessionStatus) => void;
+  onCompleted?: (status: RunAllStatusResponse) => void;
+  onFailed?: (message: string) => void;
+  onCancelled?: () => void;
+  logScope: string;
+};
+
+type StepRunStartOverrides = {
+  currentFilename?: string;
+  proposedFilename?: string;
+};
+
+function finalMessage(status: RunAllStatusResponse): string {
+  const failedStep = status.steps.find((step) => step.status === "failed");
+  return (
+    failedStep?.message ||
+    status.last_error ||
+    "Der Schritt konnte nicht vollständig ausgeführt werden."
+  );
+}
+
+export function useCancellableStepRun({
+  appSessionId,
+  stepKey,
+  stepLabel,
+  model,
+  provider,
+  keys,
+  onFinalStatus,
+  onCompleted,
+  onFailed,
+  onCancelled,
+  logScope,
+}: UseCancellableStepRunOptions) {
+  const [runId, setRunId] = useState<string | null>(null);
+  const [isRunning, setIsRunning] = useState(false);
+  const [isCancelling, setIsCancelling] = useState(false);
+  const [statusText, setStatusText] = useState<string | null>(null);
+  const pollTimerRef = useRef<number | null>(null);
+
+  const clearPoll = () => {
+    if (pollTimerRef.current !== null) {
+      window.clearTimeout(pollTimerRef.current);
+      pollTimerRef.current = null;
+    }
+  };
+
+  useEffect(() => clearPoll, []);
+
+  const finish = (status: RunAllStatusResponse) => {
+    clearPoll();
+    setRunId(null);
+    setIsRunning(false);
+    setIsCancelling(false);
+    if (status.final_status) {
+      onFinalStatus?.(status.final_status);
+    }
+    if (status.status === "completed" && status.ok !== false) {
+      setStatusText(null);
+      onCompleted?.(status);
+      return;
+    }
+    if (status.status === "cancelled") {
+      setStatusText("Ausführung abgebrochen. Der Schritt wurde nicht abgeschlossen.");
+      onCancelled?.();
+      return;
+    }
+    const message = finalMessage(status);
+    setStatusText(message);
+    onFailed?.(message);
+  };
+
+  const loadStatus = async (activeRunId: string) => {
+    try {
+      const status = await apiClient.getStepRunStatus(activeRunId);
+      if (status.final_status) {
+        onFinalStatus?.(status.final_status);
+      }
+      if (status.status === "running") {
+        const activeLabel = status.current_label || stepLabel;
+        setStatusText(`Läuft: ${activeLabel}`);
+        poll(activeRunId);
+        return;
+      }
+      finish(status);
+    } catch (error) {
+      logClientError(`${logScope}.poll`, error, {
+        appSessionId,
+        runId: activeRunId,
+      });
+      clearPoll();
+      setRunId(null);
+      setIsRunning(false);
+      setIsCancelling(false);
+      setStatusText("Status konnte nicht aktualisiert werden.");
+    }
+  };
+
+  const poll = (activeRunId: string) => {
+    pollTimerRef.current = window.setTimeout(() => {
+      void loadStatus(activeRunId);
+    }, 500);
+  };
+
+  const start = async (overrides: StepRunStartOverrides = {}) => {
+    setStatusText(null);
+    setIsRunning(true);
+    try {
+      const response = await apiClient.startStepRun({
+        appSessionId,
+        stepKey,
+        currentFilename: overrides.currentFilename,
+        proposedFilename: overrides.proposedFilename,
+        model,
+        provider,
+        keys,
+      });
+      setRunId(response.run_id);
+      setIsCancelling(false);
+      setStatusText(`Läuft: ${stepLabel}`);
+      await loadStatus(response.run_id);
+    } catch (error) {
+      logClientError(`${logScope}.start`, error, { appSessionId });
+      setIsRunning(false);
+      setRunId(null);
+      setIsCancelling(false);
+      throw error;
+    }
+  };
+
+  const cancel = async () => {
+    if (!runId || isCancelling) {
+      return;
+    }
+    setIsCancelling(true);
+    setStatusText("Abbruch angefordert...");
+    try {
+      await apiClient.cancelStepRun(runId);
+    } catch (error) {
+      logClientError(`${logScope}.cancel`, error, { appSessionId, runId });
+      setIsCancelling(false);
+      setStatusText("Abbruch konnte nicht angefordert werden.");
+    }
+  };
+
+  return {
+    isRunning,
+    isCancelling,
+    statusText,
+    start,
+    cancel,
+  };
+}

--- a/frontend/src/lib/useCancellableStepRun.ts
+++ b/frontend/src/lib/useCancellableStepRun.ts
@@ -4,6 +4,11 @@ import { useEffect, useRef, useState } from "react";
 
 import { apiClient, ApiKeys } from "@/lib/api";
 import { logClientError } from "@/lib/errorFeedback";
+import {
+  emitRunAllStepCleared,
+  emitRunAllStepStarted,
+  type RunAllStepKey,
+} from "@/lib/runAllStepEvents";
 import { RunAllStatusResponse, SessionStatus } from "@/types";
 
 type UseCancellableStepRunOptions = {
@@ -64,6 +69,7 @@ export function useCancellableStepRun({
 
   const finish = (status: RunAllStatusResponse) => {
     clearPoll();
+    emitRunAllStepCleared();
     setRunId(null);
     setIsRunning(false);
     setIsCancelling(false);
@@ -107,6 +113,7 @@ export function useCancellableStepRun({
       setRunId(null);
       setIsRunning(false);
       setIsCancelling(false);
+      emitRunAllStepCleared();
       setStatusText("Status konnte nicht aktualisiert werden.");
     }
   };
@@ -133,12 +140,19 @@ export function useCancellableStepRun({
       setRunId(response.run_id);
       setIsCancelling(false);
       setStatusText(`Läuft: ${stepLabel}`);
+      emitRunAllStepStarted(
+        stepKey as RunAllStepKey,
+        response.run_id,
+        "step",
+        stepLabel
+      );
       await loadStatus(response.run_id);
     } catch (error) {
       logClientError(`${logScope}.start`, error, { appSessionId });
       setIsRunning(false);
       setRunId(null);
       setIsCancelling(false);
+      emitRunAllStepCleared();
       throw error;
     }
   };

--- a/frontend/src/lib/useRunAllStepCancel.ts
+++ b/frontend/src/lib/useRunAllStepCancel.ts
@@ -1,0 +1,64 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import { apiClient } from "@/lib/api";
+import { logClientError } from "@/lib/errorFeedback";
+import { RunAllStepKey, useRunAllStepRun } from "@/lib/runAllStepEvents";
+
+type UseRunAllStepCancelOptions = {
+  stepKey: RunAllStepKey;
+  appSessionId: string;
+  setStatus: (status: string | null) => void;
+  logScope: string;
+};
+
+export function useRunAllStepCancel({
+  stepKey,
+  appSessionId,
+  setStatus,
+  logScope,
+}: UseRunAllStepCancelOptions) {
+  const runAllStep = useRunAllStepRun(stepKey);
+  const isRunAllBusy = runAllStep.isBusy && runAllStep.runKind === "run_all";
+  const [isCancellingRunAll, setIsCancellingRunAll] = useState(false);
+  const isCancellingRunAllRef = useRef(false);
+
+  useEffect(() => {
+    if (!isRunAllBusy) {
+      isCancellingRunAllRef.current = false;
+      setIsCancellingRunAll(false);
+    }
+  }, [isRunAllBusy]);
+
+  const cancelRunAllForStep = async () => {
+    if (!runAllStep.runId) {
+      setStatus("Lauf konnte nicht abgebrochen werden: Run-ID fehlt.");
+      return;
+    }
+    if (isCancellingRunAllRef.current) {
+      return;
+    }
+    isCancellingRunAllRef.current = true;
+    setIsCancellingRunAll(true);
+    setStatus("Abbruch angefordert...");
+    try {
+      await apiClient.cancelRunAll(runAllStep.runId);
+    } catch (error) {
+      logClientError(logScope, error, {
+        appSessionId,
+        runId: runAllStep.runId,
+      });
+      isCancellingRunAllRef.current = false;
+      setIsCancellingRunAll(false);
+      setStatus("Abbruch konnte nicht angefordert werden.");
+    }
+  };
+
+  return {
+    isRunAllBusy,
+    isCancellingRunAll,
+    runAllRunId: runAllStep.runId,
+    cancelRunAllForStep,
+  };
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -48,6 +48,7 @@ export interface SessionSummary {
   created_at: string;
   llm_model: string;
   used_llm_models?: string | null;
+  case_group_research_enabled?: boolean;
 }
 
 export interface SessionsResponse {
@@ -67,8 +68,17 @@ export interface SessionStatus {
   effort_ready_by_addressee?: Record<NormAddressee, boolean>;
   total_cost_ready: boolean;
   total_cost_ready_by_addressee?: Record<NormAddressee, boolean>;
+  case_group_research_enabled?: boolean;
+  case_group_research_status?: string;
   last_completed_step?: string | null;
   last_completed_label?: string | null;
+}
+
+export interface CaseGroupResearchSettingsResponse {
+  app_session_id: string;
+  enabled: boolean;
+  status: string;
+  locked: boolean;
 }
 
 export interface UndoStepResponse {
@@ -348,6 +358,7 @@ export interface EditableCaseGroupRow {
   addressees_proposed_effective: number | null;
   annual_frequency_proposed_effective: number | null;
   cases_proposed_effective: number | null;
+  case_metric_research_json?: Record<string, unknown> | unknown[] | string | null;
 }
 
 export interface EditableCaseGroupsResponse {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -111,6 +111,10 @@ export interface RunAllStatusResponse {
   ok?: boolean | null;
   steps: RunAllStepResult[];
   final_status?: SessionStatus | null;
+  current_step?: string | null;
+  current_label?: string | null;
+  current_norm_addressee?: string | null;
+  last_error?: string | null;
 }
 
 export interface RunAllCancelResponse {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -70,6 +70,7 @@ export interface SessionStatus {
   total_cost_ready_by_addressee?: Record<NormAddressee, boolean>;
   case_group_research_enabled?: boolean;
   case_group_research_status?: string;
+  case_group_research_elapsed_seconds?: number | null;
   last_completed_step?: string | null;
   last_completed_label?: string | null;
 }
@@ -79,6 +80,7 @@ export interface CaseGroupResearchSettingsResponse {
   enabled: boolean;
   status: string;
   locked: boolean;
+  elapsed_seconds?: number | null;
 }
 
 export interface UndoStepResponse {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -73,6 +73,9 @@ export interface SessionStatus {
   case_group_research_elapsed_seconds?: number | null;
   last_completed_step?: string | null;
   last_completed_label?: string | null;
+  last_failed_step?: string | null;
+  last_failed_label?: string | null;
+  last_failed_message?: string | null;
 }
 
 export interface CaseGroupResearchSettingsResponse {

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pandas>=2.2.0
 google-genai>=0.6.0
 pytest>=8.0.0
 python-multipart>=0.0.9
+reportlab>=4.2.0

--- a/tests/test_deep_research_cases.py
+++ b/tests/test_deep_research_cases.py
@@ -1,0 +1,54 @@
+from backend.core.deep_research_cases import parse_deep_research_case_metrics
+
+
+def test_parse_deep_research_case_metrics_preserves_field_evidence():
+    payload = """
+    Berichtstext.
+
+    {
+      "prozesse": [
+        {
+          "normadressat": "business",
+          "prozess_id": 10,
+          "fallgruppen": [
+            {
+              "fallgruppen_id": 81,
+              "anzahl_betroffene_gueltig": 500,
+              "haeufigkeit_pro_jahr_gueltig": 1,
+              "fallzahl_gueltig": 500,
+              "anzahl_betroffene_vorschlag": 520,
+              "haeufigkeit_pro_jahr_vorschlag": 2,
+              "fallzahl_vorschlag": 1040,
+              "erklaerungen": {
+                "anzahl_betroffene_gueltig": "500 Unternehmen laut Quelle https://destatis.de/.",
+                "haeufigkeit_pro_jahr_gueltig": "Ein Antrag pro Jahr.",
+                "anzahl_betroffene_vorschlag": "520 Unternehmen wegen erweitertem Kreis.",
+                "haeufigkeit_pro_jahr_vorschlag": "Zwei Meldungen pro Jahr."
+              },
+              "confidence": {
+                "anzahl_betroffene_gueltig": "high",
+                "haeufigkeit_pro_jahr_gueltig": "medium",
+                "anzahl_betroffene_vorschlag": "medium",
+                "haeufigkeit_pro_jahr_vorschlag": "low"
+              },
+              "quellen": ["https://www.destatis.de/DE/Home/_inhalt.html"]
+            }
+          ]
+        }
+      ]
+    }
+    """
+
+    data, parsed = parse_deep_research_case_metrics(payload)
+
+    assert data["prozesse"][0]["prozess_id"] == 10
+    assert len(parsed) == 1
+    entry = parsed[0]
+    assert entry.norm_addressee == "business"
+    assert entry.process_id == 10
+    assert entry.case_group_id == 81
+    assert entry.addressees_current == 500
+    assert entry.annual_frequency_proposed == 2
+    assert entry.metadata["fallzahl_vorschlag"] == 1040
+    assert entry.metadata["confidence"]["haeufigkeit_pro_jahr_vorschlag"] == "low"
+    assert "destatis.de" in entry.metadata["erklaerungen"]["anzahl_betroffene_gueltig"]

--- a/tests/test_deep_research_cases_prompt.py
+++ b/tests/test_deep_research_cases_prompt.py
@@ -100,6 +100,7 @@ def test_build_deep_research_cases_prompt_combines_addressees(monkeypatch):
     assert "anzahl_betroffene_gueltig" in prompt
     assert "haeufigkeit_pro_jahr_vorschlag" in prompt
     assert "kurze Begruendung" in prompt
+    assert "https://www.destatis.de/DE/Home/_inhalt.html" in prompt
     assert '"normadressat": "administration"' in prompt
     assert '"normadressat": "business"' in prompt
     assert '"normadressat": "citizens"' not in prompt

--- a/tests/test_deep_research_cases_prompt.py
+++ b/tests/test_deep_research_cases_prompt.py
@@ -1,0 +1,119 @@
+from backend.core import deep_research_cases_prompt as prompt_builder
+
+
+def test_build_deep_research_cases_prompt_combines_addressees(monkeypatch):
+    session = {
+        "session_id": 123,
+        "app_session_id": "PROMPT1",
+        "law_diff_title": "Testtitel",
+        "law_diff_blurb": "Kurzhinweis",
+        "law_diff_summary": "Zusammenfassung",
+    }
+    regulations = [
+        {
+            "regulation_id": 1,
+            "legal_citation": "§ 1 TestG",
+            "description": "Testvorgabe",
+            "process_id": 10,
+            "change_status": "geaendert",
+            "applies_to_administration": 1,
+            "applies_to_business": 1,
+            "applies_to_citizens": 0,
+            "is_business_information_obligation": 0,
+        }
+    ]
+    processes_by_addressee = {
+        "administration": [
+            {
+                "process_id": 10,
+                "process": "Antraege pruefen",
+                "description": "Verwaltung prueft Antraege.",
+                "change_status": "geaendert",
+            }
+        ],
+        "business": [
+            {
+                "process_id": 20,
+                "process": "Antrag stellen",
+                "description": "Unternehmen stellen Antraege.",
+                "change_status": "geaendert",
+            }
+        ],
+        "citizens": [],
+    }
+    case_groups_by_addressee = {
+        "administration": [
+            {
+                "case_group_id": 100,
+                "process_id": 10,
+                "case_group": "Standardpruefung",
+                "description": "Standardisierte Bearbeitung.",
+                "change_status": "geaendert",
+            }
+        ],
+        "business": [
+            {
+                "case_group_id": 200,
+                "process_id": 20,
+                "case_group": "Standardantrag",
+                "description": "Standardisierte Antragstellung.",
+                "change_status": "geaendert",
+            }
+        ],
+        "citizens": [],
+    }
+
+    monkeypatch.setattr(
+        prompt_builder.db,
+        "get_session_by_app_id",
+        lambda app_session_id: session if app_session_id == "PROMPT1" else None,
+    )
+    monkeypatch.setattr(
+        prompt_builder.db,
+        "get_session_law_texts",
+        lambda session_id: ("Geltendes Recht", "Vorgeschlagenes Recht"),
+    )
+    monkeypatch.setattr(
+        prompt_builder.db,
+        "list_regulations_for_session",
+        lambda session_id: regulations,
+    )
+    monkeypatch.setattr(
+        prompt_builder.db,
+        "list_regulations_for_session_and_addressee",
+        lambda session_id, norm_addressee: regulations,
+    )
+    monkeypatch.setattr(
+        prompt_builder.db,
+        "list_processes_for_session_and_addressee",
+        lambda session_id, norm_addressee: processes_by_addressee[norm_addressee],
+    )
+    monkeypatch.setattr(
+        prompt_builder.db,
+        "list_case_groups_for_session_and_addressee",
+        lambda session_id, norm_addressee: case_groups_by_addressee[norm_addressee],
+    )
+
+    prompt = prompt_builder.build_deep_research_cases_prompt(app_session_id="PROMPT1")
+
+    assert "ein konsistentes Mengenbild ueber alle Normadressaten hinweg" in prompt
+    assert "anzahl_betroffene_gueltig" in prompt
+    assert "haeufigkeit_pro_jahr_vorschlag" in prompt
+    assert "kurze Begruendung" in prompt
+    assert '"normadressat": "administration"' in prompt
+    assert '"normadressat": "business"' in prompt
+    assert '"normadressat": "citizens"' not in prompt
+    assert '"fallgruppen_id": 100' in prompt
+    assert '"fallgruppen_id": 200' in prompt
+    assert "process_steps" not in prompt
+    assert "taetigkeiten_id" not in prompt
+    assert '"gesetz_gueltig"' not in prompt
+    assert '"gesetz_vorschlag"' not in prompt
+
+    prompt_with_laws = prompt_builder.build_deep_research_cases_prompt(
+        app_session_id="PROMPT1",
+        include_law_texts=True,
+    )
+
+    assert '"gesetz_gueltig": "Geltendes Recht"' in prompt_with_laws
+    assert '"gesetz_vorschlag": "Vorgeschlagenes Recht"' in prompt_with_laws

--- a/tests/test_deep_research_service_costs.py
+++ b/tests/test_deep_research_service_costs.py
@@ -26,13 +26,17 @@ class _FakeInteractions:
 
 
 class _FakeClient:
-    def __init__(self, **_kwargs):
+    seen_http_options = None
+
+    def __init__(self, **kwargs):
+        self.__class__.seen_http_options = kwargs.get("http_options")
         self.interactions = _FakeInteractions()
 
 
 def test_deep_research_result_includes_estimated_cost(monkeypatch):
     monkeypatch.setattr(deep_research_service.genai, "Client", _FakeClient)
     _FakeInteractions.callback_seen_before_get = False
+    _FakeClient.seen_http_options = None
     started = []
 
     def record_start(agent, interaction_id):
@@ -48,6 +52,7 @@ def test_deep_research_result_includes_estimated_cost(monkeypatch):
     )
 
     assert started == [("deep-research-preview-04-2026", "interaction-1")]
+    assert _FakeClient.seen_http_options.timeout == 30_000
     assert result.input_tokens == 1_000_000
     assert result.output_tokens == 2_000_000
     assert result.thought_tokens == 500_000

--- a/tests/test_deep_research_service_costs.py
+++ b/tests/test_deep_research_service_costs.py
@@ -1,0 +1,55 @@
+from types import SimpleNamespace
+
+from backend.core import deep_research_service
+
+
+class _FakeInteractions:
+    callback_seen_before_get = False
+
+    def create(self, **_kwargs):
+        return SimpleNamespace(id="interaction-1")
+
+    def get(self, id):
+        assert id == "interaction-1"
+        assert self.callback_seen_before_get is True
+        return SimpleNamespace(
+            id=id,
+            status="completed",
+            outputs=[SimpleNamespace(text="Research report")],
+            usage={
+                "total_input_tokens": "1000000",
+                "total_output_tokens": 2_000_000,
+                "total_thought_tokens": 500_000,
+                "total_tokens": 3_500_000,
+            },
+        )
+
+
+class _FakeClient:
+    def __init__(self, **_kwargs):
+        self.interactions = _FakeInteractions()
+
+
+def test_deep_research_result_includes_estimated_cost(monkeypatch):
+    monkeypatch.setattr(deep_research_service.genai, "Client", _FakeClient)
+    _FakeInteractions.callback_seen_before_get = False
+    started = []
+
+    def record_start(agent, interaction_id):
+        started.append((agent, interaction_id))
+        _FakeInteractions.callback_seen_before_get = True
+
+    result = deep_research_service._run_interaction_sync(
+        api_key="test-key",
+        prompt="prompt",
+        agent="deep-research-preview-04-2026",
+        poll_interval_seconds=1,
+        on_interaction_started=record_start,
+    )
+
+    assert started == [("deep-research-preview-04-2026", "interaction-1")]
+    assert result.input_tokens == 1_000_000
+    assert result.output_tokens == 2_000_000
+    assert result.thought_tokens == 500_000
+    assert result.total_tokens == 3_500_000
+    assert result.estimated_cost_usd == 32.0

--- a/tests/test_effort_flow.py
+++ b/tests/test_effort_flow.py
@@ -1,8 +1,12 @@
+import asyncio
+
+import pytest
+
 from backend.core import db
+from backend.core.auth import ApiKeys
 from backend.core.models import Tile
 from backend.core.norm_addressees import ADMINISTRATION, BUSINESS, CITIZENS
 from backend.routers import effort as effort_router
-import pytest
 
 
 def _is_effort_prompt(prompt: str) -> bool:
@@ -170,8 +174,8 @@ def test_calculate_effort_updates_db_and_tiles(test_client, monkeypatch):
     case_tile = next(tile for tile in tiles if tile.id == f"case_group_{case_group_id}")
     step_tile = next(tile for tile in tiles if tile.id == f"step_{step_one}")
     assert case_tile.text.startswith("Beschreibung Fallgruppe")
-    assert "Gueltig: Betroffene: 100 | Haeufigkeit/Jahr: 2 | Faelle: 200" in case_tile.text
-    assert "Vorschlag: Betroffene: 120 | Haeufigkeit/Jahr: 2 | Faelle: 240" in case_tile.text
+    assert "Aktuell: Betroffene: 100 | Haeufigkeit/Jahr: 2 | Faelle: 200" in case_tile.text
+    assert "Entwurf: Betroffene: 120 | Haeufigkeit/Jahr: 2 | Faelle: 240" in case_tile.text
     assert case_tile.meta_information["addressees_current"] == 100
     assert case_tile.meta_information["annual_frequency_current"] == 2
     assert case_tile.meta_information["cases_current"] == 200
@@ -180,8 +184,8 @@ def test_calculate_effort_updates_db_and_tiles(test_client, monkeypatch):
     assert case_tile.meta_information["cases_proposed"] == 240
 
     assert step_tile.text.startswith("Beschreibung Schritt 1")
-    assert "Gueltig:" in step_tile.text
-    assert "Vorschlag:" in step_tile.text
+    assert "Aktuell:" in step_tile.text
+    assert "Entwurf:" in step_tile.text
     assert step_tile.meta_information["time_required_current"]["a"] == 1
     assert step_tile.meta_information["time_required_proposed"]["a"] == 1.5
     assert step_tile.meta_information["expenses_current"] == 10
@@ -421,6 +425,126 @@ def test_calculate_effort_returns_existing_without_llm_call(test_client, monkeyp
     assert payload["status"] == "existing"
     assert payload["case_groups_updated"] == 0
     assert payload["steps_updated"] == 0
+
+
+def test_public_calculate_effort_ignores_skip_cases_calculation(test_client, monkeypatch):
+    session_id, _ = db.upsert_session("EFFORT-PUBLIC-SKIP", "test-model")
+    _process_id, case_group_id = _seed_case_group(session_id)
+    step_one, _step_two = _seed_steps(session_id, case_group_id)
+
+    cases_response = f"""
+    {{
+      "prozesse": [
+        {{
+          "prozess_id": "1",
+          "fallgruppen": [
+            {{
+              "fallgruppen_id": "{case_group_id}",
+              "anzahl_betroffene_gueltig": "10",
+              "haeufigkeit_pro_jahr_gueltig": "2",
+              "anzahl_betroffene_vorschlag": "12",
+              "haeufigkeit_pro_jahr_vorschlag": "3"
+            }}
+          ]
+        }}
+      ]
+    }}
+    """
+    effort_response = f"""
+    {{
+      "prozesse": [
+        {{
+          "prozess_id": "1",
+          "fallgruppen": [
+            {{
+              "fallgruppen_id": "{case_group_id}",
+              "taetigkeiten": [
+                {{
+                  "taetigkeiten_id": "{step_one}",
+                  "stundenlohn_satz_a_gueltig": "40",
+                  "zeitaufwand_in_min_a_gueltig": "5",
+                  "sachaufwand_gueltig": "1"
+                }}
+              ]
+            }}
+          ]
+        }}
+      ]
+    }}
+    """
+    calls = []
+    monkeypatch.setattr(
+        effort_router,
+        "query_llm",
+        _build_effort_query_llm(cases_response, effort_response, calls=calls),
+    )
+
+    response = test_client.post(
+        "/effort/calculate",
+        json={
+            "app_session_id": "EFFORT-PUBLIC-SKIP",
+            "model": "test-model",
+            "provider": "openai",
+            "skip_cases_calculation": True,
+        },
+    )
+
+    assert response.status_code == 200
+    assert len(calls) == 2
+    case_group = db.list_case_groups_for_session(session_id)[0]
+    assert case_group["addressees_current"] == 10
+    assert case_group["annual_frequency_proposed"] == 3
+
+
+def test_internal_skip_cases_uses_step_only_existing_check(monkeypatch):
+    session_id, _ = db.upsert_session("EFFORT-INTERNAL-SKIP-EXISTING", "test-model")
+    _process_id, case_group_id = _seed_case_group(session_id)
+    step_one, _step_two = _seed_steps(session_id, case_group_id)
+    db.upsert_process_step_effort_split_by_addressee(
+        session_id=session_id,
+        step_id=step_one,
+        norm_addressee=ADMINISTRATION,
+        hourly_rates_current={"a": 40, "b": None, "c": None, "d": None},
+        time_required_current={"a": 5, "b": None, "c": None, "d": None},
+        expenses_current=1,
+        hourly_rates_proposed={"a": None, "b": None, "c": None, "d": None},
+        time_required_proposed={"a": None, "b": None, "c": None, "d": None},
+        expenses_proposed=None,
+    )
+    db.upsert_process_step_effort_split_by_addressee(
+        session_id=session_id,
+        step_id=_step_two,
+        norm_addressee=ADMINISTRATION,
+        hourly_rates_current={"a": 40, "b": None, "c": None, "d": None},
+        time_required_current={"a": 5, "b": None, "c": None, "d": None},
+        expenses_current=1,
+        hourly_rates_proposed={"a": None, "b": None, "c": None, "d": None},
+        time_required_proposed={"a": None, "b": None, "c": None, "d": None},
+        expenses_proposed=None,
+    )
+
+    async def fail_query_llm(*_args, **_kwargs):
+        raise AssertionError("LLM should not be called when step metrics already exist")
+
+    monkeypatch.setattr(effort_router, "query_llm", fail_query_llm)
+    payload = effort_router.EffortCalculationRequest(
+        app_session_id="EFFORT-INTERNAL-SKIP-EXISTING",
+        model="test-model",
+        provider="openai",
+        norm_addressee=ADMINISTRATION,
+    )
+
+    response = asyncio.run(
+        effort_router._calculate_effort(
+            payload,
+            ApiKeys(),
+            skip_cases_calculation=True,
+        )
+    )
+
+    assert response["status"] == "existing"
+    assert response["case_groups_updated"] == 0
+    assert response["steps_updated"] == 0
 
 
 def test_calculate_effort_rejects_legacy_keys(test_client, monkeypatch):
@@ -1156,5 +1280,3 @@ def test_calculate_effort_rejects_invalid_norm_addressee(test_client):
     )
     assert resp.status_code == 422
     assert "Unsupported norm_addressee" in resp.json()["detail"]
-
-

--- a/tests/test_llm_service_costs.py
+++ b/tests/test_llm_service_costs.py
@@ -40,6 +40,80 @@ def test_extract_provider_reported_cost_usd():
     assert reported == 0.00123
 
 
+def test_estimate_cost_supports_deep_research_agent_alias():
+    resolved = llm_service._resolve_estimated_cost_usd(
+        provider="gemini",
+        model="deep-research-preview-04-2026",
+        input_tokens=1_000_000,
+        output_tokens=2_000_000,
+    )
+
+    assert resolved == 26.0
+
+
+def test_estimate_cost_supports_current_recommended_openai_models():
+    assert (
+        llm_service._resolve_estimated_cost_usd(
+            provider="openai",
+            model="gpt-5.5",
+            input_tokens=1_000_000,
+            output_tokens=1_000_000,
+        )
+        == 35.0
+    )
+    assert (
+        llm_service._resolve_estimated_cost_usd(
+            provider="openai",
+            model="gpt-5.4-mini",
+            input_tokens=1_000_000,
+            output_tokens=1_000_000,
+        )
+        == 5.25
+    )
+    assert (
+        llm_service._resolve_estimated_cost_usd(
+            provider="openai",
+            model="gpt-5.4-nano",
+            input_tokens=1_000_000,
+            output_tokens=1_000_000,
+        )
+        == 1.45
+    )
+
+
+def test_estimate_cost_supports_current_recommended_gemini_models():
+    assert (
+        llm_service._resolve_estimated_cost_usd(
+            provider="gemini",
+            model="gemini-3.5-flash",
+            input_tokens=1_000_000,
+            output_tokens=1_000_000,
+        )
+        == 10.5
+    )
+    assert (
+        llm_service._resolve_estimated_cost_usd(
+            provider="gemini",
+            model="gemini-3-flash-preview",
+            input_tokens=1_000_000,
+            output_tokens=1_000_000,
+        )
+        == 3.5
+    )
+
+
+def test_estimate_cost_returns_none_for_deepinfra_without_provider_reported_cost():
+    assert (
+        llm_service._resolve_estimated_cost_usd(
+            provider="deepinfra",
+            model="anthropic/claude-sonnet-4-6",
+            input_tokens=1_000_000,
+            output_tokens=1_000_000,
+        )
+        is None
+    )
+
+
 def test_normalize_llm_exception_timeout_reason():
     normalized = llm_service._normalize_llm_exception(
         provider="openai",

--- a/tests/test_sessions_contract.py
+++ b/tests/test_sessions_contract.py
@@ -292,6 +292,46 @@ def test_sessions_llm_monitor_snapshot_contract(test_client):
     assert first["provider"] == "openai"
 
 
+def test_sessions_llm_monitor_snapshot_includes_deep_research_recent(test_client):
+    app_session_id = "CONTRACT-LLM-MONITOR-DR"
+    session_id, _ = db.upsert_session(app_session_id, "gpt-5")
+    run_id = db.create_deep_research_run(
+        session_id=session_id,
+        purpose="case_group_metrics",
+        agent="deep-research-preview-04-2026",
+        status="running",
+    )
+    db.update_deep_research_run(
+        run_id,
+        status="parsed",
+        input_tokens=100,
+        output_tokens=200,
+        thought_tokens=30,
+        estimated_cost_usd=0.0042,
+    )
+
+    resp = test_client.get(
+        "/sessions/llm-monitor",
+        params={"app_session_id": app_session_id},
+    )
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    _parse_contract(sessions_router.SessionLlmMonitorSnapshotResponse, payload)
+    deep_research_row = next(
+        row
+        for row in payload["recent"]
+        if row["prompt_id"] == "deep_research_case_group_metrics"
+    )
+    assert deep_research_row["provider"] == "gemini"
+    assert deep_research_row["model"] == "deep-research-preview-04-2026"
+    assert deep_research_row["attempt_id"] == f"deep_research:{run_id}"
+    assert deep_research_row["answer_state"] == "active"
+    assert deep_research_row["input_tokens"] == 100
+    assert deep_research_row["hidden_thinking_tokens"] == 30
+    assert deep_research_row["estimated_cost_usd"] == 0.0042
+
+
 def test_sessions_llm_monitor_events_contract(test_client):
     app_session_id = "CONTRACT-LLM-MONITOR-EVENTS"
     db.upsert_session(app_session_id, "gpt-5")

--- a/tests/test_sessions_deep_research.py
+++ b/tests/test_sessions_deep_research.py
@@ -2,10 +2,65 @@ import asyncio
 
 import pytest
 
-from backend.core import db
+from backend.core import db, llm_monitor
 from backend.core.auth import ApiKeys
 from backend.core.deep_research_cases import CASE_GROUP_RESEARCH_PURPOSE
+from backend.core.deep_research_service import DeepResearchResult
 from backend.routers import sessions as sessions_router
+
+
+def test_parse_pipe_table_accepts_basic_markdown_table():
+    table = (
+        "| Fallgruppe | Wert | Hinweis |\n"
+        "| --- | ---: | :--- |\n"
+        "| A | 10 | plausibel |\n"
+        "| B | 20 | Quelle \\| Zusatz |"
+    )
+
+    assert sessions_router._parse_pipe_table(table) == [
+        ["Fallgruppe", "Wert", "Hinweis"],
+        ["A", "10", "plausibel"],
+        ["B", "20", "Quelle | Zusatz"],
+    ]
+
+
+def test_parse_pipe_table_rejects_pipe_paragraph_and_malformed_table():
+    assert sessions_router._parse_pipe_table("Absatz mit A | B im Text.") is None
+    malformed = "| A | B |\n| --- | --- |\n| 1 | 2 | 3 |"
+    assert sessions_router._parse_pipe_table(malformed) is None
+
+
+def test_research_pdf_inline_markup_renders_bold_and_escapes_text():
+    rendered = sessions_router._research_pdf_inline_markup(
+        "**Erstanerkennung** & <Prüfung> https://www.destatis.de/test."
+    )
+
+    assert rendered.startswith("<b>Erstanerkennung</b> &amp; &lt;Prüfung&gt;")
+    assert '<link href="https://www.destatis.de/test">' in rendered
+    assert rendered.endswith("</link>.")
+
+
+def test_format_research_report_metadata_lines_includes_disclaimer_and_cost():
+    lines = sessions_router._format_research_report_metadata_lines(
+        {
+            "app_session_id": "DR-REPORT",
+            "generated_at": "2026-06-01 12:00",
+            "agent": "deep-research-preview-04-2026",
+            "status": "parsed",
+            "input_tokens": 100,
+            "output_tokens": 200,
+            "thought_tokens": 30,
+            "total_tokens": 330,
+            "estimated_cost_usd": 0.0042,
+        }
+    )
+
+    joined = "\n".join(lines)
+    assert "KI-gestuetzt" in joined
+    assert "DR-REPORT" in joined
+    assert "deep-research-preview-04-2026" in joined
+    assert "in 100 / out 200 / thinking 30 / total 330" in joined
+    assert "$0.0042" in joined
 
 
 def test_case_group_research_toggle_locks_after_run_started(test_client):
@@ -22,6 +77,7 @@ def test_case_group_research_toggle_locks_after_run_started(test_client):
         "enabled": False,
         "status": "idle",
         "locked": False,
+        "elapsed_seconds": None,
     }
 
     enabled = test_client.post(
@@ -44,6 +100,7 @@ def test_case_group_research_toggle_locks_after_run_started(test_client):
     assert locked.status_code == 200
     assert locked.json()["status"] == "running"
     assert locked.json()["locked"] is True
+    assert isinstance(locked.json()["elapsed_seconds"], int)
 
     blocked = test_client.post(
         "/sessions/case-group-research",
@@ -77,7 +134,19 @@ def test_deep_research_report_downloads_markdown_and_pdf(test_client):
     db.update_deep_research_run(
         running_id,
         status="completed",
-        report_md="# Bericht\n\nEine belegte Zahl.",
+        input_tokens=100,
+        output_tokens=200,
+        thought_tokens=30,
+        total_tokens=330,
+        estimated_cost_usd=0.0042,
+        report_md=(
+            "# Bericht\n\n"
+            "Eine belegte Zahl mit Quelle https://www.destatis.de/DE/Home/_inhalt.html.\n\n"
+            "| Fallgruppe | Wert |\n"
+            "| --- | --- |\n"
+            "| **A** | 10 |\n"
+            "| B | 20 |"
+        ),
     )
     markdown = test_client.get(
         "/sessions/deep-research-report",
@@ -124,3 +193,74 @@ def test_deep_research_cancellation_marks_run_terminal(monkeypatch):
     assert run is not None
     assert run["status"] == "cancelled"
     assert "cancelled" in run["error"]
+
+
+def test_deep_research_publishes_llm_monitor_lifecycle(monkeypatch):
+    app_session_id = "DR-MONITOR"
+    session_id, _ = db.upsert_session(app_session_id, "test-model")
+
+    monkeypatch.setattr(
+        sessions_router,
+        "build_deep_research_cases_prompt",
+        lambda *, app_session_id: "prompt",
+    )
+    monkeypatch.setattr(
+        sessions_router,
+        "apply_deep_research_case_metrics",
+        lambda **_kwargs: 1,
+    )
+
+    async def fake_run_deep_research(*_args, **kwargs):
+        kwargs["on_interaction_started"](
+            "deep-research-preview-04-2026",
+            "interaction-1",
+        )
+        running_run = db.get_latest_deep_research_run(
+            session_id,
+            CASE_GROUP_RESEARCH_PURPOSE,
+        )
+        assert running_run is not None
+        assert running_run["status"] == "running"
+        assert running_run["interaction_id"] == "interaction-1"
+        return DeepResearchResult(
+            agent="deep-research-preview-04-2026",
+            interaction_id="interaction-1",
+            report_text='{"prozesse": []}',
+            response_json={"status": "completed"},
+            input_tokens=100,
+            output_tokens=200,
+            thought_tokens=30,
+            total_tokens=330,
+            estimated_cost_usd=0.0042,
+        )
+
+    monkeypatch.setattr(sessions_router, "run_deep_research", fake_run_deep_research)
+
+    asyncio.run(
+        sessions_router._run_case_group_deep_research(
+            app_session_id=app_session_id,
+            session_id=session_id,
+            api_keys=ApiKeys(gemini_api_key="test"),
+        )
+    )
+
+    events = asyncio.run(llm_monitor.get_recent_events(app_session_id, limit=10))
+    event_types = [event["event_type"] for event in events]
+    assert "llm_query_started" in event_types
+    assert "llm_query_succeeded" in event_types
+    assert "llm_apply_succeeded" in event_types
+
+    pending = asyncio.run(llm_monitor.get_pending(app_session_id))
+    assert pending == []
+
+    run = db.get_latest_deep_research_run(session_id, CASE_GROUP_RESEARCH_PURPOSE)
+    assert run is not None
+    attempt_id = f"deep_research:{run['research_run_id']}"
+    succeeded = next(event for event in events if event["event_type"] == "llm_query_succeeded")
+    assert succeeded["attempt_id"] == attempt_id
+    assert succeeded["prompt_id"] == "deep_research_case_group_metrics"
+    assert succeeded["provider"] == "gemini"
+    assert succeeded["model"] == "deep-research-preview-04-2026"
+    assert succeeded["input_tokens"] == 100
+    assert succeeded["hidden_thinking_tokens"] == 30
+    assert succeeded["estimated_cost_usd"] == 0.0042

--- a/tests/test_sessions_deep_research.py
+++ b/tests/test_sessions_deep_research.py
@@ -1,0 +1,126 @@
+import asyncio
+
+import pytest
+
+from backend.core import db
+from backend.core.auth import ApiKeys
+from backend.core.deep_research_cases import CASE_GROUP_RESEARCH_PURPOSE
+from backend.routers import sessions as sessions_router
+
+
+def test_case_group_research_toggle_locks_after_run_started(test_client):
+    app_session_id = "DR-TOGGLE"
+    session_id, _ = db.upsert_session(app_session_id, "test-model")
+
+    initial = test_client.get(
+        "/sessions/case-group-research",
+        params={"app_session_id": app_session_id},
+    )
+    assert initial.status_code == 200
+    assert initial.json() == {
+        "app_session_id": app_session_id,
+        "enabled": False,
+        "status": "idle",
+        "locked": False,
+    }
+
+    enabled = test_client.post(
+        "/sessions/case-group-research",
+        json={"app_session_id": app_session_id, "enabled": True},
+    )
+    assert enabled.status_code == 200
+    assert enabled.json()["enabled"] is True
+
+    db.create_deep_research_run(
+        session_id=session_id,
+        purpose=CASE_GROUP_RESEARCH_PURPOSE,
+        agent="test-agent",
+        status="running",
+    )
+    locked = test_client.get(
+        "/sessions/case-group-research",
+        params={"app_session_id": app_session_id},
+    )
+    assert locked.status_code == 200
+    assert locked.json()["status"] == "running"
+    assert locked.json()["locked"] is True
+
+    blocked = test_client.post(
+        "/sessions/case-group-research",
+        json={"app_session_id": app_session_id, "enabled": False},
+    )
+    assert blocked.status_code == 409
+
+
+def test_deep_research_report_downloads_markdown_and_pdf(test_client):
+    app_session_id = "DR-REPORT"
+    session_id, _ = db.upsert_session(app_session_id, "test-model")
+
+    missing = test_client.get(
+        "/sessions/deep-research-report",
+        params={"app_session_id": app_session_id},
+    )
+    assert missing.status_code == 404
+
+    running_id = db.create_deep_research_run(
+        session_id=session_id,
+        purpose=CASE_GROUP_RESEARCH_PURPOSE,
+        agent="test-agent",
+        status="running",
+    )
+    not_ready = test_client.get(
+        "/sessions/deep-research-report",
+        params={"app_session_id": app_session_id},
+    )
+    assert not_ready.status_code == 409
+
+    db.update_deep_research_run(
+        running_id,
+        status="completed",
+        report_md="# Bericht\n\nEine belegte Zahl.",
+    )
+    markdown = test_client.get(
+        "/sessions/deep-research-report",
+        params={"app_session_id": app_session_id, "format": "md"},
+    )
+    assert markdown.status_code == 200
+    assert markdown.text.startswith("# Bericht")
+    assert markdown.headers["content-type"].startswith("text/markdown")
+
+    pdf = test_client.get(
+        "/sessions/deep-research-report",
+        params={"app_session_id": app_session_id, "format": "pdf"},
+    )
+    assert pdf.status_code == 200
+    assert pdf.content.startswith(b"%PDF")
+    assert pdf.headers["content-type"] == "application/pdf"
+
+
+def test_deep_research_cancellation_marks_run_terminal(monkeypatch):
+    app_session_id = "DR-CANCEL"
+    session_id, _ = db.upsert_session(app_session_id, "test-model")
+
+    monkeypatch.setattr(
+        sessions_router,
+        "build_deep_research_cases_prompt",
+        lambda *, app_session_id: "prompt",
+    )
+
+    async def fake_run_deep_research(*_args, **_kwargs):
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(sessions_router, "run_deep_research", fake_run_deep_research)
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(
+            sessions_router._run_case_group_deep_research(
+                app_session_id=app_session_id,
+                session_id=session_id,
+                api_keys=ApiKeys(gemini_api_key="test"),
+            )
+        )
+
+    run = db.get_latest_deep_research_run(session_id, CASE_GROUP_RESEARCH_PURPOSE)
+    assert run is not None
+    assert run["status"] == "cancelled"
+    assert "cancelled" in run["error"]

--- a/tests/test_sessions_run_all.py
+++ b/tests/test_sessions_run_all.py
@@ -1225,6 +1225,51 @@ def test_single_step_run_executes_shared_step_runner(test_client, monkeypatch):
     assert payload["final_status"]["processes_ready"] is True
 
 
+def test_undo_rejects_while_workflow_run_is_active(test_client, monkeypatch):
+    app_session_id = "UNDO-ACTIVE-RUN"
+    session_id, _ = db.upsert_session(app_session_id, "test-model")
+    db.update_session_summary(app_session_id, "Titel", "Zusammenfassung")
+    db.insert_regulation(
+        session_id,
+        "§ 1",
+        "Beschreibung",
+        applies_to_administration=True,
+        applies_to_business=False,
+        applies_to_citizens=False,
+    )
+
+    async def slow_compile_processes(*_args, **_kwargs):
+        await asyncio.sleep(1.0)
+        return {"status": "ok"}
+
+    monkeypatch.setattr(processes_router, "compile_processes", slow_compile_processes)
+
+    start_response = test_client.post(
+        "/sessions/step-runs/start",
+        json={
+            "app_session_id": app_session_id,
+            "step_key": "processes",
+            "model": "test-model",
+            "provider": "openai",
+        },
+    )
+    assert start_response.status_code == 200
+    run_id = start_response.json()["run_id"]
+
+    undo_response = test_client.post(
+        "/sessions/undo",
+        json={"app_session_id": app_session_id},
+    )
+
+    assert undo_response.status_code == 409
+    assert "lauf zuerst abbrechen" in undo_response.json()["detail"].lower()
+
+    cancel_response = test_client.post(f"/sessions/step-runs/{run_id}/cancel")
+    assert cancel_response.status_code == 200
+    done = _wait_for_run_completion(test_client, run_id, timeout_s=5.0)
+    assert done["status"] == "cancelled"
+
+
 def test_single_step_run_effort_uses_deep_research_when_enabled(
     test_client,
     monkeypatch,

--- a/tests/test_sessions_run_all.py
+++ b/tests/test_sessions_run_all.py
@@ -2,6 +2,8 @@ import json
 import time
 import asyncio
 
+import pytest
+
 from backend.core import db
 from backend.core.deep_research_service import DeepResearchResult
 from backend.routers import (
@@ -785,6 +787,7 @@ def test_run_all_uses_deep_research_for_case_group_metrics(test_client, monkeypa
             interaction_id="dr-test",
             report_text=report_text,
             response_json={"status": "completed"},
+            estimated_cost_usd=0.032,
         )
 
     monkeypatch.setattr(effort_router, "query_llm", fake_effort_llm)
@@ -809,6 +812,7 @@ def test_run_all_uses_deep_research_for_case_group_metrics(test_client, monkeypa
     run = db.get_latest_deep_research_run(session_id, "case_group_metrics")
     assert run is not None
     assert run["status"] == "parsed"
+    assert run["estimated_cost_usd"] == pytest.approx(0.032)
     assert all(
         group["case_metric_research_json"]
         for group in db.list_case_groups_for_session(session_id)

--- a/tests/test_sessions_run_all.py
+++ b/tests/test_sessions_run_all.py
@@ -4,8 +4,8 @@ import asyncio
 
 import pytest
 
-from backend.core import db
-from backend.core.deep_research_service import DeepResearchResult
+from backend.core import db, llm_monitor
+from backend.core.deep_research_service import DeepResearchError, DeepResearchResult
 from backend.routers import (
     case_groups as case_groups_router,
     effort as effort_router,
@@ -56,6 +56,45 @@ def _detect_addressee_from_prompt(prompt: str) -> str:
     ):
         return ADMINISTRATION
     return ADMINISTRATION
+
+
+def _seed_step6_prerequisites(app_session_id: str) -> int:
+    session_id, _ = db.upsert_session(app_session_id, "test-model")
+    db.update_session_summary(app_session_id, "Titel", "Zusammenfassung")
+    for norm_addressee in (ADMINISTRATION, BUSINESS, CITIZENS):
+        regulation_kwargs = {
+            "applies_to_administration": norm_addressee == ADMINISTRATION,
+            "applies_to_business": norm_addressee == BUSINESS,
+            "applies_to_citizens": norm_addressee == CITIZENS,
+            "is_business_information_obligation": norm_addressee == BUSINESS,
+        }
+        db.insert_regulation(
+            session_id,
+            f"§ {norm_addressee}",
+            f"Vorgabe {norm_addressee}",
+            **regulation_kwargs,
+        )
+        process_id = db.insert_process(
+            session_id,
+            f"Prozess {norm_addressee}",
+            f"Beschreibung Prozess {norm_addressee}",
+            norm_addressee=norm_addressee,
+        )
+        case_group_id = db.insert_case_group(
+            session_id,
+            process_id,
+            f"Fallgruppe {norm_addressee}",
+            f"Beschreibung Fallgruppe {norm_addressee}",
+            norm_addressee=norm_addressee,
+        )
+        db.insert_process_step(
+            session_id,
+            case_group_id,
+            f"Schritt {norm_addressee}",
+            f"Beschreibung Schritt {norm_addressee}",
+            norm_addressee=norm_addressee,
+        )
+    return session_id
 
 
 def _patch_run_all_llms(monkeypatch, app_session_id: str) -> None:
@@ -1136,6 +1175,276 @@ def test_run_all_events_stream_emits_terminal_event(test_client, monkeypatch):
     assert "snapshot" in seen_events
     assert "addressee_started" in seen_events
     assert "run_completed" in seen_events
+
+
+def test_single_step_run_executes_shared_step_runner(test_client, monkeypatch):
+    app_session_id = "STEP-RUN-PROCESSES"
+    session_id, _ = db.upsert_session(app_session_id, "test-model")
+    db.insert_regulation(session_id, "§ 1", "Beschreibung")
+
+    async def fake_compile_processes(payload, *_args, **_kwargs):
+        norm_addressee = payload.norm_addressee or ADMINISTRATION
+        db.insert_process(
+            session_id,
+            f"Prozess {norm_addressee}",
+            "Beschreibung",
+            norm_addressee=norm_addressee,
+        )
+        return {"status": "ok"}
+
+    monkeypatch.setattr(processes_router, "compile_processes", fake_compile_processes)
+
+    start_response = test_client.post(
+        "/sessions/step-runs/start",
+        json={
+            "app_session_id": app_session_id,
+            "step_key": "processes",
+            "model": "test-model",
+            "provider": "openai",
+        },
+    )
+    assert start_response.status_code == 200
+    run_id = start_response.json()["run_id"]
+
+    deadline = time.time() + 2.0
+    payload = None
+    while time.time() < deadline:
+        response = test_client.get(f"/sessions/step-runs/{run_id}")
+        assert response.status_code == 200
+        payload = response.json()
+        if payload["status"] != "running":
+            break
+        time.sleep(0.05)
+
+    assert payload is not None
+    assert payload["status"] == "completed"
+    assert payload["ok"] is True
+    assert payload["steps"] == [
+        {"key": "processes", "label": "Prozesse bündeln", "status": "completed", "message": None}
+    ]
+    assert payload["final_status"]["processes_ready"] is True
+
+
+def test_single_step_run_effort_uses_deep_research_when_enabled(
+    test_client,
+    monkeypatch,
+):
+    app_session_id = "STEP-RUN-EFFORT-DR"
+    session_id = _seed_step6_prerequisites(app_session_id)
+    db.update_case_group_research_enabled(session_id, True)
+    calls = {"cases": 0, "effort": 0}
+
+    async def fake_effort_llm(prompt, *_args, **_kwargs):
+        if not _is_effort_prompt(prompt):
+            calls["cases"] += 1
+            raise AssertionError("cases_calculation should be replaced by Deep Research")
+        calls["effort"] += 1
+        addressee = _detect_addressee_from_prompt(prompt)
+        processes = db.list_processes_for_session_and_addressee(session_id, addressee)
+        case_groups = db.list_case_groups_for_session_and_addressee(session_id, addressee)
+        steps = db.list_process_steps_for_session_and_addressee(session_id, addressee)
+        assert len(processes) == 1
+        assert len(case_groups) == 1
+        assert len(steps) == 1
+        if addressee == CITIZENS:
+            effort_entry = {
+                "taetigkeiten_id": str(steps[0]["step_id"]),
+                "zeitaufwand_in_min_vorschlag": "30",
+                "sachaufwand_vorschlag": "10",
+            }
+        else:
+            effort_entry = {
+                "taetigkeiten_id": str(steps[0]["step_id"]),
+                "stundenlohn_satz_a_vorschlag": "60",
+                "zeitaufwand_in_min_a_vorschlag": "30",
+                "sachaufwand_vorschlag": "10",
+            }
+        return json.dumps(
+            {
+                "prozesse": [
+                    {
+                        "prozess_id": str(processes[0]["process_id"]),
+                        "normadressat": addressee,
+                        "fallgruppen": [
+                            {
+                                "fallgruppen_id": str(case_groups[0]["case_group_id"]),
+                                "taetigkeiten": [effort_entry],
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
+
+    async def fake_run_deep_research(*_args, **_kwargs):
+        processes = []
+        for group in db.list_case_groups_for_session(session_id):
+            processes.append(
+                {
+                    "prozess_id": str(group["process_id"]),
+                    "normadressat": group["norm_addressee"],
+                    "fallgruppen": [
+                        {
+                            "fallgruppen_id": str(group["case_group_id"]),
+                            "anzahl_betroffene_gueltig": "10",
+                            "haeufigkeit_pro_jahr_gueltig": "1",
+                            "anzahl_betroffene_vorschlag": "20",
+                            "haeufigkeit_pro_jahr_vorschlag": "2",
+                            "confidence": {
+                                "anzahl_betroffene_gueltig": "high",
+                                "haeufigkeit_pro_jahr_gueltig": "high",
+                                "anzahl_betroffene_vorschlag": "medium",
+                                "haeufigkeit_pro_jahr_vorschlag": "medium",
+                            },
+                            "erklaerungen": {
+                                "anzahl_betroffene_gueltig": "Begründung gültig.",
+                                "haeufigkeit_pro_jahr_gueltig": "Begründung Häufigkeit.",
+                                "anzahl_betroffene_vorschlag": "Begründung Entwurf.",
+                                "haeufigkeit_pro_jahr_vorschlag": "Begründung Häufigkeit Entwurf.",
+                            },
+                        }
+                    ],
+                }
+            )
+        report_text = json.dumps({"prozesse": processes})
+        return DeepResearchResult(
+            agent="test-agent",
+            interaction_id="step-dr",
+            report_text=report_text,
+            response_json={"status": "completed"},
+        )
+
+    monkeypatch.setattr(effort_router, "query_llm", fake_effort_llm)
+    monkeypatch.setattr(sessions_router, "run_deep_research", fake_run_deep_research)
+
+    start_response = test_client.post(
+        "/sessions/step-runs/start",
+        json={
+            "app_session_id": app_session_id,
+            "step_key": "effort",
+            "model": "test-model",
+            "provider": "openai",
+        },
+    )
+    assert start_response.status_code == 200
+    payload = _wait_for_run_completion(test_client, start_response.json()["run_id"])
+
+    assert payload["status"] == "completed"
+    assert payload["ok"] is True
+    assert payload["final_status"]["effort_ready"] is True
+    assert payload["final_status"]["total_cost_ready"] is False
+    assert calls == {"cases": 0, "effort": 3}
+    assert db.get_latest_deep_research_run(session_id, "case_group_metrics")["status"] == "parsed"
+    assert "cases_calculation" not in {
+        row["prompt_id"] for row in db.list_recent_llm_answers_for_session(session_id)
+    }
+
+
+def test_single_step_run_effort_deep_research_timeout_leaves_step_incomplete(
+    test_client,
+    monkeypatch,
+):
+    app_session_id = "STEP-RUN-EFFORT-DR-TIMEOUT"
+    session_id = _seed_step6_prerequisites(app_session_id)
+    db.update_case_group_research_enabled(session_id, True)
+    calls = {"cases": 0}
+
+    async def fake_effort_llm(prompt, *_args, **_kwargs):
+        if not _is_effort_prompt(prompt):
+            calls["cases"] += 1
+            raise AssertionError("cases_calculation should not run in Deep Research mode")
+        await asyncio.sleep(10.0)
+
+    async def timed_out_deep_research(*_args, **_kwargs):
+        raise DeepResearchError("Gemini Deep Research timed out after 1800 seconds")
+
+    monkeypatch.setattr(effort_router, "query_llm", fake_effort_llm)
+    monkeypatch.setattr(sessions_router, "run_deep_research", timed_out_deep_research)
+
+    start_response = test_client.post(
+        "/sessions/step-runs/start",
+        json={
+            "app_session_id": app_session_id,
+            "step_key": "effort",
+            "model": "test-model",
+            "provider": "openai",
+        },
+    )
+    assert start_response.status_code == 200
+    payload = _wait_for_run_completion(
+        test_client,
+        start_response.json()["run_id"],
+        timeout_s=10.0,
+    )
+
+    assert payload["status"] == "failed"
+    assert payload["ok"] is False
+    assert payload["final_status"]["effort_ready"] is False
+    assert payload["final_status"]["case_group_research_status"] == "failed"
+    assert calls == {"cases": 0}
+    run = db.get_latest_deep_research_run(session_id, "case_group_metrics")
+    assert run is not None
+    assert run["status"] == "failed"
+    assert "timed out" in run["error"]
+
+
+def test_single_step_run_effort_cancel_clears_normal_llm_monitor_pending(
+    test_client,
+    monkeypatch,
+):
+    app_session_id = "STEP-RUN-EFFORT-CANCEL"
+    _seed_step6_prerequisites(app_session_id)
+
+    async def slow_effort_llm(*_args, **_kwargs):
+        await asyncio.sleep(10.0)
+
+    monkeypatch.setattr(effort_router, "query_llm", slow_effort_llm)
+
+    start_response = test_client.post(
+        "/sessions/step-runs/start",
+        json={
+            "app_session_id": app_session_id,
+            "step_key": "effort",
+            "model": "test-model",
+            "provider": "openai",
+        },
+    )
+    assert start_response.status_code == 200
+    run_id = start_response.json()["run_id"]
+
+    deadline = time.time() + 3.0
+    pending = []
+    while time.time() < deadline:
+        pending = asyncio.run(llm_monitor.get_pending(app_session_id))
+        if len(pending) >= 2:
+            break
+        time.sleep(0.05)
+    assert {row["prompt_id"] for row in pending} == {
+        "cases_calculation",
+        "effort_calculation",
+    }
+
+    cancel_response = test_client.post(f"/sessions/step-runs/{run_id}/cancel")
+    assert cancel_response.status_code == 200
+    assert cancel_response.json()["accepted"] is True
+
+    payload = _wait_for_run_completion(test_client, run_id, timeout_s=10.0)
+    assert payload["status"] == "cancelled"
+    assert payload["ok"] is False
+    assert payload["final_status"]["effort_ready"] is False
+    assert asyncio.run(llm_monitor.get_pending(app_session_id)) == []
+
+    events = asyncio.run(llm_monitor.get_recent_events(app_session_id, limit=20))
+    cancelled = [
+        event
+        for event in events
+        if event["event_type"] == "llm_query_failed"
+        and event.get("error_kind") == "cancelled"
+    ]
+    assert {event["prompt_id"] for event in cancelled} == {
+        "cases_calculation",
+        "effort_calculation",
+    }
 
 
 def test_run_all_cancel_preserves_completed_steps_and_allows_restart(

--- a/tests/test_sessions_run_all.py
+++ b/tests/test_sessions_run_all.py
@@ -3,6 +3,7 @@ import time
 import asyncio
 
 from backend.core import db
+from backend.core.deep_research_service import DeepResearchResult
 from backend.routers import (
     case_groups as case_groups_router,
     effort as effort_router,
@@ -694,6 +695,124 @@ def test_run_all_executes_all_addressees_end_to_end(test_client, monkeypatch):
         BUSINESS: True,
         CITIZENS: True,
     }
+
+
+def test_run_all_uses_deep_research_for_case_group_metrics(test_client, monkeypatch):
+    app_session_id = "RUNALL-DEEP-RESEARCH"
+    db.insert_law("current_deep.txt", "aktuelles gesetz")
+    db.insert_law("proposed_deep.txt", "neuer entwurf")
+    session_id, _ = db.upsert_session(app_session_id, "test-model")
+    db.update_case_group_research_enabled(session_id, True)
+    _patch_run_all_llms_for_all_addressees(monkeypatch, app_session_id)
+
+    async def fake_effort_llm(prompt, *_args, **_kwargs):
+        if not _is_effort_prompt(prompt):
+            raise AssertionError("cases_calculation should be replaced by Deep Research")
+        addressee = _detect_addressee_from_prompt(prompt)
+        sid = db.get_session_id_by_app_id(app_session_id)
+        assert sid is not None
+        processes = db.list_processes_for_session_and_addressee(sid, addressee)
+        case_groups = db.list_case_groups_for_session_and_addressee(sid, addressee)
+        steps = db.list_process_steps_for_session_and_addressee(sid, addressee)
+        assert len(processes) == 1
+        assert len(case_groups) == 1
+        assert len(steps) == 1
+        if addressee == CITIZENS:
+            effort_entry = {
+                "taetigkeiten_id": str(steps[0]["step_id"]),
+                "zeitaufwand_in_min_vorschlag": "30",
+                "sachaufwand_vorschlag": "10",
+            }
+        else:
+            effort_entry = {
+                "taetigkeiten_id": str(steps[0]["step_id"]),
+                "stundenlohn_satz_a_vorschlag": "60",
+                "zeitaufwand_in_min_a_vorschlag": "30",
+                "sachaufwand_vorschlag": "10",
+            }
+        return json.dumps(
+            {
+                "prozesse": [
+                    {
+                        "prozess_id": str(processes[0]["process_id"]),
+                        "normadressat": addressee,
+                        "fallgruppen": [
+                            {
+                                "fallgruppen_id": str(case_groups[0]["case_group_id"]),
+                                "taetigkeiten": [effort_entry],
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
+
+    async def fake_run_deep_research(*_args, **_kwargs):
+        sid = db.get_session_id_by_app_id(app_session_id)
+        assert sid is not None
+        processes = []
+        for group in db.list_case_groups_for_session(sid):
+            processes.append(
+                {
+                    "prozess_id": str(group["process_id"]),
+                    "normadressat": group["norm_addressee"],
+                    "fallgruppen": [
+                        {
+                            "fallgruppen_id": str(group["case_group_id"]),
+                            "anzahl_betroffene_gueltig": "10",
+                            "haeufigkeit_pro_jahr_gueltig": "1",
+                            "anzahl_betroffene_vorschlag": "10",
+                            "haeufigkeit_pro_jahr_vorschlag": "2",
+                            "confidence": {
+                                "anzahl_betroffene_gueltig": "high",
+                                "haeufigkeit_pro_jahr_gueltig": "medium",
+                                "anzahl_betroffene_vorschlag": "high",
+                                "haeufigkeit_pro_jahr_vorschlag": "medium",
+                            },
+                            "erklaerungen": {
+                                "anzahl_betroffene_gueltig": "Deep Research Begründung",
+                                "haeufigkeit_pro_jahr_gueltig": "Deep Research Begründung",
+                                "anzahl_betroffene_vorschlag": "Deep Research Begründung",
+                                "haeufigkeit_pro_jahr_vorschlag": "Deep Research Begründung",
+                            },
+                        }
+                    ],
+                }
+            )
+        report_text = json.dumps({"prozesse": processes})
+        return DeepResearchResult(
+            agent="test-agent",
+            interaction_id="dr-test",
+            report_text=report_text,
+            response_json={"status": "completed"},
+        )
+
+    monkeypatch.setattr(effort_router, "query_llm", fake_effort_llm)
+    monkeypatch.setattr(sessions_router, "run_deep_research", fake_run_deep_research)
+
+    start_response = test_client.post(
+        "/sessions/run-all/start",
+        json={
+            "app_session_id": app_session_id,
+            "current_filename": "current_deep.txt",
+            "proposed_filename": "proposed_deep.txt",
+            "model": "test-model",
+            "provider": "openai",
+        },
+    )
+    assert start_response.status_code == 200
+    payload = _wait_for_run_completion(test_client, start_response.json()["run_id"])
+
+    assert payload["status"] == "completed"
+    assert payload["ok"] is True
+    assert payload["final_status"]["total_cost_ready"] is True
+    run = db.get_latest_deep_research_run(session_id, "case_group_metrics")
+    assert run is not None
+    assert run["status"] == "parsed"
+    assert all(
+        group["case_metric_research_json"]
+        for group in db.list_case_groups_for_session(session_id)
+    )
 
 
 def test_run_all_skips_administration_when_only_business_regulations_exist(

--- a/tests/test_sessions_status.py
+++ b/tests/test_sessions_status.py
@@ -1,6 +1,47 @@
 from backend.core import db
 
 
+def test_session_status_exposes_latest_failed_step_message(test_client):
+    session_id, _ = db.upsert_session("STATUS-FAILED-STEP", "test-model")
+    db.update_session_summary("STATUS-FAILED-STEP", "Titel", "Zusammenfassung")
+    db.insert_regulation(session_id, "§ 1", "Beschreibung")
+    db.insert_llm_answer(
+        session_id=session_id,
+        prompt_id="process_compilation",
+        model="test-model",
+        answer_text="{}",
+        answer_state=db.LLM_ANSWER_STATE_INVALID,
+        state_reason="session_update_failed: Vorgabe 295 linked to multiple processes",
+        norm_addressee="administration",
+    )
+
+    resp = test_client.get(
+        "/sessions/status", params={"app_session_id": "STATUS-FAILED-STEP"}
+    )
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["processes_ready"] is False
+    assert payload["last_failed_step"] == "processes"
+    assert payload["last_failed_label"] == "Prozesse bündeln"
+    assert payload["last_failed_message"] == "Vorgabe 295 linked to multiple processes"
+
+    process_id = db.insert_process(
+        session_id,
+        "Prozess A",
+        "Beschreibung Prozess",
+        norm_addressee="administration",
+    )
+    assert process_id is not None
+
+    resp = test_client.get(
+        "/sessions/status", params={"app_session_id": "STATUS-FAILED-STEP"}
+    )
+    payload = resp.json()
+    assert payload["last_failed_step"] is None
+    assert payload["last_failed_message"] is None
+
+
 def test_session_status_progression(test_client):
     """Reflects readiness flags as session data accumulates."""
     session_id, _ = db.upsert_session("STATUS-OK", "test-model")

--- a/tests/test_sessions_undo.py
+++ b/tests/test_sessions_undo.py
@@ -3,6 +3,7 @@ import pytest
 from backend.core import db
 from backend.core.norm_addressees import ADMINISTRATION, BUSINESS
 from backend.core.prompts import PromptId
+from backend.core.session_graph import sync_all_norm_addressee_tile_snapshots
 
 
 def _seed_flow(app_session_id: str) -> dict:
@@ -54,6 +55,55 @@ def _seed_flow_for_addressee(app_session_id: str, norm_addressee: str) -> dict:
         "case_group_id": case_group_id,
         "step_id": step_id,
     }
+
+
+def _seed_multi_addressee_process_steps(app_session_id: str) -> dict:
+    session_id, _ = db.upsert_session(app_session_id, "test-model")
+    db.update_session_summary(app_session_id, "Titel", "Zusammenfassung")
+    db.insert_regulation(
+        session_id,
+        "§ 1",
+        "Beschreibung",
+        applies_to_administration=True,
+        applies_to_business=True,
+        applies_to_citizens=False,
+        is_business_information_obligation=True,
+    )
+    seeded: dict[str, dict] = {"session_id": session_id}
+    for addressee in (ADMINISTRATION, BUSINESS):
+        process_id = db.insert_process(
+            session_id,
+            f"Prozess {addressee}",
+            "Beschreibung Prozess",
+            norm_addressee=addressee,
+        )
+        case_group_id = db.insert_case_group(
+            session_id,
+            process_id,
+            f"Fallgruppe {addressee}",
+            "Beschreibung Fallgruppe",
+            norm_addressee=addressee,
+        )
+        step_id = db.insert_process_step(
+            session_id,
+            case_group_id,
+            f"Schritt {addressee}",
+            "Beschreibung Schritt",
+            norm_addressee=addressee,
+        )
+        seeded[addressee] = {
+            "process_id": process_id,
+            "case_group_id": case_group_id,
+            "step_id": step_id,
+        }
+    session = db.get_session_by_id(session_id)
+    assert session is not None
+    sync_all_norm_addressee_tile_snapshots(session)
+    return seeded
+
+
+def _tile_ids(session_id: int, norm_addressee: str) -> set[str]:
+    return {tile.id for tile in db.fetch_tiles(session_id, norm_addressee)}
 
 
 def test_undo_total_cost_clears_costs_only(test_client):
@@ -212,6 +262,39 @@ def test_undo_effort_clears_metrics(test_client):
     assert step["time_required_in_min_a_proposed"] is None
     assert step["expenses_proposed"] is None
     conn.close()
+
+
+def test_undo_rebuilds_tiles_for_all_norm_addressees(test_client):
+    seeded = _seed_multi_addressee_process_steps("UNDO-TILES-ALL-NA")
+    session_id = int(seeded["session_id"])
+
+    for addressee in (ADMINISTRATION, BUSINESS):
+        ids = _tile_ids(session_id, addressee)
+        assert any(tile_id.startswith("case_group_") for tile_id in ids)
+        assert any(tile_id.startswith("step_") for tile_id in ids)
+
+    resp = test_client.post(
+        "/sessions/undo", json={"app_session_id": "UNDO-TILES-ALL-NA"}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["undone_step"] == "process_steps"
+
+    for addressee in (ADMINISTRATION, BUSINESS):
+        ids = _tile_ids(session_id, addressee)
+        assert any(tile_id.startswith("case_group_") for tile_id in ids)
+        assert not any(tile_id.startswith("step_") for tile_id in ids)
+
+    resp = test_client.post(
+        "/sessions/undo", json={"app_session_id": "UNDO-TILES-ALL-NA"}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["undone_step"] == "case_groups"
+
+    for addressee in (ADMINISTRATION, BUSINESS):
+        ids = _tile_ids(session_id, addressee)
+        assert any(tile_id.startswith("process_") for tile_id in ids)
+        assert not any(tile_id.startswith("case_group_") for tile_id in ids)
+        assert not any(tile_id.startswith("step_") for tile_id in ids)
 
 
 def test_undo_effort_is_atomic_on_failure(test_client, monkeypatch):

--- a/tests/test_tiles_rebuild_steps.py
+++ b/tests/test_tiles_rebuild_steps.py
@@ -107,8 +107,8 @@ def test_rebuild_tiles_populates_structured_metrics_meta(test_client):
     step_tile = next(tile for tile in tiles if tile.id == f"step_{step_id}")
 
     assert case_tile.text.startswith("Fallgruppenbeschreibung")
-    assert "Gueltig: Betroffene: 10 | Haeufigkeit/Jahr: 2 | Faelle: 20" in case_tile.text
-    assert "Vorschlag: Betroffene: 12 | Haeufigkeit/Jahr: 3 | Faelle: 36" in case_tile.text
+    assert "Aktuell: Betroffene: 10 | Haeufigkeit/Jahr: 2 | Faelle: 20" in case_tile.text
+    assert "Entwurf: Betroffene: 12 | Haeufigkeit/Jahr: 3 | Faelle: 36" in case_tile.text
     assert case_tile.meta_information["description"] == "Fallgruppenbeschreibung"
     assert case_tile.meta_information["addressees_current"] == 10
     assert case_tile.meta_information["annual_frequency_current"] == 2
@@ -118,8 +118,8 @@ def test_rebuild_tiles_populates_structured_metrics_meta(test_client):
     assert case_tile.meta_information["cases_proposed"] == 36
 
     assert step_tile.text.startswith("Schrittbeschreibung")
-    assert "Gueltig:" in step_tile.text
-    assert "Vorschlag:" in step_tile.text
+    assert "Aktuell:" in step_tile.text
+    assert "Entwurf:" in step_tile.text
     assert step_tile.meta_information["description"] == "Schrittbeschreibung"
     assert step_tile.meta_information["time_required_current"]["a"] == 5
     assert step_tile.meta_information["time_required_proposed"]["a"] == 7


### PR DESCRIPTION
## Summary

This PR adds opt-in Gemini Deep Research support for researching Fallzahlen across all norm addressees and case groups in a session.

It includes:
- standalone Deep Research prompt generation for case-number research
- Gemini Deep Research service integration
- session-level toggle and report download
- persistence for Deep Research runs, reports, and case-group evidence metadata
- parser/apply logic for researched case metrics
- Step 6 integration replacing `cases_calculation` when explicitly enabled
- EA editor display of confidence and explanations for researched values
- updated labels from `Gültig`/`Vorschlag` to `Aktuelles Gesetz`/`Gesetzesentwurf`
- targeted backend and frontend regression coverage

## Notes

Deep Research is session-wide, so it can align case numbers across norm addressees instead of running separate per-case-group tasks. The regular `effort_calculation` path remains unchanged for process-step costs.

`execution_per_case` / `ausfuehrung_pro_einzelfall` is intentionally left for a separate follow-up issue.

ToDo: 
- Small custom parser for pipe tables should be added, since tables in the report are displayed in plain text and pipes; no need to change the whole pdf stack
- No `estimated_cost_usd` for deep-research runs (Gemini Deep Research price model is not wired into the existing normal LLM cost estimator) 

## Testing

- Backend targeted tests for prompt generation, Deep Research parsing, Step 6 behavior, session endpoints, and effort flow
- Frontend targeted tests for session controls, tile labels, and EA evidence display