### PR TITLE
Add confidence and explanations to case group calculations

### DIFF
--- a/backend/core/db.py
+++ b/backend/core/db.py
@@ -4428,6 +4428,7 @@ def clear_effort_metrics(session_id: int, norm_addressee: str = ADMINISTRATION) 
             addressees_proposed_edited = NULL,
             annual_frequency_proposed_edited = NULL,
             cases_proposed_edited = NULL,
+            case_metric_research_json = NULL,
             last_edited_at = NULL
         WHERE session_id = ? AND norm_addressee = ?
         """,

--- a/backend/core/prompts.py
+++ b/backend/core/prompts.py
@@ -1002,6 +1002,11 @@ PROMPT_TEMPLATES: Dict[str, str] = {
 
         Geben Sie nur und ausschliesslich JSON im folgenden Format zurueck:
 
+        Fuegen Sie fuer jede Fallgruppe zusaetzlich erklaerungen und confidence hinzu. Die erklaerungen
+        muessen pro Kennzahl kurz und eigenstaendig darstellen, auf welcher Grundlage der jeweilige Wert hergeleitet wurde.
+        confidence muss pro Kennzahl genau einen der Werte high, medium oder low enthalten und gibt an,
+        wie belastbar die jeweilige Schaetzung ist.
+
         {{
         "normadressat": "{norm_addressee}",
         "prozesse": [
@@ -1027,7 +1032,19 @@ PROMPT_TEMPLATES: Dict[str, str] = {
                     "anzahl_betroffene_gueltig": "",
                     "haeufigkeit_pro_jahr_gueltig": "",
                     "anzahl_betroffene_vorschlag": "",
-                    "haeufigkeit_pro_jahr_vorschlag": ""
+                    "haeufigkeit_pro_jahr_vorschlag": "",
+                    "erklaerungen": {{
+                        "anzahl_betroffene_gueltig": "",
+                        "haeufigkeit_pro_jahr_gueltig": "",
+                        "anzahl_betroffene_vorschlag": "",
+                        "haeufigkeit_pro_jahr_vorschlag": ""
+                    }},
+                    "confidence": {{
+                        "anzahl_betroffene_gueltig": "high | medium | low",
+                        "haeufigkeit_pro_jahr_gueltig": "high | medium | low",
+                        "anzahl_betroffene_vorschlag": "high | medium | low",
+                        "haeufigkeit_pro_jahr_vorschlag": "high | medium | low"
+                    }}
                 }},
                 {{
                     "fallgruppen_id": "",
@@ -1037,7 +1054,19 @@ PROMPT_TEMPLATES: Dict[str, str] = {
                     "anzahl_betroffene_gueltig": "",
                     "haeufigkeit_pro_jahr_gueltig": "",
                     "anzahl_betroffene_vorschlag": "",
-                    "haeufigkeit_pro_jahr_vorschlag": ""
+                    "haeufigkeit_pro_jahr_vorschlag": "",
+                    "erklaerungen": {{
+                        "anzahl_betroffene_gueltig": "",
+                        "haeufigkeit_pro_jahr_gueltig": "",
+                        "anzahl_betroffene_vorschlag": "",
+                        "haeufigkeit_pro_jahr_vorschlag": ""
+                    }},
+                    "confidence": {{
+                        "anzahl_betroffene_gueltig": "high | medium | low",
+                        "haeufigkeit_pro_jahr_gueltig": "high | medium | low",
+                        "anzahl_betroffene_vorschlag": "high | medium | low",
+                        "haeufigkeit_pro_jahr_vorschlag": "high | medium | low"
+                    }}
                 }}
             ]
             }},
@@ -1069,7 +1098,19 @@ PROMPT_TEMPLATES: Dict[str, str] = {
                     "anzahl_betroffene_gueltig": "",
                     "haeufigkeit_pro_jahr_gueltig": "",
                     "anzahl_betroffene_vorschlag": "",
-                    "haeufigkeit_pro_jahr_vorschlag": ""
+                    "haeufigkeit_pro_jahr_vorschlag": "",
+                    "erklaerungen": {{
+                        "anzahl_betroffene_gueltig": "",
+                        "haeufigkeit_pro_jahr_gueltig": "",
+                        "anzahl_betroffene_vorschlag": "",
+                        "haeufigkeit_pro_jahr_vorschlag": ""
+                    }},
+                    "confidence": {{
+                        "anzahl_betroffene_gueltig": "high | medium | low",
+                        "haeufigkeit_pro_jahr_gueltig": "high | medium | low",
+                        "anzahl_betroffene_vorschlag": "high | medium | low",
+                        "haeufigkeit_pro_jahr_vorschlag": "high | medium | low"
+                    }}
                 }}
             ]
             }}

--- a/backend/routers/effort.py
+++ b/backend/routers/effort.py
@@ -140,6 +140,13 @@ def _parse_cases_payload(
             and annual_frequency_proposed is None
         ):
             continue
+        metadata: dict[str, object] = {}
+        confidence = fallgruppe.get("confidence")
+        if isinstance(confidence, dict):
+            metadata["confidence"] = confidence
+        explanations = fallgruppe.get("erklaerungen")
+        if isinstance(explanations, dict):
+            metadata["erklaerungen"] = explanations
         parsed.append(
             {
                 "case_group_id": case_group_id,
@@ -148,6 +155,7 @@ def _parse_cases_payload(
                 "addressees_proposed": addressees_proposed,
                 "annual_frequency_proposed": annual_frequency_proposed,
                 "aenderungsstatus": extract_change_status(fallgruppe),
+                "case_metric_research_json": metadata or None,
             }
         )
     return parsed, fallback_kinds
@@ -765,6 +773,9 @@ async def _calculate_effort(
                         annual_frequency_proposed=annual_frequency_proposed,
                         cases_current=cases_current,
                         cases_proposed=cases_proposed,
+                        case_metric_research_json=entry.get(
+                            "case_metric_research_json"
+                        ),
                     )
 
             for entry in parsed_effort:

--- a/tests/test_effort_flow.py
+++ b/tests/test_effort_flow.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 
 import pytest
 
@@ -95,7 +96,19 @@ def test_calculate_effort_updates_db_and_tiles(test_client, monkeypatch):
               "anzahl_betroffene_gueltig": "100",
               "haeufigkeit_pro_jahr_gueltig": "2",
               "anzahl_betroffene_vorschlag": "120",
-              "haeufigkeit_pro_jahr_vorschlag": "2"
+              "haeufigkeit_pro_jahr_vorschlag": "2",
+              "erklaerungen": {{
+                "anzahl_betroffene_gueltig": "100 Betroffene laut Modellannahme.",
+                "haeufigkeit_pro_jahr_gueltig": "Zweimal jaehrlich laut Vorgang.",
+                "anzahl_betroffene_vorschlag": "120 Betroffene nach Erweiterung.",
+                "haeufigkeit_pro_jahr_vorschlag": "Weiterhin zweimal jaehrlich."
+              }},
+              "confidence": {{
+                "anzahl_betroffene_gueltig": "medium",
+                "haeufigkeit_pro_jahr_gueltig": "high",
+                "anzahl_betroffene_vorschlag": "medium",
+                "haeufigkeit_pro_jahr_vorschlag": "high"
+              }}
             }}
           ]
         }}
@@ -161,6 +174,21 @@ def test_calculate_effort_updates_db_and_tiles(test_client, monkeypatch):
     assert case_groups[0]["annual_frequency_current"] == 2
     assert case_groups[0]["addressees_proposed"] == 120
     assert case_groups[0]["annual_frequency_proposed"] == 2
+    research_json = json.loads(case_groups[0]["case_metric_research_json"])
+    assert research_json == {
+        "confidence": {
+            "anzahl_betroffene_gueltig": "medium",
+            "haeufigkeit_pro_jahr_gueltig": "high",
+            "anzahl_betroffene_vorschlag": "medium",
+            "haeufigkeit_pro_jahr_vorschlag": "high",
+        },
+        "erklaerungen": {
+            "anzahl_betroffene_gueltig": "100 Betroffene laut Modellannahme.",
+            "haeufigkeit_pro_jahr_gueltig": "Zweimal jaehrlich laut Vorgang.",
+            "anzahl_betroffene_vorschlag": "120 Betroffene nach Erweiterung.",
+            "haeufigkeit_pro_jahr_vorschlag": "Weiterhin zweimal jaehrlich.",
+        },
+    }
 
     steps = db.list_process_steps_for_session(session_id)
     assert steps[0]["hourly_rate_a_current"] == 40
@@ -299,6 +327,43 @@ def test_calculate_effort_preserves_existing_base_values(test_client, monkeypatc
     assert step["hourly_rate_a_proposed"] == 44
     assert step["time_required_in_min_a_proposed"] == 6
     assert step["expenses_proposed"] == 8
+
+
+def test_parse_cases_payload_keeps_evidence_metadata():
+    payload = """
+    {
+      "normadressat": "business",
+      "prozesse": [
+        {
+          "prozess_id": "1",
+          "fallgruppen": [
+            {
+              "fallgruppen_id": "42",
+              "anzahl_betroffene_vorschlag": "10",
+              "haeufigkeit_pro_jahr_vorschlag": "1",
+              "erklaerungen": {
+                "anzahl_betroffene_vorschlag": "10 erwartete Faelle."
+              },
+              "confidence": {
+                "anzahl_betroffene_vorschlag": "medium"
+              },
+              "raw_should_not_be_copied": true
+            }
+          ]
+        }
+      ]
+    }
+    """
+
+    parsed, fallbacks = effort_router._parse_cases_payload(payload, BUSINESS)
+
+    assert fallbacks == set()
+    assert parsed[0]["case_metric_research_json"] == {
+        "confidence": {"anzahl_betroffene_vorschlag": "medium"},
+        "erklaerungen": {
+            "anzahl_betroffene_vorschlag": "10 erwartete Faelle."
+        },
+    }
 
 
 def test_calculate_effort_returns_existing_without_llm_call(test_client, monkeypatch):

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -165,6 +165,28 @@ def test_cases_calculation_prompt_includes_verbatim_handbook_examples():
     assert "Aufgrund einer Änderung der Straßenverkehrs-Ordnung (StVO)" in prompt
 
 
+def test_cases_calculation_prompt_requests_case_metric_evidence():
+    prompt = render_prompt(
+        PromptId.CASES_CALCULATION,
+        law_summary="Kurzfassung",
+        case_groups_json="[]",
+        norm_addressee=BUSINESS,
+    )
+
+    assert '"erklaerungen"' in prompt
+    assert '"confidence"' in prompt
+    assert "high | medium | low" in prompt
+    assert "auf welcher Grundlage der jeweilige Wert hergeleitet wurde" in prompt
+    assert "wie belastbar die jeweilige Schaetzung ist" in prompt
+    for key in (
+        "anzahl_betroffene_gueltig",
+        "haeufigkeit_pro_jahr_gueltig",
+        "anzahl_betroffene_vorschlag",
+        "haeufigkeit_pro_jahr_vorschlag",
+    ):
+        assert key in prompt
+
+
 def test_process_compilation_prompt_skips_business_example_for_administration():
     prompt = render_prompt(
         PromptId.PROCESS_COMPILATION,
@@ -476,4 +498,3 @@ def test_citizens_step_analysis_prompt_matches_schema_without_time_estimate():
     assert "Schaetzen Sie in diesem Schritt keine Minuten, Lohngruppen" in prompt
     assert "Schaetzen Sie in der Schrittanalyse keine Zeit-" not in prompt
     assert "Gesamtzeitaufwand" not in prompt
-

--- a/tests/test_sessions_undo.py
+++ b/tests/test_sessions_undo.py
@@ -437,6 +437,12 @@ def test_undo_effort_clears_all_norm_addressees(test_client):
         norm_addressee=ADMINISTRATION,
         addressees_proposed=10,
         annual_frequency_proposed=2,
+        case_metric_research_json={
+            "confidence": {"anzahl_betroffene_vorschlag": "medium"},
+            "erklaerungen": {
+                "anzahl_betroffene_vorschlag": "Admin-Evidenz vor Undo."
+            },
+        },
     )
     db.upsert_case_group_metrics_by_addressee(
         session_id=session_id,
@@ -444,6 +450,12 @@ def test_undo_effort_clears_all_norm_addressees(test_client):
         norm_addressee=BUSINESS,
         addressees_proposed=20,
         annual_frequency_proposed=3,
+        case_metric_research_json={
+            "confidence": {"anzahl_betroffene_vorschlag": "high"},
+            "erklaerungen": {
+                "anzahl_betroffene_vorschlag": "Business-Evidenz vor Undo."
+            },
+        },
     )
     db.upsert_process_step_effort_split_by_addressee(
         session_id=session_id,
@@ -480,7 +492,7 @@ def test_undo_effort_clears_all_norm_addressees(test_client):
     for seed in (admin, business):
         cur.execute(
             """
-            SELECT addressees_proposed, annual_frequency_proposed
+            SELECT addressees_proposed, annual_frequency_proposed, case_metric_research_json
             FROM case_groups
             WHERE case_group_id = ?
             """,
@@ -489,6 +501,7 @@ def test_undo_effort_clears_all_norm_addressees(test_client):
         row = cur.fetchone()
         assert row["addressees_proposed"] is None
         assert row["annual_frequency_proposed"] is None
+        assert row["case_metric_research_json"] is None
 
         cur.execute(
             """


### PR DESCRIPTION
- request confidence and short explanations in cases_calculation output
- persist case metric evidence for normal LLM-generated case numbers
- clear case metric evidence when effort metrics are reset
- fix selected norm addressee hydration mismatch after page reload
- add regression coverage for prompt wording, parsing, persistence, and undo cleanup

This is a pull request to be able to merge the branch onto develop and not onto 27-deep-research-with-gemini as previously chosen.

Replaces PR #47 