### PR TITLE
Add session activity locking for EA editing

### DIFF
--- a/backend/core/db.py
+++ b/backend/core/db.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import json
+import logging
 import sqlite3
+import time
 from contextlib import contextmanager
 from contextvars import ContextVar
 from datetime import datetime
@@ -26,6 +28,8 @@ from .norm_addressees import (
     SUPPORTED_NORM_ADDRESSEES,
     normalize_norm_addressee,
 )
+
+logger = logging.getLogger(__name__)
 
 _TX_CONN: ContextVar[sqlite3.Connection | None] = ContextVar("tx_conn", default=None)
 
@@ -467,6 +471,32 @@ def _create_session_cc_cost_triggers(cur: sqlite3.Cursor) -> None:
         BEGIN
             {recompute.format(sid='OLD.session_id')}
         END
+        """
+    )
+
+
+def _create_session_activities_table(cur: sqlite3.Cursor) -> None:
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS session_activities (
+            session_id      INTEGER PRIMARY KEY,
+            activity_id     TEXT NOT NULL UNIQUE,
+            activity_type   TEXT NOT NULL CHECK (activity_type IN ('workflow', 'ea_edit')),
+            label           TEXT NOT NULL,
+            created_at      REAL NOT NULL,
+            updated_at      REAL NOT NULL,
+            expires_at      REAL,
+            FOREIGN KEY (session_id)
+            REFERENCES sessions(session_id)
+                ON UPDATE CASCADE
+                ON DELETE CASCADE
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_session_activities_expires_at
+        ON session_activities(expires_at)
         """
     )
 
@@ -1650,6 +1680,7 @@ def init_db() -> None:
     cur.execute(
         "CREATE UNIQUE INDEX IF NOT EXISTS idx_sessions_app_session_id ON sessions(app_session_id)"
     )
+    _create_session_activities_table(cur)
     _create_session_total_costs_by_addressee_table(cur)
     _create_session_pay_rate_overrides_by_addressee_table(cur)
     _create_compliance_text_examples_table(cur)
@@ -2100,6 +2131,175 @@ def get_session_by_id(session_id: int) -> dict | None:
     if row is None:
         return None
     return dict(row)
+
+
+def _activity_row_to_dict(row: sqlite3.Row | None) -> dict | None:
+    return dict(row) if row is not None else None
+
+
+def purge_expired_session_activity(session_id: int | None = None) -> int:
+    conn = get_conn()
+    cur = conn.cursor()
+    now = time.time()
+    if session_id is None:
+        params = (now,)
+        cur.execute(
+            """
+            SELECT session_id, activity_id, activity_type, label, created_at, updated_at, expires_at
+            FROM session_activities
+            WHERE expires_at IS NOT NULL AND expires_at <= ?
+            """,
+            params,
+        )
+        expired_rows = cur.fetchall()
+        cur.execute(
+            """
+            DELETE FROM session_activities
+            WHERE expires_at IS NOT NULL AND expires_at <= ?
+            """,
+            params,
+        )
+    else:
+        params = (int(session_id), now)
+        cur.execute(
+            """
+            SELECT session_id, activity_id, activity_type, label, created_at, updated_at, expires_at
+            FROM session_activities
+            WHERE session_id = ?
+              AND expires_at IS NOT NULL
+              AND expires_at <= ?
+            """,
+            params,
+        )
+        expired_rows = cur.fetchall()
+        cur.execute(
+            """
+            DELETE FROM session_activities
+            WHERE session_id = ?
+              AND expires_at IS NOT NULL
+              AND expires_at <= ?
+            """,
+            params,
+        )
+    deleted = len(expired_rows)
+    for row in expired_rows:
+        logger.warning(
+            "Purged expired session activity | session=%s activity=%s type=%s label=%s "
+            "created_at=%s updated_at=%s expires_at=%s",
+            row["session_id"],
+            row["activity_id"],
+            row["activity_type"],
+            row["label"],
+            row["created_at"],
+            row["updated_at"],
+            row["expires_at"],
+        )
+    _maybe_commit(conn)
+    _maybe_close(conn)
+    return deleted
+
+
+def get_session_activity(session_id: int) -> dict | None:
+    purge_expired_session_activity(session_id)
+    conn = get_conn()
+    cur = conn.cursor()
+    cur.execute(
+        """
+        SELECT session_id, activity_id, activity_type, label, created_at, updated_at, expires_at
+        FROM session_activities
+        WHERE session_id = ?
+        LIMIT 1
+        """,
+        (int(session_id),),
+    )
+    row = cur.fetchone()
+    _maybe_close(conn)
+    return _activity_row_to_dict(row)
+
+
+def begin_session_activity(
+    *,
+    session_id: int,
+    activity_id: str,
+    activity_type: str,
+    label: str,
+    ttl_seconds: float | None = None,
+) -> tuple[dict | None, dict | None]:
+    purge_expired_session_activity(session_id)
+    conn = get_conn()
+    cur = conn.cursor()
+    now = time.time()
+    expires_at = None if ttl_seconds is None else now + float(ttl_seconds)
+    try:
+        cur.execute(
+            """
+            INSERT INTO session_activities (
+                session_id, activity_id, activity_type, label,
+                created_at, updated_at, expires_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (int(session_id), activity_id, activity_type, label, now, now, expires_at),
+        )
+        _maybe_commit(conn)
+    except sqlite3.IntegrityError:
+        _maybe_close(conn)
+        return None, get_session_activity(session_id)
+    activity = get_session_activity(session_id)
+    _maybe_close(conn)
+    return activity, None
+
+
+def refresh_session_activity(
+    *,
+    session_id: int,
+    activity_id: str,
+    ttl_seconds: float,
+) -> dict | None:
+    purge_expired_session_activity(session_id)
+    conn = get_conn()
+    cur = conn.cursor()
+    now = time.time()
+    cur.execute(
+        """
+        UPDATE session_activities
+        SET updated_at = ?, expires_at = ?
+        WHERE session_id = ? AND activity_id = ?
+        """,
+        (now, now + float(ttl_seconds), int(session_id), activity_id),
+    )
+    updated = int(cur.rowcount or 0)
+    _maybe_commit(conn)
+    _maybe_close(conn)
+    if updated == 0:
+        return None
+    return get_session_activity(session_id)
+
+
+def clear_session_activity(session_id: int, activity_id: str) -> bool:
+    conn = get_conn()
+    cur = conn.cursor()
+    cur.execute(
+        """
+        DELETE FROM session_activities
+        WHERE session_id = ? AND activity_id = ?
+        """,
+        (int(session_id), activity_id),
+    )
+    deleted = int(cur.rowcount or 0) > 0
+    _maybe_commit(conn)
+    _maybe_close(conn)
+    return deleted
+
+
+def clear_all_session_activities() -> int:
+    conn = get_conn()
+    cur = conn.cursor()
+    cur.execute("DELETE FROM session_activities")
+    deleted = int(cur.rowcount or 0)
+    _maybe_commit(conn)
+    _maybe_close(conn)
+    return deleted
 
 
 def get_session_law_texts(session_id: int) -> tuple[str, str]:

--- a/backend/core/session_activity.py
+++ b/backend/core/session_activity.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import uuid
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import AsyncIterator, Literal
+
+from backend.core import db
+
+
+SessionActivityType = Literal["workflow", "ea_edit"]
+
+EA_EDIT_LEASE_SECONDS = 120.0
+WORKFLOW_LEASE_SECONDS = 12 * 60 * 60.0
+
+
+@dataclass(frozen=True)
+class SessionActivity:
+    session_id: int
+    activity_id: str
+    activity_type: SessionActivityType
+    label: str
+    created_at: float
+    updated_at: float
+    expires_at: float | None
+
+
+class SessionActivityConflict(Exception):
+    def __init__(self, active: SessionActivity):
+        self.active = active
+        super().__init__(
+            f"Active {active.activity_type} for session {active.session_id}: "
+            f"{active.activity_id}"
+        )
+
+
+class SessionActivityUnavailable(Exception):
+    def __init__(self, *, session_id: int, activity_type: SessionActivityType):
+        self.session_id = session_id
+        self.activity_type = activity_type
+        super().__init__(f"No active {activity_type} for session {session_id}")
+
+
+def _activity_from_row(row: dict | None) -> SessionActivity | None:
+    if row is None:
+        return None
+    return SessionActivity(
+        session_id=int(row["session_id"]),
+        activity_id=str(row["activity_id"]),
+        activity_type=str(row["activity_type"]),  # type: ignore[arg-type]
+        label=str(row["label"]),
+        created_at=float(row["created_at"]),
+        updated_at=float(row["updated_at"]),
+        expires_at=(
+            None if row.get("expires_at") is None else float(row["expires_at"])
+        ),
+    )
+
+
+def get_session_activity(session_id: int) -> SessionActivity | None:
+    return _activity_from_row(db.get_session_activity(session_id))
+
+
+def begin_session_activity(
+    *,
+    session_id: int,
+    activity_type: SessionActivityType,
+    label: str,
+    ttl_seconds: float | None,
+) -> SessionActivity:
+    activity_id = f"{activity_type}:{uuid.uuid4().hex}"
+    activity_row, conflict_row = db.begin_session_activity(
+        session_id=session_id,
+        activity_id=activity_id,
+        activity_type=activity_type,
+        label=label,
+        ttl_seconds=ttl_seconds,
+    )
+    activity = _activity_from_row(activity_row)
+    if activity is not None:
+        return activity
+    conflict = _activity_from_row(conflict_row)
+    if conflict is not None:
+        raise SessionActivityConflict(conflict)
+    raise SessionActivityUnavailable(session_id=session_id, activity_type=activity_type)
+
+
+def refresh_session_activity(
+    *,
+    session_id: int,
+    activity_id: str,
+    activity_type: SessionActivityType,
+    ttl_seconds: float,
+) -> SessionActivity:
+    active = get_session_activity(session_id)
+    if active is None:
+        raise SessionActivityUnavailable(
+            session_id=session_id,
+            activity_type=activity_type,
+        )
+    if active.activity_id != activity_id or active.activity_type != activity_type:
+        raise SessionActivityConflict(active)
+    refreshed = _activity_from_row(
+        db.refresh_session_activity(
+            session_id=session_id,
+            activity_id=activity_id,
+            ttl_seconds=ttl_seconds,
+        )
+    )
+    if refreshed is None:
+        raise SessionActivityUnavailable(
+            session_id=session_id,
+            activity_type=activity_type,
+        )
+    return refreshed
+
+
+def use_existing_session_activity(
+    *,
+    session_id: int,
+    activity_id: str | None,
+    activity_type: SessionActivityType,
+) -> SessionActivity:
+    if not activity_id:
+        active = get_session_activity(session_id)
+        if active is not None:
+            raise SessionActivityConflict(active)
+        raise SessionActivityUnavailable(
+            session_id=session_id,
+            activity_type=activity_type,
+        )
+    active = get_session_activity(session_id)
+    if active is None:
+        raise SessionActivityUnavailable(
+            session_id=session_id,
+            activity_type=activity_type,
+        )
+    if active.activity_id != activity_id or active.activity_type != activity_type:
+        raise SessionActivityConflict(active)
+    return active
+
+
+def clear_session_activity(session_id: int, activity_id: str) -> None:
+    db.clear_session_activity(session_id, activity_id)
+
+
+def release_session_activity(
+    *,
+    session_id: int,
+    activity_id: str,
+    activity_type: SessionActivityType,
+) -> bool:
+    active = get_session_activity(session_id)
+    if active is None:
+        return False
+    if active.activity_id != activity_id or active.activity_type != activity_type:
+        return False
+    return db.clear_session_activity(session_id, activity_id)
+
+
+def clear_all_session_activities() -> None:
+    db.clear_all_session_activities()
+
+
+@asynccontextmanager
+async def session_activity_scope(
+    *,
+    session_id: int,
+    activity_type: SessionActivityType,
+    label: str,
+    owner_activity_id: str | None = None,
+    ttl_seconds: float | None = None,
+) -> AsyncIterator[SessionActivity]:
+    if owner_activity_id:
+        yield use_existing_session_activity(
+            session_id=session_id,
+            activity_id=owner_activity_id,
+            activity_type=activity_type,
+        )
+        return
+    activity = begin_session_activity(
+        session_id=session_id,
+        activity_type=activity_type,
+        label=label,
+        ttl_seconds=ttl_seconds,
+    )
+    try:
+        yield activity
+    finally:
+        clear_session_activity(session_id, activity.activity_id)

--- a/backend/main.py
+++ b/backend/main.py
@@ -162,6 +162,7 @@ async def log_backend_communication(request: Request, call_next):
 @app.on_event("startup")
 def startup() -> None:
     db.ensure_db()
+    db.clear_all_session_activities()
 
 
 app.include_router(tiles.router)

--- a/backend/routers/_session_activity_guard.py
+++ b/backend/routers/_session_activity_guard.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import AsyncIterator
+
+from fastapi import HTTPException
+
+from backend.core.session_activity import (
+    SessionActivity,
+    SessionActivityConflict,
+    SessionActivityType,
+    SessionActivityUnavailable,
+    use_existing_session_activity,
+    session_activity_scope,
+)
+
+
+def raise_session_activity_conflict(exc: SessionActivityConflict) -> None:
+    active = exc.active
+    if active.activity_type == "workflow":
+        message = (
+            "Diese Aktion ist während einer laufenden Ausführung in derselben "
+            "Session nicht möglich. Bitte den Lauf zuerst abbrechen oder "
+            "abschließen."
+        )
+    else:
+        message = (
+            "Diese Aktion ist während einer laufenden EA-Bearbeitung in "
+            "derselben Session nicht möglich. Bitte die Bearbeitung zuerst "
+            "abschließen."
+        )
+    raise HTTPException(
+        status_code=409,
+        detail={
+            "error": "session_activity_conflict",
+            "active_type": active.activity_type,
+            "message": message,
+        },
+    ) from exc
+
+
+def raise_session_activity_unavailable(exc: SessionActivityUnavailable) -> None:
+    if exc.activity_type == "ea_edit":
+        message = (
+            "EA-Bearbeitung ist nicht mehr aktiv. Bitte den Editor schließen "
+            "und erneut öffnen."
+        )
+    else:
+        message = "Die Ausführung ist nicht mehr aktiv. Bitte den Lauf erneut starten."
+    raise HTTPException(
+        status_code=409,
+        detail={
+            "error": "session_activity_unavailable",
+            "activity_type": exc.activity_type,
+            "message": message,
+        },
+    ) from exc
+
+
+@asynccontextmanager
+async def guarded_session_activity(
+    *,
+    session_id: int,
+    activity_type: SessionActivityType,
+    label: str,
+    owner_activity_id: str | None = None,
+    ttl_seconds: float | None = None,
+) -> AsyncIterator[SessionActivity]:
+    try:
+        if activity_type == "ea_edit":
+            yield use_existing_session_activity(
+                session_id=session_id,
+                activity_id=owner_activity_id,
+                activity_type=activity_type,
+            )
+            return
+        async with session_activity_scope(
+            session_id=session_id,
+            activity_type=activity_type,
+            label=label,
+            owner_activity_id=owner_activity_id,
+            ttl_seconds=ttl_seconds,
+        ) as activity:
+            yield activity
+    except SessionActivityConflict as exc:
+        raise_session_activity_conflict(exc)
+    except SessionActivityUnavailable as exc:
+        raise_session_activity_unavailable(exc)

--- a/backend/routers/case_groups.py
+++ b/backend/routers/case_groups.py
@@ -28,6 +28,7 @@ from backend.routers._edit_validation import validate_non_empty_rows
 from backend.routers._edit_validation import validate_non_noop_update_count
 from backend.routers._edit_validation import validate_unique_ids
 from backend.routers._norm_addressee import normalize_norm_addressee_or_422
+from backend.routers._session_activity_guard import guarded_session_activity
 from backend.routers._session_validation import (
     APP_SESSION_ID_QUERY_VALIDATION,
     AppSessionId,
@@ -46,6 +47,7 @@ class CaseGroupEditRow(BaseModel):
 
 class CaseGroupBulkUpdateRequest(BaseModel):
     app_session_id: AppSessionId
+    ea_activity_id: str | None = None
     rows: list[CaseGroupEditRow]
 
 
@@ -226,18 +228,24 @@ async def bulk_update_case_groups(payload: CaseGroupBulkUpdateRequest) -> BulkUp
     edited_case_group_ids = {
         int(row.case_group_id) for row in payload.rows if row.case_group_id is not None
     }
-    with db.transaction():
-        updated, missing_ids = db.bulk_update_case_group_edits(session_id, updates)
-        if missing_ids:
-            raise HTTPException(
-                status_code=422,
-                detail=(
-                    "Unknown case_group_id values for this session: "
-                    + ", ".join(str(case_group_id) for case_group_id in missing_ids)
-                ),
-            )
-        validate_non_noop_update_count(updated)
-        refresh_case_group_tiles(session_id, db.list_case_groups_for_session(session_id))
+    async with guarded_session_activity(
+        session_id=session_id,
+        activity_type="ea_edit",
+        label="EA bearbeiten",
+        owner_activity_id=payload.ea_activity_id,
+    ):
+        with db.transaction():
+            updated, missing_ids = db.bulk_update_case_group_edits(session_id, updates)
+            if missing_ids:
+                raise HTTPException(
+                    status_code=422,
+                    detail=(
+                        "Unknown case_group_id values for this session: "
+                        + ", ".join(str(case_group_id) for case_group_id in missing_ids)
+                    ),
+                )
+            validate_non_noop_update_count(updated)
+            refresh_case_group_tiles(session_id, db.list_case_groups_for_session(session_id))
     return BulkUpdateResponse(updated=updated)
 
 

--- a/backend/routers/costs.py
+++ b/backend/routers/costs.py
@@ -12,8 +12,17 @@ from backend.core.norm_addressees import (
     BUSINESS,
     CITIZENS,
 )
+from backend.core.session_activity import (
+    SessionActivityConflict,
+    SessionActivityUnavailable,
+    use_existing_session_activity,
+)
 from backend.core.tile_refresh import refresh_case_group_tiles, refresh_step_tiles
 from backend.routers._norm_addressee import normalize_norm_addressee_or_422
+from backend.routers._session_activity_guard import (
+    raise_session_activity_conflict,
+    raise_session_activity_unavailable,
+)
 
 
 router = APIRouter(prefix="/costs", tags=["costs"])
@@ -22,6 +31,7 @@ router = APIRouter(prefix="/costs", tags=["costs"])
 class CostComputationRequest(BaseModel):
     app_session_id: str
     norm_addressee: str | None = None
+    ea_activity_id: str | None = None
 
 
 def _build_cost_response(
@@ -282,6 +292,24 @@ def compute_total_cost_for_session(
 
 @router.post("/compute")
 async def compute_costs(payload: CostComputationRequest) -> dict:
+    session_id = db.get_session_id_by_app_id(payload.app_session_id)
+    if session_id is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+    active_activity = db.get_session_activity(session_id)
+    requires_ea_owner = payload.ea_activity_id or (
+        active_activity is not None and active_activity["activity_type"] == "ea_edit"
+    )
+    if requires_ea_owner:
+        try:
+            use_existing_session_activity(
+                session_id=session_id,
+                activity_id=payload.ea_activity_id,
+                activity_type="ea_edit",
+            )
+        except SessionActivityConflict as exc:
+            raise_session_activity_conflict(exc)
+        except SessionActivityUnavailable as exc:
+            raise_session_activity_unavailable(exc)
     return compute_total_cost_for_session(
         app_session_id=payload.app_session_id,
         norm_addressee=payload.norm_addressee,

--- a/backend/routers/process_steps.py
+++ b/backend/routers/process_steps.py
@@ -26,6 +26,7 @@ from backend.routers._edit_validation import validate_non_noop_update_count
 from backend.routers._edit_validation import validate_unique_ids
 from backend.routers._edit_validation import validate_wage_source_kind
 from backend.routers._norm_addressee import normalize_norm_addressee_or_422
+from backend.routers._session_activity_guard import guarded_session_activity
 from backend.routers._session_validation import (
     APP_SESSION_ID_QUERY_VALIDATION,
     AppSessionId,
@@ -50,11 +51,13 @@ class ProcessStepEditRow(BaseModel):
 
 class ProcessStepBulkUpdateRequest(BaseModel):
     app_session_id: AppSessionId
+    ea_activity_id: str | None = None
     rows: list[ProcessStepEditRow]
 
 
 class PersonnelEffortTimeEditRequest(BaseModel):
     app_session_id: AppSessionId
+    ea_activity_id: str | None = None
     norm_addressee: str
     step_id: int
     period: str
@@ -262,18 +265,24 @@ async def bulk_update_process_steps(
             entity_label="step_id",
         )
         updates.append(row.model_dump())
-    with db.transaction():
-        updated, missing_ids = db.bulk_update_process_step_edits(session_id, updates)
-        if missing_ids:
-            raise HTTPException(
-                status_code=422,
-                detail=(
-                    "Unknown step_id values for this session: "
-                    + ", ".join(str(step_id) for step_id in missing_ids)
-                ),
-            )
-        validate_non_noop_update_count(updated)
-        refresh_step_tiles(session_id, db.list_process_steps_for_session(session_id))
+    async with guarded_session_activity(
+        session_id=session_id,
+        activity_type="ea_edit",
+        label="EA bearbeiten",
+        owner_activity_id=payload.ea_activity_id,
+    ):
+        with db.transaction():
+            updated, missing_ids = db.bulk_update_process_step_edits(session_id, updates)
+            if missing_ids:
+                raise HTTPException(
+                    status_code=422,
+                    detail=(
+                        "Unknown step_id values for this session: "
+                        + ", ".join(str(step_id) for step_id in missing_ids)
+                    ),
+                )
+            validate_non_noop_update_count(updated)
+            refresh_step_tiles(session_id, db.list_process_steps_for_session(session_id))
     return BulkUpdateResponse(updated=updated)
 
 
@@ -296,16 +305,22 @@ async def edit_personnel_effort_time(
             status_code=422, detail="time_required_in_min_edited must not be negative"
         )
     try:
-        updated = db.upsert_personnel_effort_time_edit(
+        async with guarded_session_activity(
             session_id=session_id,
-            norm_addressee=resolved,
-            step_id=payload.step_id,
-            period=payload.period,
-            qualification=payload.qualification,
-            wage_source_kind=payload.wage_source_kind,
-            wage_source_value=payload.wage_source_value,
-            time_required_in_min_edited=payload.time_required_in_min_edited,
-        )
+            activity_type="ea_edit",
+            label="EA bearbeiten",
+            owner_activity_id=payload.ea_activity_id,
+        ):
+            updated = db.upsert_personnel_effort_time_edit(
+                session_id=session_id,
+                norm_addressee=resolved,
+                step_id=payload.step_id,
+                period=payload.period,
+                qualification=payload.qualification,
+                wage_source_kind=payload.wage_source_kind,
+                wage_source_value=payload.wage_source_value,
+                time_required_in_min_edited=payload.time_required_in_min_edited,
+            )
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
     validate_non_noop_update_count(updated)

--- a/backend/routers/sessions.py
+++ b/backend/routers/sessions.py
@@ -51,6 +51,15 @@ from backend.core.norm_addressees import SUPPORTED_NORM_ADDRESSEES
 from backend.core.norm_addressees import ADMINISTRATION, BUSINESS, CITIZENS
 from backend.core.prompts import PromptId, render_prompt
 from backend.core.request_context import get_request_context
+from backend.core.session_activity import (
+    EA_EDIT_LEASE_SECONDS,
+    SessionActivityConflict,
+    SessionActivityUnavailable,
+    WORKFLOW_LEASE_SECONDS,
+    begin_session_activity,
+    refresh_session_activity,
+    release_session_activity,
+)
 from backend.core.session_graph import build_session_tiles_snapshot
 from backend.core.workflow import (
     get_last_completed_step,
@@ -63,6 +72,11 @@ from backend.routers._llm_router_utils import (
 )
 from backend.routers._edit_validation import validate_wage_source_kind
 from backend.routers._norm_addressee import normalize_norm_addressee_or_422
+from backend.routers._session_activity_guard import (
+    guarded_session_activity,
+    raise_session_activity_conflict,
+    raise_session_activity_unavailable,
+)
 from backend.routers._session_validation import (
     APP_SESSION_ID_QUERY_VALIDATION,
     AppSessionId,
@@ -140,6 +154,7 @@ class SessionStatusResponse(BaseModel):
 class SessionPayRatesUpdateRequest(BaseModel):
     app_session_id: AppSessionId
     norm_addressee: str | None = None
+    ea_activity_id: str | None = None
     administration_level: str | None = None
     edited_a: float | None
     edited_b: float | None
@@ -175,6 +190,7 @@ class SessionWageRatesResponse(BaseModel):
 class SessionWageRateUpdateRequest(BaseModel):
     app_session_id: AppSessionId
     norm_addressee: str | None = None
+    ea_activity_id: str | None = None
     wage_source_kind: str
     wage_source_value: str
     qualification: str
@@ -199,12 +215,25 @@ class SessionEditAuditResponse(BaseModel):
 
 class SessionEaEditResetRequest(BaseModel):
     app_session_id: AppSessionId
+    ea_activity_id: str | None = None
 
 
 class SessionEaEditResetResponse(BaseModel):
     app_session_id: str
     reset_counts: dict[str, int]
     recomputed_norm_addressees: list[str]
+
+
+class SessionEaEditActivityRequest(BaseModel):
+    app_session_id: AppSessionId
+    activity_id: str | None = None
+
+
+class SessionEaEditActivityResponse(BaseModel):
+    app_session_id: str
+    activity_id: str
+    lease_seconds: float
+    expires_at: float | None = None
 
 
 class CaseGroupResearchSettingsRequest(BaseModel):
@@ -2053,6 +2082,85 @@ async def session_status(
     return _as_session_status_response(app_session_id)
 
 
+def _session_id_or_404(app_session_id: str) -> int:
+    session_id = db.get_session_id_by_app_id(app_session_id)
+    if session_id is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+    return session_id
+
+
+def _ensure_ea_edit_allowed(app_session_id: str) -> None:
+    status = db.get_session_status(app_session_id)
+    if not status:
+        raise HTTPException(status_code=404, detail="Session not found")
+    if not bool(status.get("total_cost_ready")):
+        raise HTTPException(
+            status_code=409,
+            detail="EA-Bearbeitung ist erst nach berechneten Gesamtkosten möglich.",
+        )
+
+
+@router.post("/ea-edit-activity/acquire", response_model=SessionEaEditActivityResponse)
+async def acquire_ea_edit_activity(
+    payload: SessionEaEditActivityRequest,
+) -> SessionEaEditActivityResponse:
+    session_id = _session_id_or_404(payload.app_session_id)
+    _ensure_ea_edit_allowed(payload.app_session_id)
+    try:
+        activity = begin_session_activity(
+            session_id=session_id,
+            activity_type="ea_edit",
+            label="EA bearbeiten",
+            ttl_seconds=EA_EDIT_LEASE_SECONDS,
+        )
+    except SessionActivityConflict as exc:
+        raise_session_activity_conflict(exc)
+    except SessionActivityUnavailable as exc:
+        raise_session_activity_unavailable(exc)
+    return SessionEaEditActivityResponse(
+        app_session_id=payload.app_session_id,
+        activity_id=activity.activity_id,
+        lease_seconds=EA_EDIT_LEASE_SECONDS,
+        expires_at=activity.expires_at,
+    )
+
+
+@router.post("/ea-edit-activity/heartbeat", response_model=SessionEaEditActivityResponse)
+async def heartbeat_ea_edit_activity(
+    payload: SessionEaEditActivityRequest,
+) -> SessionEaEditActivityResponse:
+    session_id = _session_id_or_404(payload.app_session_id)
+    try:
+        activity = refresh_session_activity(
+            session_id=session_id,
+            activity_id=payload.activity_id or "",
+            activity_type="ea_edit",
+            ttl_seconds=EA_EDIT_LEASE_SECONDS,
+        )
+    except SessionActivityConflict as exc:
+        raise_session_activity_conflict(exc)
+    except SessionActivityUnavailable as exc:
+        raise_session_activity_unavailable(exc)
+    return SessionEaEditActivityResponse(
+        app_session_id=payload.app_session_id,
+        activity_id=activity.activity_id,
+        lease_seconds=EA_EDIT_LEASE_SECONDS,
+        expires_at=activity.expires_at,
+    )
+
+
+@router.post("/ea-edit-activity/release")
+async def release_ea_edit_activity(payload: SessionEaEditActivityRequest) -> dict:
+    session_id = _session_id_or_404(payload.app_session_id)
+    if payload.activity_id:
+        release_session_activity(
+            session_id=session_id,
+            activity_id=payload.activity_id,
+            activity_type="ea_edit",
+        )
+    return {"ok": True}
+
+
 @router.get("/pay-rates", response_model=SessionPayRatesResponse)
 async def session_pay_rates(
     app_session_id: str = APP_SESSION_ID_QUERY_VALIDATION,
@@ -2069,20 +2177,26 @@ async def session_pay_rates_update(
     session_id = db.get_session_id_by_app_id(payload.app_session_id)
     if session_id is None:
         raise HTTPException(status_code=404, detail="Session not found")
-    try:
-        changed = db.update_session_pay_rate_edits_for_addressee(
-            session_id=session_id,
-            norm_addressee=normalize_norm_addressee_or_422(payload.norm_addressee),
-            administration_level=payload.administration_level,
-            edited={
-                "a": payload.edited_a,
-                "b": payload.edited_b,
-                "c": payload.edited_c,
-                "d": payload.edited_d,
-            },
-        )
-    except ValueError as exc:
-        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    async with guarded_session_activity(
+        session_id=session_id,
+        activity_type="ea_edit",
+        label="EA bearbeiten",
+        owner_activity_id=payload.ea_activity_id,
+    ):
+        try:
+            changed = db.update_session_pay_rate_edits_for_addressee(
+                session_id=session_id,
+                norm_addressee=normalize_norm_addressee_or_422(payload.norm_addressee),
+                administration_level=payload.administration_level,
+                edited={
+                    "a": payload.edited_a,
+                    "b": payload.edited_b,
+                    "c": payload.edited_c,
+                    "d": payload.edited_d,
+                },
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
     if not changed:
         raise HTTPException(status_code=422, detail="No changes in payload")
     return _as_session_pay_rates_response(
@@ -2138,14 +2252,20 @@ async def session_wage_rates_update(
                     f"{payload.qualification!r} for {resolved!r}"
                 ),
             )
-    changed = db.upsert_session_wage_rate_override(
+    async with guarded_session_activity(
         session_id=session_id,
-        norm_addressee=resolved,
-        wage_source_kind=payload.wage_source_kind,
-        wage_source_value=payload.wage_source_value,
-        qualification=payload.qualification,
-        hourly_rate_edited=payload.hourly_rate_edited,
-    )
+        activity_type="ea_edit",
+        label="EA bearbeiten",
+        owner_activity_id=payload.ea_activity_id,
+    ):
+        changed = db.upsert_session_wage_rate_override(
+            session_id=session_id,
+            norm_addressee=resolved,
+            wage_source_kind=payload.wage_source_kind,
+            wage_source_value=payload.wage_source_value,
+            qualification=payload.qualification,
+            hourly_rate_edited=payload.hourly_rate_edited,
+        )
     if not changed:
         raise HTTPException(status_code=422, detail="No changes in payload")
     return _as_session_wage_rates_response(payload.app_session_id, session_id, resolved)
@@ -2170,20 +2290,26 @@ async def reset_session_ea_edits(
     session_id = db.get_session_id_by_app_id(payload.app_session_id)
     if session_id is None:
         raise HTTPException(status_code=404, detail="Session not found")
-    status = db.get_session_status(payload.app_session_id) or {}
-    ready_by_addressee = status.get("total_cost_ready_by_addressee")
-    if not isinstance(ready_by_addressee, dict):
-        ready_by_addressee = {}
-    reset_counts = db.reset_all_ea_edit_overrides(session_id)
-    recomputed: list[str] = []
-    for norm_addressee in SUPPORTED_NORM_ADDRESSEES:
-        if not bool(ready_by_addressee.get(norm_addressee)):
-            continue
-        costs_router.compute_total_cost_for_session(
-            app_session_id=payload.app_session_id,
-            norm_addressee=norm_addressee,
-        )
-        recomputed.append(norm_addressee)
+    async with guarded_session_activity(
+        session_id=session_id,
+        activity_type="ea_edit",
+        label="EA bearbeiten",
+        owner_activity_id=payload.ea_activity_id,
+    ):
+        status = db.get_session_status(payload.app_session_id) or {}
+        ready_by_addressee = status.get("total_cost_ready_by_addressee")
+        if not isinstance(ready_by_addressee, dict):
+            ready_by_addressee = {}
+        reset_counts = db.reset_all_ea_edit_overrides(session_id)
+        recomputed: list[str] = []
+        for norm_addressee in SUPPORTED_NORM_ADDRESSEES:
+            if not bool(ready_by_addressee.get(norm_addressee)):
+                continue
+            costs_router.compute_total_cost_for_session(
+                app_session_id=payload.app_session_id,
+                norm_addressee=norm_addressee,
+            )
+            recomputed.append(norm_addressee)
     return SessionEaEditResetResponse(
         app_session_id=payload.app_session_id,
         reset_counts=reset_counts,
@@ -2957,8 +3083,14 @@ async def undo_last_step(payload: SessionUndoRequest) -> SessionUndoResponse:
     if not step:
         return SessionUndoResponse(status="no-op", message="No completed steps")
 
-    with db.transaction():
-        undo_step(session_id, step.key)
+    async with guarded_session_activity(
+        session_id=session_id,
+        activity_type="workflow",
+        label=f"{step.label} zurücksetzen",
+        ttl_seconds=WORKFLOW_LEASE_SECONDS,
+    ):
+        with db.transaction():
+            undo_step(session_id, step.key)
 
     return SessionUndoResponse(
         status="ok",
@@ -3007,88 +3139,98 @@ async def _mark_background_run_terminal(
     await _trim_finished_runs()
 
 
+def _release_workflow_activity(session_id: int | None, activity_id: str) -> None:
+    if session_id is not None:
+        db.clear_session_activity(session_id, activity_id)
+
+
 async def _run_all_background(
     run_id: str,
     payload: SessionRunAllRequest,
     api_keys: ApiKeys,
     model: str,
+    workflow_activity_id: str,
 ) -> None:
-    trace_token = None
-    if llm_trace.trace_enabled_by_env():
-        trace_token = llm_trace.start_run(
-            request_id=run_id,
-            route_method="BACKGROUND",
-            route_path=f"/sessions/{payload.app_session_id}/run-all",
-            app_session_id=payload.app_session_id,
-        )
-    lock = _get_run_all_lock(payload.app_session_id)
+    session_id = db.get_session_id_by_app_id(payload.app_session_id)
     try:
-        start_record = await _get_run_record(run_id)
+        trace_token = None
+        if llm_trace.trace_enabled_by_env():
+            trace_token = llm_trace.start_run(
+                request_id=run_id,
+                route_method="BACKGROUND",
+                route_path=f"/sessions/{payload.app_session_id}/run-all",
+                app_session_id=payload.app_session_id,
+            )
+        lock = _get_run_all_lock(payload.app_session_id)
+        try:
+            start_record = await _get_run_record(run_id)
+            await _publish_run_event(
+                run_id,
+                "snapshot",
+                _run_snapshot_payload(start_record),
+            )
+            async with lock:
+                steps, final_status, ok = await _execute_run_all_steps(
+                    payload=payload,
+                    api_keys=api_keys,
+                    model=model,
+                    event_hook=lambda event, data: _publish_run_event(run_id, event, data),
+                )
+        except asyncio.CancelledError:
+            _promote_effort_answers_for_retry(payload.app_session_id)
+            await _mark_background_run_terminal(
+                run_id=run_id,
+                app_session_id=payload.app_session_id,
+                status="cancelled",
+                event_name="run_cancelled",
+                message="Run cancelled by user",
+            )
+            if trace_token is not None:
+                try:
+                    llm_trace.flush_run(trace_token, status_code=499)
+                except Exception:
+                    pass
+            return
+        except Exception as exc:
+            await _mark_background_run_terminal(
+                run_id=run_id,
+                app_session_id=payload.app_session_id,
+                status="failed",
+                event_name="run_failed",
+                message=_step_error_message(exc),
+            )
+            if trace_token is not None:
+                try:
+                    llm_trace.flush_run(trace_token, status_code=500)
+                except Exception:
+                    pass
+            return
+
+        async with _RUN_REGISTRY_LOCK:
+            record = _RUNS_BY_ID.get(run_id)
+            if record is not None:
+                record.steps = steps
+                record.final_status = final_status
+                record.ok = ok
+                record.status = "completed" if ok else "failed"
+                record.updated_at = time.time()
+                if _ACTIVE_RUN_BY_SESSION.get(record.app_session_id) == run_id:
+                    _ACTIVE_RUN_BY_SESSION.pop(record.app_session_id, None)
+
+        record_after = await _get_run_record(run_id)
         await _publish_run_event(
             run_id,
             "snapshot",
-            _run_snapshot_payload(start_record),
+            _run_snapshot_payload(record_after),
         )
-        async with lock:
-            steps, final_status, ok = await _execute_run_all_steps(
-                payload=payload,
-                api_keys=api_keys,
-                model=model,
-                event_hook=lambda event, data: _publish_run_event(run_id, event, data),
-            )
-    except asyncio.CancelledError:
-        _promote_effort_answers_for_retry(payload.app_session_id)
-        await _mark_background_run_terminal(
-            run_id=run_id,
-            app_session_id=payload.app_session_id,
-            status="cancelled",
-            event_name="run_cancelled",
-            message="Run cancelled by user",
-        )
+        await _trim_finished_runs()
         if trace_token is not None:
             try:
-                llm_trace.flush_run(trace_token, status_code=499)
+                llm_trace.flush_run(trace_token, status_code=200 if ok else 500)
             except Exception:
                 pass
-        return
-    except Exception as exc:
-        await _mark_background_run_terminal(
-            run_id=run_id,
-            app_session_id=payload.app_session_id,
-            status="failed",
-            event_name="run_failed",
-            message=_step_error_message(exc),
-        )
-        if trace_token is not None:
-            try:
-                llm_trace.flush_run(trace_token, status_code=500)
-            except Exception:
-                pass
-        return
-
-    async with _RUN_REGISTRY_LOCK:
-        record = _RUNS_BY_ID.get(run_id)
-        if record is not None:
-            record.steps = steps
-            record.final_status = final_status
-            record.ok = ok
-            record.status = "completed" if ok else "failed"
-            record.updated_at = time.time()
-            if _ACTIVE_RUN_BY_SESSION.get(record.app_session_id) == run_id:
-                _ACTIVE_RUN_BY_SESSION.pop(record.app_session_id, None)
-
-    record_after = await _get_run_record(run_id)
-    await _publish_run_event(
-        run_id,
-        "snapshot",
-        _run_snapshot_payload(record_after),
-    )
-    await _trim_finished_runs()
-    if trace_token is not None:
-        try:
-            llm_trace.flush_run(trace_token, status_code=200 if ok else 500)
-        except Exception:
-            pass
+    finally:
+        _release_workflow_activity(session_id, workflow_activity_id)
 
 
 async def _run_single_step_background(
@@ -3097,61 +3239,66 @@ async def _run_single_step_background(
     payload: SessionRunAllRequest,
     api_keys: ApiKeys,
     model: str,
+    workflow_activity_id: str,
 ) -> None:
-    lock = _get_run_all_lock(payload.app_session_id)
+    session_id = db.get_session_id_by_app_id(payload.app_session_id)
     try:
-        start_record = await _get_run_record(run_id)
+        lock = _get_run_all_lock(payload.app_session_id)
+        try:
+            start_record = await _get_run_record(run_id)
+            await _publish_run_event(
+                run_id,
+                "snapshot",
+                _run_snapshot_payload(start_record),
+            )
+            async with lock:
+                steps, final_status, ok = await _execute_single_step(
+                    step_key=step_key,
+                    payload=payload,
+                    api_keys=api_keys,
+                    model=model,
+                    event_hook=lambda event, data: _publish_run_event(run_id, event, data),
+                )
+        except asyncio.CancelledError:
+            _promote_effort_answers_for_retry(payload.app_session_id)
+            await _mark_background_run_terminal(
+                run_id=run_id,
+                app_session_id=payload.app_session_id,
+                status="cancelled",
+                event_name="run_cancelled",
+                message="Run cancelled by user",
+            )
+            return
+        except Exception as exc:
+            await _mark_background_run_terminal(
+                run_id=run_id,
+                app_session_id=payload.app_session_id,
+                status="failed",
+                event_name="run_failed",
+                message=_step_error_message(exc),
+            )
+            return
+
+        async with _RUN_REGISTRY_LOCK:
+            record = _RUNS_BY_ID.get(run_id)
+            if record is not None:
+                record.steps = steps
+                record.final_status = final_status
+                record.ok = ok
+                record.status = "completed" if ok else "failed"
+                record.updated_at = time.time()
+                if _ACTIVE_RUN_BY_SESSION.get(record.app_session_id) == run_id:
+                    _ACTIVE_RUN_BY_SESSION.pop(record.app_session_id, None)
+
+        record_after = await _get_run_record(run_id)
         await _publish_run_event(
             run_id,
             "snapshot",
-            _run_snapshot_payload(start_record),
+            _run_snapshot_payload(record_after),
         )
-        async with lock:
-            steps, final_status, ok = await _execute_single_step(
-                step_key=step_key,
-                payload=payload,
-                api_keys=api_keys,
-                model=model,
-                event_hook=lambda event, data: _publish_run_event(run_id, event, data),
-            )
-    except asyncio.CancelledError:
-        _promote_effort_answers_for_retry(payload.app_session_id)
-        await _mark_background_run_terminal(
-            run_id=run_id,
-            app_session_id=payload.app_session_id,
-            status="cancelled",
-            event_name="run_cancelled",
-            message="Run cancelled by user",
-        )
-        return
-    except Exception as exc:
-        await _mark_background_run_terminal(
-            run_id=run_id,
-            app_session_id=payload.app_session_id,
-            status="failed",
-            event_name="run_failed",
-            message=_step_error_message(exc),
-        )
-        return
-
-    async with _RUN_REGISTRY_LOCK:
-        record = _RUNS_BY_ID.get(run_id)
-        if record is not None:
-            record.steps = steps
-            record.final_status = final_status
-            record.ok = ok
-            record.status = "completed" if ok else "failed"
-            record.updated_at = time.time()
-            if _ACTIVE_RUN_BY_SESSION.get(record.app_session_id) == run_id:
-                _ACTIVE_RUN_BY_SESSION.pop(record.app_session_id, None)
-
-    record_after = await _get_run_record(run_id)
-    await _publish_run_event(
-        run_id,
-        "snapshot",
-        _run_snapshot_payload(record_after),
-    )
-    await _trim_finished_runs()
+        await _trim_finished_runs()
+    finally:
+        _release_workflow_activity(session_id, workflow_activity_id)
 
 
 @router.post("/step-runs/start", response_model=SessionRunAllStartResponse)
@@ -3165,6 +3312,7 @@ async def start_step_run(
         payload.app_session_id,
         payload.model,
     )
+    workflow_activity_id: str | None = None
 
     async with _RUN_REGISTRY_LOCK:
         active_run_id = _ACTIVE_RUN_BY_SESSION.get(payload.app_session_id)
@@ -3178,6 +3326,19 @@ async def start_step_run(
                     status="running",
                 )
             _ACTIVE_RUN_BY_SESSION.pop(payload.app_session_id, None)
+
+        try:
+            workflow_activity = begin_session_activity(
+                session_id=_session_id,
+                activity_type="workflow",
+                label=RUN_ALL_STEP_BY_KEY[payload.step_key][0],
+                ttl_seconds=WORKFLOW_LEASE_SECONDS,
+            )
+            workflow_activity_id = workflow_activity.activity_id
+        except SessionActivityConflict as exc:
+            raise_session_activity_conflict(exc)
+        except SessionActivityUnavailable as exc:
+            raise_session_activity_unavailable(exc)
 
         run_id = uuid.uuid4().hex
         record = _RunRecord(
@@ -3201,6 +3362,7 @@ async def start_step_run(
             run_payload,
             api_keys,
             model,
+            workflow_activity_id,
         )
     )
     async with _RUN_REGISTRY_LOCK:
@@ -3242,6 +3404,7 @@ async def start_run_all_steps(
         payload.app_session_id,
         payload.model,
     )
+    workflow_activity_id: str | None = None
 
     async with _RUN_REGISTRY_LOCK:
         active_run_id = _ACTIVE_RUN_BY_SESSION.get(payload.app_session_id)
@@ -3256,6 +3419,19 @@ async def start_run_all_steps(
                 )
             _ACTIVE_RUN_BY_SESSION.pop(payload.app_session_id, None)
 
+        try:
+            workflow_activity = begin_session_activity(
+                session_id=_session_id,
+                activity_type="workflow",
+                label="Alle Schritte ausführen",
+                ttl_seconds=WORKFLOW_LEASE_SECONDS,
+            )
+            workflow_activity_id = workflow_activity.activity_id
+        except SessionActivityConflict as exc:
+            raise_session_activity_conflict(exc)
+        except SessionActivityUnavailable as exc:
+            raise_session_activity_unavailable(exc)
+
         run_id = uuid.uuid4().hex
         record = _RunRecord(
             run_id=run_id,
@@ -3264,7 +3440,9 @@ async def start_run_all_steps(
         _RUNS_BY_ID[run_id] = record
         _ACTIVE_RUN_BY_SESSION[payload.app_session_id] = run_id
 
-    task = asyncio.create_task(_run_all_background(run_id, payload, api_keys, model))
+    task = asyncio.create_task(
+        _run_all_background(run_id, payload, api_keys, model, workflow_activity_id)
+    )
     async with _RUN_REGISTRY_LOCK:
         active = _RUNS_BY_ID.get(run_id)
         if active is not None:

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import EaEditDrawerShell from "@/components/ea_edit/EaEditDrawerShell";
 import ModelSelector from "@/components/ModelSelector";
@@ -10,6 +10,12 @@ export default function Header() {
   const { state, setSelectedNormAddressee } = useApp();
   const [eaEditOpen, setEaEditOpen] = useState(false);
   const canOpenEditor = state.totalCostReady;
+
+  useEffect(() => {
+    if (!canOpenEditor) {
+      setEaEditOpen(false);
+    }
+  }, [canOpenEditor]);
 
   return (
     <header className="border-b border-white/20 bg-gradient-to-r from-slate-900 via-slate-800 to-slate-700 text-white shadow-xl">

--- a/frontend/src/components/SessionMenu.tsx
+++ b/frontend/src/components/SessionMenu.tsx
@@ -62,6 +62,15 @@ function formatElapsedDuration(totalSeconds: number): string {
   return `${minutes}:${String(seconds).padStart(2, "0")} min`;
 }
 
+function getApiDetailMessage(error: unknown): string | null {
+  const details = (error as ApiClientError | undefined)?.details;
+  if (typeof details !== "object" || details === null || Array.isArray(details)) {
+    return null;
+  }
+  const message = (details as Record<string, unknown>).message;
+  return typeof message === "string" && message.trim() ? message : null;
+}
+
 export default function SessionMenu({ compact }: SessionMenuProps) {
   const {
     state,
@@ -372,7 +381,10 @@ export default function SessionMenu({ compact }: SessionMenuProps) {
         appSessionId: state.appSessionId,
         lastStepLabel,
       });
-      setStatus("Letzter Schritt konnte nicht zurückgesetzt werden.");
+      setStatus(
+        getApiDetailMessage(error) ||
+          "Letzter Schritt konnte nicht zurückgesetzt werden."
+      );
     } finally {
       setIsUndoing(false);
     }

--- a/frontend/src/components/__tests__/Header.test.tsx
+++ b/frontend/src/components/__tests__/Header.test.tsx
@@ -80,4 +80,30 @@ describe("Header norm addressee switch", () => {
       screen.getByRole("button", { name: /ea bearbeiten/i })
     ).toBeEnabled();
   });
+
+  it("closes the EA drawer when total cost readiness is reset", async () => {
+    const user = userEvent.setup();
+    mockUseApp.mockReturnValue({
+      state: {
+        selectedNormAddressee: "administration",
+        totalCostReady: true,
+      },
+      setSelectedNormAddressee: jest.fn(),
+    });
+    const { rerender } = render(<Header />);
+
+    await user.click(screen.getByRole("button", { name: /ea bearbeiten/i }));
+    expect(screen.getByTestId("ea-drawer")).toHaveAttribute("data-open", "true");
+
+    mockUseApp.mockReturnValue({
+      state: {
+        selectedNormAddressee: "administration",
+        totalCostReady: false,
+      },
+      setSelectedNormAddressee: jest.fn(),
+    });
+    rerender(<Header />);
+
+    expect(screen.getByTestId("ea-drawer")).toHaveAttribute("data-open", "false");
+  });
 });

--- a/frontend/src/components/__tests__/SessionMenu.test.tsx
+++ b/frontend/src/components/__tests__/SessionMenu.test.tsx
@@ -222,6 +222,34 @@ describe("SessionMenu", () => {
     expect(mockUndoLastStep).toHaveBeenCalledWith("ABC123");
   });
 
+  it("shows the activity conflict reason when undo is blocked by EA editing", async () => {
+    const error = new Error("Conflict") as Error & {
+      status?: number;
+      details?: unknown;
+    };
+    error.status = 409;
+    error.details = {
+      error: "session_activity_conflict",
+      active_type: "ea_edit",
+      message:
+        "Diese Aktion ist während einer laufenden EA-Bearbeitung in derselben Session nicht möglich. Bitte die Bearbeitung zuerst abschließen.",
+    };
+    mockUndoLastStep.mockRejectedValueOnce(error);
+    const user = await openMenu();
+
+    await user.click(
+      screen.getByRole("button", {
+        name: /aufwand berechnen/i,
+      })
+    );
+
+    expect(
+      await screen.findByText(
+        /laufenden ea-bearbeitung in derselben session nicht möglich/i
+      )
+    ).toBeInTheDocument();
+  });
+
   it("prepares pending uploads before starting run-all", async () => {
     mockUseApp.mockReturnValue({
       state: {

--- a/frontend/src/components/ea_edit/EaCaseMetricsTab.tsx
+++ b/frontend/src/components/ea_edit/EaCaseMetricsTab.tsx
@@ -24,6 +24,8 @@ type EaCaseMetricsTabProps = {
   active: boolean;
   appSessionId: string;
   normAddressee: NormAddressee;
+  eaActivityId?: string | null;
+  readOnly?: boolean;
   runAutoRecompute: () => Promise<void>;
   onDirtyChange?: (dirty: boolean) => void;
 };
@@ -159,6 +161,8 @@ export default function EaCaseMetricsTab({
   active,
   appSessionId,
   normAddressee,
+  eaActivityId = null,
+  readOnly = false,
   runAutoRecompute,
   onDirtyChange,
 }: EaCaseMetricsTabProps) {
@@ -290,15 +294,27 @@ export default function EaCaseMetricsTab({
   );
 
   useEffect(() => {
-    onDirtyChange?.(changes.length > 0);
-  }, [changes.length, onDirtyChange]);
+    onDirtyChange?.(!readOnly && changes.length > 0);
+  }, [changes.length, onDirtyChange, readOnly]);
+
+  useEffect(() => {
+    if (!readOnly) {
+      return;
+    }
+    setDraft({});
+    setReviewMode(false);
+  }, [readOnly, setReviewMode]);
 
   const handleSave = async () => {
+    if (readOnly || changes.length === 0 || invalidCellCount > 0) {
+      return;
+    }
     try {
       await runSave(
         async () => {
           await apiClient.bulkUpdateCaseGroups({
             appSessionId,
+            eaActivityId: eaActivityId ?? undefined,
             rows: changes.map((item) => {
               const payloadRow = { case_group_id: item.row.case_group_id } as {
                 case_group_id: number;
@@ -326,7 +342,7 @@ export default function EaCaseMetricsTab({
   };
 
   const handleResetToModelValues = async () => {
-    if (rows.length === 0 || !hasEditedOverrides) {
+    if (readOnly || rows.length === 0 || !hasEditedOverrides) {
       return;
     }
     try {
@@ -334,6 +350,7 @@ export default function EaCaseMetricsTab({
         async () => {
           await apiClient.bulkUpdateCaseGroups({
             appSessionId,
+            eaActivityId: eaActivityId ?? undefined,
             rows: rows.map((row) => {
               const payloadRow = { case_group_id: row.case_group_id } as {
                 case_group_id: number;
@@ -431,6 +448,9 @@ export default function EaCaseMetricsTab({
                       : "border border-red-400 bg-red-50"
                   }`;
                 const updateField = (fieldKey: CaseFieldKey, value: string) => {
+                  if (readOnly) {
+                    return;
+                  }
                   setStatus(null);
                   setDraft((prev) => ({
                     ...prev,
@@ -450,6 +470,7 @@ export default function EaCaseMetricsTab({
                         <input
                           value={draftRow[field.key]}
                           onChange={(event) => updateField(field.key, event.target.value)}
+                          disabled={readOnly}
                           className={inputClass(draftRow[field.key])}
                         />
                         <EvidenceDisclosure
@@ -477,6 +498,7 @@ export default function EaCaseMetricsTab({
                         <input
                           value={draftRow[field.key]}
                           onChange={(event) => updateField(field.key, event.target.value)}
+                          disabled={readOnly}
                           className={inputClass(draftRow[field.key])}
                         />
                         <EvidenceDisclosure
@@ -502,14 +524,16 @@ export default function EaCaseMetricsTab({
           <div className="flex justify-end gap-2">
             <button
               onClick={handleResetToModelValues}
-              disabled={isSaving || rows.length === 0 || !hasEditedOverrides}
+              disabled={
+                isSaving || readOnly || !eaActivityId || rows.length === 0 || !hasEditedOverrides
+              }
               className="rounded-full border border-slate-300 px-4 py-2 text-xs font-semibold text-slate-700 disabled:cursor-not-allowed disabled:opacity-50"
             >
               Auf Modellwerte zurücksetzen
             </button>
             <button
               onClick={() => setReviewMode(true)}
-              disabled={changes.length === 0 || invalidCellCount > 0}
+              disabled={readOnly || !eaActivityId || changes.length === 0 || invalidCellCount > 0}
               className="rounded-full border border-slate-300 px-4 py-2 text-xs font-semibold text-slate-700 disabled:cursor-not-allowed disabled:opacity-50"
             >
               Prüfen
@@ -531,7 +555,13 @@ export default function EaCaseMetricsTab({
             </button>
             <button
               onClick={handleSave}
-              disabled={isSaving || changes.length === 0 || invalidCellCount > 0}
+              disabled={
+                isSaving ||
+                readOnly ||
+                !eaActivityId ||
+                changes.length === 0 ||
+                invalidCellCount > 0
+              }
               className="rounded-full bg-slate-900 px-4 py-2 text-xs font-semibold text-white disabled:cursor-not-allowed disabled:bg-slate-400"
             >
               {isSaving ? "Speichert..." : "Änderungen speichern"}

--- a/frontend/src/components/ea_edit/EaEditDrawerShell.tsx
+++ b/frontend/src/components/ea_edit/EaEditDrawerShell.tsx
@@ -5,6 +5,7 @@ import { createPortal } from "react-dom";
 
 import { useApp } from "@/contexts/AppContext";
 import { apiClient } from "@/lib/api";
+import type { ApiClientError } from "@/lib/api";
 import { logClientError } from "@/lib/errorFeedback";
 import { useMounted } from "@/lib/useMounted";
 import type { NormAddressee } from "@/types";
@@ -21,6 +22,13 @@ type EaEditDrawerShellProps = {
 };
 
 type EditorTab = "pay_rates" | "case_metrics" | "effort_metrics";
+type EaActivityState =
+  | "idle"
+  | "acquiring"
+  | "owned"
+  | "blocked_ea"
+  | "blocked_workflow"
+  | "unavailable";
 
 const NORM_ADDRESSEE_LABELS: Record<NormAddressee, string> = {
   administration: "Verwaltung",
@@ -43,10 +51,58 @@ const TAB_COPY: Record<EditorTab, { title: string; hint: string }> = {
   },
 };
 
+const EA_ACTIVITY_HEARTBEAT_MS = 30_000;
+
+function detailRecord(error: unknown): Record<string, unknown> | null {
+  const details = (error as ApiClientError | undefined)?.details;
+  if (typeof details !== "object" || details === null || Array.isArray(details)) {
+    return null;
+  }
+  return details as Record<string, unknown>;
+}
+
+function classifyEaActivityError(error: unknown): {
+  state: EaActivityState;
+  message: string;
+} {
+  const detail = detailRecord(error);
+  if (detail?.error === "session_activity_conflict") {
+    if (detail.active_type === "ea_edit") {
+      return {
+        state: "blocked_ea",
+        message:
+          "EA-Bearbeitung ist in dieser Session gerade in einem anderen Tab oder Fenster geöffnet. Bitte später erneut versuchen.",
+      };
+    }
+    if (detail.active_type === "workflow") {
+      return {
+        state: "blocked_workflow",
+        message:
+          "EA-Bearbeitung ist während einer laufenden Ausführung in dieser Session gesperrt. Bitte warten Sie, bis der Lauf abgeschlossen ist.",
+      };
+    }
+  }
+  if (detail?.error === "session_activity_unavailable") {
+    return {
+      state: "unavailable",
+      message:
+        "EA-Bearbeitung ist nicht mehr aktiv. Bitte den Editor schließen und erneut öffnen.",
+    };
+  }
+  return {
+    state: "unavailable",
+    message:
+      "EA-Bearbeitung ist in dieser Session gerade nicht möglich. Bitte später erneut versuchen.",
+  };
+}
+
 export default function EaEditDrawerShell({ open, onClose }: EaEditDrawerShellProps) {
   const isMounted = useMounted();
   const { state } = useApp();
   const [activeTab, setActiveTab] = useState<EditorTab>("pay_rates");
+  const [activityState, setActivityState] = useState<EaActivityState>("idle");
+  const [eaActivityId, setEaActivityId] = useState<string | null>(null);
+  const [activityStatus, setActivityStatus] = useState<string | null>(null);
   const [resetConfirmOpen, setResetConfirmOpen] = useState(false);
   const [isResettingAllEaEdits, setIsResettingAllEaEdits] = useState(false);
   const [resetStatus, setResetStatus] = useState<string | null>(null);
@@ -56,6 +112,7 @@ export default function EaEditDrawerShell({ open, onClose }: EaEditDrawerShellPr
   const { recomputeStatus, runAutoRecompute } = useDebouncedSessionRecompute({
     appSessionId: state.appSessionId,
     normAddressee: state.selectedNormAddressee,
+    eaActivityId,
     debounceMs: 400,
   });
   const {
@@ -66,6 +123,7 @@ export default function EaEditDrawerShell({ open, onClose }: EaEditDrawerShellPr
     continueEditing,
     discardAndClose,
     leadToSave,
+    resetDirtyState,
   } = useDrawerCloseGuard({
     open,
     sessionKey: state.appSessionId,
@@ -92,12 +150,121 @@ export default function EaEditDrawerShell({ open, onClose }: EaEditDrawerShellPr
     if (!open) {
       setResetConfirmOpen(false);
       setResetStatus(null);
+      setActivityState("idle");
       return;
     }
     setResetStatus(null);
   }, [open, state.appSessionId]);
 
+  useEffect(() => {
+    if (activityState !== "owned") {
+      resetDirtyState();
+    }
+  }, [activityState, resetDirtyState]);
+
+  useEffect(() => {
+    if (!open) {
+      setEaActivityId(null);
+      setActivityStatus(null);
+      setActivityState("idle");
+      return;
+    }
+
+    let cancelled = false;
+    let acquiredActivityId: string | null = null;
+    let heartbeatTimer: number | null = null;
+
+    const stopHeartbeat = () => {
+      if (heartbeatTimer !== null) {
+        window.clearInterval(heartbeatTimer);
+        heartbeatTimer = null;
+      }
+    };
+
+    const release = (activityId: string | null) => {
+      if (!activityId) {
+        return;
+      }
+      void apiClient
+        .releaseEaEditActivity({
+          appSessionId: state.appSessionId,
+          activityId,
+        })
+        .catch((error) => {
+          logClientError("EaEditDrawerShell.releaseActivity", error, {
+            appSessionId: state.appSessionId,
+          });
+        });
+    };
+
+    const heartbeat = async (activityId: string) => {
+      try {
+        await apiClient.heartbeatEaEditActivity({
+          appSessionId: state.appSessionId,
+          activityId,
+        });
+      } catch (error) {
+        if (cancelled) {
+          return;
+        }
+        stopHeartbeat();
+        logClientError("EaEditDrawerShell.heartbeatActivity", error, {
+          appSessionId: state.appSessionId,
+        });
+        setEaActivityId(null);
+        setActivityState("unavailable");
+        setActivityStatus(
+          "EA-Bearbeitung ist nicht mehr aktiv. Bitte den Editor schließen und erneut öffnen."
+        );
+      }
+    };
+
+    setEaActivityId(null);
+    setActivityState("acquiring");
+    setActivityStatus("EA-Bearbeitung wird gesperrt...");
+    apiClient
+      .acquireEaEditActivity({ appSessionId: state.appSessionId })
+      .then((payload) => {
+        acquiredActivityId = payload.activity_id;
+        if (cancelled) {
+          release(acquiredActivityId);
+          return;
+        }
+        setEaActivityId(payload.activity_id);
+        setActivityState("owned");
+        setActivityStatus(null);
+        heartbeatTimer = window.setInterval(() => {
+          void heartbeat(payload.activity_id);
+        }, EA_ACTIVITY_HEARTBEAT_MS);
+      })
+      .catch((error) => {
+        if (cancelled) {
+          return;
+        }
+        logClientError("EaEditDrawerShell.acquireActivity", error, {
+          appSessionId: state.appSessionId,
+        });
+        setEaActivityId(null);
+        const classified = classifyEaActivityError(error);
+        setActivityState(classified.state);
+        setActivityStatus(classified.message);
+      });
+
+    return () => {
+      cancelled = true;
+      stopHeartbeat();
+      release(acquiredActivityId);
+    };
+  }, [open, state.appSessionId]);
+
+  const ownsEaActivity = activityState === "owned" && Boolean(eaActivityId);
+  const drawerReadOnly = !ownsEaActivity;
+
   const handleTabDirtyChange = (tab: EditorTab, dirty: boolean) => {
+    if (drawerReadOnly) {
+      markTabDirty(tab, false);
+      return;
+    }
     if (dirty) {
       setResetStatus(null);
     }
@@ -105,10 +272,16 @@ export default function EaEditDrawerShell({ open, onClose }: EaEditDrawerShellPr
   };
 
   const handleResetAllEaEdits = async () => {
+    if (drawerReadOnly || !eaActivityId) {
+      return;
+    }
     setIsResettingAllEaEdits(true);
     setResetStatus(null);
     try {
-      await apiClient.resetSessionEaEdits({ appSessionId: state.appSessionId });
+      await apiClient.resetSessionEaEdits({
+        appSessionId: state.appSessionId,
+        eaActivityId: eaActivityId ?? undefined,
+      });
       setResetConfirmOpen(false);
       setResetVersion((value) => value + 1);
       window.dispatchEvent(new Event("tiles-updated"));
@@ -130,6 +303,10 @@ export default function EaEditDrawerShell({ open, onClose }: EaEditDrawerShellPr
   }
 
   const normAddresseeLabel = NORM_ADDRESSEE_LABELS[state.selectedNormAddressee];
+  const activityStatusClass =
+    activityState === "blocked_ea"
+      ? "border-amber-300 bg-amber-100 text-amber-800"
+      : "border-slate-200 bg-slate-100 text-slate-700";
 
   const body = (
     <div className="pointer-events-none fixed inset-0 z-[85]">
@@ -153,7 +330,12 @@ export default function EaEditDrawerShell({ open, onClose }: EaEditDrawerShellPr
                 <button
                   type="button"
                   onClick={() => setResetConfirmOpen(true)}
-                  disabled={state.isComplianceExportRunning || isResettingAllEaEdits}
+                  disabled={
+                    state.isComplianceExportRunning ||
+                    isResettingAllEaEdits ||
+                    drawerReadOnly ||
+                    !eaActivityId
+                  }
                   className="rounded-full border border-rose-200 px-3 py-1 text-xs font-semibold text-rose-700 disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   Alle EA-Werte auf Modellwerte zurücksetzen
@@ -195,6 +377,13 @@ export default function EaEditDrawerShell({ open, onClose }: EaEditDrawerShellPr
                 Vorblatt/Begründung wird gerade erzeugt. EA-Werte sind bis zum Abschluss gesperrt.
               </div>
             )}
+            {activityStatus && (
+              <div
+                className={`mt-2 rounded-xl border px-3 py-2 text-xs font-semibold ${activityStatusClass}`}
+              >
+                {activityStatus}
+              </div>
+            )}
             {resetStatus && (
               <div className="mt-2 rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-xs font-semibold text-amber-800">
                 {resetStatus}
@@ -214,6 +403,8 @@ export default function EaEditDrawerShell({ open, onClose }: EaEditDrawerShellPr
                   active={activeTab === "pay_rates"}
                   appSessionId={state.appSessionId}
                   normAddressee={state.selectedNormAddressee}
+                  eaActivityId={eaActivityId}
+                  readOnly={drawerReadOnly}
                   runAutoRecompute={runAutoRecompute}
                   onDirtyChange={(dirty) => handleTabDirtyChange("pay_rates", dirty)}
                 />
@@ -223,6 +414,8 @@ export default function EaEditDrawerShell({ open, onClose }: EaEditDrawerShellPr
                   active={activeTab === "case_metrics"}
                   appSessionId={state.appSessionId}
                   normAddressee={state.selectedNormAddressee}
+                  eaActivityId={eaActivityId}
+                  readOnly={drawerReadOnly}
                   runAutoRecompute={runAutoRecompute}
                   onDirtyChange={(dirty) => handleTabDirtyChange("case_metrics", dirty)}
                 />
@@ -232,6 +425,8 @@ export default function EaEditDrawerShell({ open, onClose }: EaEditDrawerShellPr
                   active={activeTab === "effort_metrics"}
                   appSessionId={state.appSessionId}
                   normAddressee={state.selectedNormAddressee}
+                  eaActivityId={eaActivityId}
+                  readOnly={drawerReadOnly}
                   runAutoRecompute={runAutoRecompute}
                   onDirtyChange={(dirty) => handleTabDirtyChange("effort_metrics", dirty)}
                 />

--- a/frontend/src/components/ea_edit/EaEffortMetricsTab.tsx
+++ b/frontend/src/components/ea_edit/EaEffortMetricsTab.tsx
@@ -33,6 +33,8 @@ type EaEffortMetricsTabProps = {
   active: boolean;
   appSessionId: string;
   normAddressee: NormAddressee;
+  eaActivityId?: string | null;
+  readOnly?: boolean;
   runAutoRecompute: () => Promise<void>;
   onDirtyChange?: (dirty: boolean) => void;
 };
@@ -343,6 +345,8 @@ export default function EaEffortMetricsTab({
   active,
   appSessionId,
   normAddressee,
+  eaActivityId = null,
+  readOnly = false,
   runAutoRecompute,
   onDirtyChange,
 }: EaEffortMetricsTabProps) {
@@ -732,10 +736,21 @@ export default function EaEffortMetricsTab({
   );
 
   useEffect(() => {
-    onDirtyChange?.(changes.length > 0);
-  }, [changes.length, onDirtyChange]);
+    onDirtyChange?.(!readOnly && changes.length > 0);
+  }, [changes.length, onDirtyChange, readOnly]);
+
+  useEffect(() => {
+    if (!readOnly) {
+      return;
+    }
+    setDraft({});
+    setReviewMode(false);
+  }, [readOnly, setReviewMode]);
 
   const handleSave = async () => {
+    if (readOnly || changes.length === 0 || invalidCellCount > 0) {
+      return;
+    }
     try {
       await runSave(
         async () => {
@@ -770,11 +785,16 @@ export default function EaEffortMetricsTab({
             }
           }
           if (bulkRows.length > 0) {
-            await apiClient.bulkUpdateProcessSteps({ appSessionId, rows: bulkRows });
+            await apiClient.bulkUpdateProcessSteps({
+              appSessionId,
+              eaActivityId: eaActivityId ?? undefined,
+              rows: bulkRows,
+            });
           }
           for (const edit of personnelEdits) {
             await apiClient.updatePersonnelEffortTime({
               appSessionId,
+              eaActivityId: eaActivityId ?? undefined,
               normAddressee: edit.row.norm_addressee,
               stepId: edit.row.step_id,
               period: edit.save.period,
@@ -802,7 +822,7 @@ export default function EaEffortMetricsTab({
   };
 
   const handleResetToModelValues = async () => {
-    if (stepRowsForChanges.length === 0 || !hasEditedOverrides) {
+    if (readOnly || stepRowsForChanges.length === 0 || !hasEditedOverrides) {
       return;
     }
     try {
@@ -814,6 +834,7 @@ export default function EaEffortMetricsTab({
           if (hasBulkEdited) {
             await apiClient.bulkUpdateProcessSteps({
               appSessionId,
+              eaActivityId: eaActivityId ?? undefined,
               rows: stepRowsForChanges.map((row) => {
                 const payloadRow = { step_id: row.step_id } as {
                   step_id: number;
@@ -832,6 +853,7 @@ export default function EaEffortMetricsTab({
               }
               await apiClient.updatePersonnelEffortTime({
                 appSessionId,
+                eaActivityId: eaActivityId ?? undefined,
                 normAddressee: row.norm_addressee,
                 stepId: row.step_id,
                 period: cell.save.period,
@@ -982,6 +1004,9 @@ export default function EaEffortMetricsTab({
                       : "border border-red-400 bg-red-50"
                   }`;
                 const updateField = (cellKey: string, value: string) => {
+                  if (readOnly) {
+                    return;
+                  }
                   setStatus(null);
                   setDraft((prev) => ({
                     ...prev,
@@ -1007,6 +1032,7 @@ export default function EaEffortMetricsTab({
                               <input
                                 value={draftRow[cell.key] ?? ""}
                                 onChange={(event) => updateField(cell.key, event.target.value)}
+                                disabled={readOnly}
                                 className={inputClass(draftRow[cell.key] ?? "")}
                               />
                               {columnCells.length > 1 && cell.sourceTag && (
@@ -1050,7 +1076,13 @@ export default function EaEffortMetricsTab({
           <div className="flex justify-end">
             <button
               onClick={handleResetToModelValues}
-              disabled={isSaving || stepRowsForChanges.length === 0 || !hasEditedOverrides}
+              disabled={
+                isSaving ||
+                readOnly ||
+                !eaActivityId ||
+                stepRowsForChanges.length === 0 ||
+                !hasEditedOverrides
+              }
               className="rounded-full border border-slate-300 px-4 py-2 text-xs font-semibold text-slate-700 disabled:cursor-not-allowed disabled:opacity-50"
             >
               Auf Modellwerte zurücksetzen
@@ -1059,7 +1091,7 @@ export default function EaEffortMetricsTab({
           <div className="flex justify-end">
             <button
               onClick={() => setReviewMode(true)}
-              disabled={changes.length === 0 || invalidCellCount > 0}
+              disabled={readOnly || !eaActivityId || changes.length === 0 || invalidCellCount > 0}
               className="rounded-full border border-slate-300 px-4 py-2 text-xs font-semibold text-slate-700 disabled:cursor-not-allowed disabled:opacity-50"
             >
               Prüfen
@@ -1082,7 +1114,13 @@ export default function EaEffortMetricsTab({
             </button>
             <button
               onClick={handleSave}
-              disabled={isSaving || changes.length === 0 || invalidCellCount > 0}
+              disabled={
+                isSaving ||
+                readOnly ||
+                !eaActivityId ||
+                changes.length === 0 ||
+                invalidCellCount > 0
+              }
               className="rounded-full bg-slate-900 px-4 py-2 text-xs font-semibold text-white disabled:cursor-not-allowed disabled:bg-slate-400"
             >
               {isSaving ? "Speichert..." : "Änderungen speichern"}

--- a/frontend/src/components/ea_edit/EaPayRatesTab.tsx
+++ b/frontend/src/components/ea_edit/EaPayRatesTab.tsx
@@ -18,6 +18,8 @@ type EaPayRatesTabProps = {
   active: boolean;
   appSessionId: string;
   normAddressee: NormAddressee;
+  eaActivityId?: string | null;
+  readOnly?: boolean;
   runAutoRecompute: () => Promise<void>;
   onDirtyChange?: (dirty: boolean) => void;
 };
@@ -98,6 +100,8 @@ export default function EaPayRatesTab({
   active,
   appSessionId,
   normAddressee,
+  eaActivityId = null,
+  readOnly = false,
   runAutoRecompute,
   onDirtyChange,
 }: EaPayRatesTabProps) {
@@ -137,8 +141,15 @@ export default function EaPayRatesTab({
   );
 
   useEffect(() => {
-    onDirtyChange?.(dirtyRows.length > 0);
-  }, [dirtyRows, onDirtyChange]);
+    onDirtyChange?.(!readOnly && dirtyRows.length > 0);
+  }, [dirtyRows, onDirtyChange, readOnly]);
+
+  useEffect(() => {
+    if (!readOnly) {
+      return;
+    }
+    setEditedInputs({});
+  }, [readOnly]);
 
   const loadRows = useCallback(async () => {
     setIsLoading(true);
@@ -177,7 +188,7 @@ export default function EaPayRatesTab({
   }, [open, active, normAddressee, loadRows, loadedKey, loadKey]);
 
   const handleSave = async () => {
-    if (dirtyRows.length === 0 || hasInvalidInput) {
+    if (readOnly || dirtyRows.length === 0 || hasInvalidInput) {
       return;
     }
     try {
@@ -187,6 +198,7 @@ export default function EaPayRatesTab({
             await apiClient.updateSessionWageRate({
               appSessionId,
               normAddressee,
+              eaActivityId: eaActivityId ?? undefined,
               wageSourceKind: row.wage_source_kind,
               wageSourceValue: row.wage_source_value,
               qualification: row.qualification,
@@ -208,7 +220,7 @@ export default function EaPayRatesTab({
   };
 
   const handleResetEdited = async () => {
-    if (!hasActiveEdited) {
+    if (readOnly || !hasActiveEdited) {
       return;
     }
     try {
@@ -218,6 +230,7 @@ export default function EaPayRatesTab({
             await apiClient.updateSessionWageRate({
               appSessionId,
               normAddressee,
+              eaActivityId: eaActivityId ?? undefined,
               wageSourceKind: row.wage_source_kind,
               wageSourceValue: row.wage_source_value,
               qualification: row.qualification,
@@ -341,12 +354,16 @@ export default function EaPayRatesTab({
                               : ""
                           }
                           onChange={(event) => {
+                            if (readOnly) {
+                              return;
+                            }
                             setStatus(null);
                             setEditedInputs((prev) => ({
                               ...prev,
                               [key]: event.target.value,
                             }));
                           }}
+                          disabled={readOnly}
                           className={inputClass(editedInputs[key] ?? "")}
                         />
                       </td>
@@ -361,14 +378,14 @@ export default function EaPayRatesTab({
       <div className="flex justify-end gap-2">
         <button
           onClick={handleResetEdited}
-          disabled={isSaving || !hasActiveEdited}
+          disabled={isSaving || readOnly || !eaActivityId || !hasActiveEdited}
           className="rounded-full border border-slate-300 px-4 py-2 text-xs font-semibold text-slate-700 disabled:cursor-not-allowed disabled:opacity-50"
         >
           Auf Modellwerte zurücksetzen
         </button>
         <button
           onClick={handleSave}
-          disabled={isSaving || hasInvalidInput || dirtyRows.length === 0}
+          disabled={isSaving || readOnly || !eaActivityId || hasInvalidInput || dirtyRows.length === 0}
           className="rounded-full bg-slate-900 px-4 py-2 text-xs font-semibold text-white disabled:cursor-not-allowed disabled:bg-slate-400"
         >
           {isSaving ? "Speichert..." : "Lohnsätze speichern"}

--- a/frontend/src/components/ea_edit/__tests__/EaCaseMetricsTab.test.tsx
+++ b/frontend/src/components/ea_edit/__tests__/EaCaseMetricsTab.test.tsx
@@ -13,6 +13,7 @@ jest.mock("@/lib/api", () => ({
 
 const mockGetEditableCaseGroups = apiClient.getEditableCaseGroups as jest.Mock;
 const mockBulkUpdateCaseGroups = apiClient.bulkUpdateCaseGroups as jest.Mock;
+const EA_ACTIVITY_ID = "ea_edit:test";
 
 describe("EaCaseMetricsTab", () => {
   beforeEach(() => {
@@ -58,6 +59,7 @@ describe("EaCaseMetricsTab", () => {
         open
         active
         appSessionId="CASE-TAB"
+        eaActivityId={EA_ACTIVITY_ID}
         runAutoRecompute={runAutoRecompute}
       />
     );
@@ -82,6 +84,7 @@ describe("EaCaseMetricsTab", () => {
     await waitFor(() => expect(mockBulkUpdateCaseGroups).toHaveBeenCalledTimes(1));
     expect(mockBulkUpdateCaseGroups).toHaveBeenCalledWith({
       appSessionId: "CASE-TAB",
+      eaActivityId: EA_ACTIVITY_ID,
       rows: [
         {
           case_group_id: 11,
@@ -131,6 +134,7 @@ describe("EaCaseMetricsTab", () => {
         open
         active
         appSessionId="CASE-TAB"
+        eaActivityId={EA_ACTIVITY_ID}
         runAutoRecompute={jest.fn()}
       />
     );
@@ -193,6 +197,7 @@ describe("EaCaseMetricsTab", () => {
         open
         active
         appSessionId="CASE-TAB"
+        eaActivityId={EA_ACTIVITY_ID}
         runAutoRecompute={jest.fn()}
       />
     );
@@ -251,6 +256,7 @@ describe("EaCaseMetricsTab", () => {
         open
         active
         appSessionId="CASE-TAB"
+        eaActivityId={EA_ACTIVITY_ID}
         runAutoRecompute={jest.fn()}
       />
     );
@@ -298,6 +304,7 @@ describe("EaCaseMetricsTab", () => {
         open
         active
         appSessionId="CASE-TAB"
+        eaActivityId={EA_ACTIVITY_ID}
         runAutoRecompute={jest.fn()}
       />
     );
@@ -317,6 +324,7 @@ describe("EaCaseMetricsTab", () => {
         open
         active
         appSessionId="CASE-TAB"
+        eaActivityId={EA_ACTIVITY_ID}
         runAutoRecompute={jest.fn()}
       />
     );
@@ -372,6 +380,7 @@ describe("EaCaseMetricsTab", () => {
         open
         active
         appSessionId="CASE-TAB"
+        eaActivityId={EA_ACTIVITY_ID}
         runAutoRecompute={runAutoRecompute}
       />
     );
@@ -390,6 +399,7 @@ describe("EaCaseMetricsTab", () => {
     await waitFor(() => expect(mockBulkUpdateCaseGroups).toHaveBeenCalledTimes(1));
     expect(mockBulkUpdateCaseGroups).toHaveBeenCalledWith({
       appSessionId: "CASE-TAB",
+      eaActivityId: EA_ACTIVITY_ID,
       rows: [
         {
           case_group_id: 11,
@@ -409,6 +419,7 @@ describe("EaCaseMetricsTab", () => {
         open
         active
         appSessionId="CASE-TAB"
+        eaActivityId={EA_ACTIVITY_ID}
         runAutoRecompute={jest.fn()}
       />
     );
@@ -425,6 +436,7 @@ describe("EaCaseMetricsTab", () => {
         open
         active
         appSessionId="CASE-TAB"
+        eaActivityId={EA_ACTIVITY_ID}
         runAutoRecompute={jest.fn()}
       />
     );
@@ -444,6 +456,7 @@ describe("EaCaseMetricsTab", () => {
         open
         active={false}
         appSessionId="CASE-TAB"
+        eaActivityId={EA_ACTIVITY_ID}
         runAutoRecompute={jest.fn()}
       />
     );
@@ -452,6 +465,7 @@ describe("EaCaseMetricsTab", () => {
         open
         active
         appSessionId="CASE-TAB"
+        eaActivityId={EA_ACTIVITY_ID}
         runAutoRecompute={jest.fn()}
       />
     );

--- a/frontend/src/components/ea_edit/__tests__/EaEditDrawerShell.integration.test.tsx
+++ b/frontend/src/components/ea_edit/__tests__/EaEditDrawerShell.integration.test.tsx
@@ -15,6 +15,9 @@ jest.mock("@/lib/useMounted", () => ({
 
 jest.mock("@/lib/api", () => ({
   apiClient: {
+    acquireEaEditActivity: jest.fn(),
+    heartbeatEaEditActivity: jest.fn(),
+    releaseEaEditActivity: jest.fn(),
     computeTotalCost: jest.fn(),
     getSessionWageRates: jest.fn(),
     updateSessionWageRate: jest.fn(),
@@ -24,6 +27,9 @@ jest.mock("@/lib/api", () => ({
 }));
 
 const mockUseApp = useApp as jest.Mock;
+const mockAcquireEaEditActivity = apiClient.acquireEaEditActivity as jest.Mock;
+const mockHeartbeatEaEditActivity = apiClient.heartbeatEaEditActivity as jest.Mock;
+const mockReleaseEaEditActivity = apiClient.releaseEaEditActivity as jest.Mock;
 const mockGetSessionWageRates = apiClient.getSessionWageRates as jest.Mock;
 const mockUpdateSessionWageRate = apiClient.updateSessionWageRate as jest.Mock;
 const mockComputeTotalCost = apiClient.computeTotalCost as jest.Mock;
@@ -47,6 +53,19 @@ describe("EaEditDrawerShell integration", () => {
       app_session_id: "EA-INTEGRATION",
       rows: ADMIN_WAGE_ROWS,
     });
+    mockAcquireEaEditActivity.mockResolvedValue({
+      app_session_id: "EA-INTEGRATION",
+      activity_id: "ea_edit:integration",
+      lease_seconds: 120,
+      expires_at: 123,
+    });
+    mockHeartbeatEaEditActivity.mockResolvedValue({
+      app_session_id: "EA-INTEGRATION",
+      activity_id: "ea_edit:integration",
+      lease_seconds: 120,
+      expires_at: 456,
+    });
+    mockReleaseEaEditActivity.mockResolvedValue({ ok: true });
   });
 
   it("opens close guard after real pay-rate edit", async () => {

--- a/frontend/src/components/ea_edit/__tests__/EaEditDrawerShell.test.tsx
+++ b/frontend/src/components/ea_edit/__tests__/EaEditDrawerShell.test.tsx
@@ -11,6 +11,9 @@ jest.mock("@/contexts/AppContext", () => ({
 
 jest.mock("@/lib/api", () => ({
   apiClient: {
+    acquireEaEditActivity: jest.fn(),
+    heartbeatEaEditActivity: jest.fn(),
+    releaseEaEditActivity: jest.fn(),
     computeTotalCost: jest.fn(),
     resetSessionEaEdits: jest.fn(),
   },
@@ -24,10 +27,12 @@ jest.mock("@/components/ea_edit/EaPayRatesTab", () => ({
   __esModule: true,
   default: ({
     active,
+    readOnly,
     runAutoRecompute,
     onDirtyChange,
   }: {
     active: boolean;
+    readOnly?: boolean;
     runAutoRecompute: () => Promise<void>;
     onDirtyChange?: (dirty: boolean) => void;
   }) =>
@@ -35,16 +40,17 @@ jest.mock("@/components/ea_edit/EaPayRatesTab", () => ({
       <>
         <button
           type="button"
+          disabled={readOnly}
           onClick={() => {
             void runAutoRecompute().catch(() => undefined);
           }}
         >
           Trigger Recompute
         </button>
-        <button type="button" onClick={() => onDirtyChange?.(true)}>
+        <button type="button" disabled={readOnly} onClick={() => onDirtyChange?.(true)}>
           Mark Dirty
         </button>
-        <button type="button" onClick={() => onDirtyChange?.(false)}>
+        <button type="button" disabled={readOnly} onClick={() => onDirtyChange?.(false)}>
           Mark Clean
         </button>
       </>
@@ -55,17 +61,19 @@ jest.mock("@/components/ea_edit/EaCaseMetricsTab", () => ({
   __esModule: true,
   default: ({
     active,
+    readOnly,
     onDirtyChange,
   }: {
     active: boolean;
+    readOnly?: boolean;
     onDirtyChange?: (dirty: boolean) => void;
   }) =>
     active ? (
       <>
-        <button type="button" onClick={() => onDirtyChange?.(true)}>
+        <button type="button" disabled={readOnly} onClick={() => onDirtyChange?.(true)}>
           Mark Case Dirty
         </button>
-        <button type="button" onClick={() => onDirtyChange?.(false)}>
+        <button type="button" disabled={readOnly} onClick={() => onDirtyChange?.(false)}>
           Mark Case Clean
         </button>
       </>
@@ -76,17 +84,19 @@ jest.mock("@/components/ea_edit/EaEffortMetricsTab", () => ({
   __esModule: true,
   default: ({
     active,
+    readOnly,
     onDirtyChange,
   }: {
     active: boolean;
+    readOnly?: boolean;
     onDirtyChange?: (dirty: boolean) => void;
   }) =>
     active ? (
       <>
-        <button type="button" onClick={() => onDirtyChange?.(true)}>
+        <button type="button" disabled={readOnly} onClick={() => onDirtyChange?.(true)}>
           Mark Effort Dirty
         </button>
-        <button type="button" onClick={() => onDirtyChange?.(false)}>
+        <button type="button" disabled={readOnly} onClick={() => onDirtyChange?.(false)}>
           Mark Effort Clean
         </button>
       </>
@@ -94,14 +104,28 @@ jest.mock("@/components/ea_edit/EaEffortMetricsTab", () => ({
 }));
 
 const mockUseApp = useApp as jest.Mock;
+const mockAcquireEaEditActivity = apiClient.acquireEaEditActivity as jest.Mock;
+const mockHeartbeatEaEditActivity = apiClient.heartbeatEaEditActivity as jest.Mock;
+const mockReleaseEaEditActivity = apiClient.releaseEaEditActivity as jest.Mock;
 const mockComputeTotalCost = apiClient.computeTotalCost as jest.Mock;
 const mockResetSessionEaEdits = apiClient.resetSessionEaEdits as jest.Mock;
 
 describe("EaEditDrawerShell", () => {
   beforeEach(() => {
     jest.useFakeTimers();
+    mockAcquireEaEditActivity.mockReset();
+    mockHeartbeatEaEditActivity.mockReset();
+    mockReleaseEaEditActivity.mockReset();
     mockComputeTotalCost.mockReset();
     mockResetSessionEaEdits.mockReset();
+    mockAcquireEaEditActivity.mockReturnValue(new Promise(() => undefined));
+    mockHeartbeatEaEditActivity.mockResolvedValue({
+      app_session_id: "EA-TEST",
+      activity_id: "ea_edit:test",
+      lease_seconds: 120,
+      expires_at: 456,
+    });
+    mockReleaseEaEditActivity.mockResolvedValue({ ok: true });
     mockResetSessionEaEdits.mockResolvedValue({
       app_session_id: "EA-TEST",
       reset_counts: { pay_rates: 1, case_groups: 2, process_steps: 3 },
@@ -120,9 +144,30 @@ describe("EaEditDrawerShell", () => {
     jest.useRealTimers();
   });
 
+  const waitForEaActivity = async () => {
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", {
+          name: /alle ea-werte auf modellwerte zurücksetzen/i,
+        })
+      ).toBeEnabled()
+    );
+  };
+
+  const mockSuccessfulActivityAcquire = () => {
+    mockAcquireEaEditActivity.mockResolvedValue({
+      app_session_id: "EA-TEST",
+      activity_id: "ea_edit:test",
+      lease_seconds: 120,
+      expires_at: 123,
+    });
+  };
+
   it("debounces recompute calls to a single provider call", async () => {
+    mockSuccessfulActivityAcquire();
     mockComputeTotalCost.mockResolvedValue({ total_cost: 1 });
     render(<EaEditDrawerShell open onClose={jest.fn()} />);
+    await waitForEaActivity();
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     const button = screen.getByRole("button", { name: /trigger recompute/i });
 
@@ -135,9 +180,105 @@ describe("EaEditDrawerShell", () => {
       jest.advanceTimersByTime(400);
     });
     await waitFor(() => expect(mockComputeTotalCost).toHaveBeenCalledTimes(1));
+    expect(mockComputeTotalCost).toHaveBeenCalledWith({
+      appSessionId: "EA-TEST",
+      normAddressee: "administration",
+      eaActivityId: "ea_edit:test",
+    });
+  });
+
+  it("releases the EA activity when the drawer closes", async () => {
+    mockSuccessfulActivityAcquire();
+    const { rerender } = render(<EaEditDrawerShell open onClose={jest.fn()} />);
+
+    await waitFor(() => expect(mockAcquireEaEditActivity).toHaveBeenCalledTimes(1));
+    rerender(<EaEditDrawerShell open={false} onClose={jest.fn()} />);
+
+    await waitFor(() =>
+      expect(mockReleaseEaEditActivity).toHaveBeenCalledWith({
+        appSessionId: "EA-TEST",
+        activityId: "ea_edit:test",
+      })
+    );
+  });
+
+  it("stops the heartbeat loop after a heartbeat failure", async () => {
+    mockSuccessfulActivityAcquire();
+    mockHeartbeatEaEditActivity.mockRejectedValue(new Error("activity expired"));
+    render(<EaEditDrawerShell open onClose={jest.fn()} />);
+
+    await waitForEaActivity();
+    await act(async () => {
+      jest.advanceTimersByTime(30_000);
+    });
+
+    expect(
+      await screen.findByText(/ea-bearbeitung ist nicht mehr aktiv/i)
+    ).toBeInTheDocument();
+    expect(mockHeartbeatEaEditActivity).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      jest.advanceTimersByTime(90_000);
+    });
+
+    expect(mockHeartbeatEaEditActivity).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps a same-session EA conflict drawer inspectable but read-only", async () => {
+    const onClose = jest.fn();
+    const error = Object.assign(new Error("conflict"), {
+      status: 409,
+      details: {
+        error: "session_activity_conflict",
+        active_type: "ea_edit",
+        message: "Backend conflict text",
+      },
+    });
+    mockAcquireEaEditActivity.mockRejectedValue(error);
+    render(<EaEditDrawerShell open onClose={onClose} />);
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+    expect(
+      await screen.findByText(/ander(en)? tab oder fenster/i)
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /mark dirty/i })).toBeDisabled();
+    expect(
+      screen.getByRole("button", {
+        name: /alle ea-werte auf modellwerte zurücksetzen/i,
+      })
+    ).toBeDisabled();
+
+    await user.click(screen.getByRole("button", { name: /fallzahlen/i }));
+    expect(screen.getByRole("button", { name: /mark case dirty/i })).toBeDisabled();
+
+    await user.click(screen.getByRole("button", { name: /^schließen$/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(
+      screen.queryByRole("dialog", { name: /ungespeicherte änderungen/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("uses the workflow conflict state for blocked EA editing", async () => {
+    const error = Object.assign(new Error("conflict"), {
+      status: 409,
+      details: {
+        error: "session_activity_conflict",
+        active_type: "workflow",
+        message: "Backend workflow conflict text",
+      },
+    });
+    mockAcquireEaEditActivity.mockRejectedValue(error);
+
+    render(<EaEditDrawerShell open onClose={jest.fn()} />);
+
+    expect(
+      await screen.findByText(/laufenden ausführung in dieser session/i)
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /mark dirty/i })).toBeDisabled();
   });
 
   it("keeps one in-flight recompute request per session", async () => {
+    mockSuccessfulActivityAcquire();
     let resolveFirst: (() => void) | null = null;
     mockComputeTotalCost.mockImplementation(
       () =>
@@ -148,6 +289,7 @@ describe("EaEditDrawerShell", () => {
 
     render(<EaEditDrawerShell open onClose={jest.fn()} />);
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    await waitForEaActivity();
     const button = screen.getByRole("button", { name: /trigger recompute/i });
 
     await user.click(button);
@@ -167,9 +309,11 @@ describe("EaEditDrawerShell", () => {
   });
 
   it("shows a status message on recompute failure", async () => {
+    mockSuccessfulActivityAcquire();
     mockComputeTotalCost.mockRejectedValue(new Error("boom"));
     render(<EaEditDrawerShell open onClose={jest.fn()} />);
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    await waitForEaActivity();
     const button = screen.getByRole("button", { name: /trigger recompute/i });
 
     await user.click(button);
@@ -183,9 +327,11 @@ describe("EaEditDrawerShell", () => {
   });
 
   it("shows close guard modal when unsaved changes exist", async () => {
+    mockSuccessfulActivityAcquire();
     const onClose = jest.fn();
     render(<EaEditDrawerShell open onClose={onClose} />);
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    await waitForEaActivity();
 
     await user.click(screen.getByRole("button", { name: /mark dirty/i }));
     await user.click(screen.getByRole("button", { name: /^schließen$/i }));
@@ -226,9 +372,11 @@ describe("EaEditDrawerShell", () => {
   });
 
   it("prompts to review dirty tabs on save-and-close", async () => {
+    mockSuccessfulActivityAcquire();
     const onClose = jest.fn();
     render(<EaEditDrawerShell open onClose={onClose} />);
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    await waitForEaActivity();
 
     await user.click(screen.getByRole("button", { name: /mark dirty/i }));
     await user.click(screen.getByRole("button", { name: /^schließen$/i }));
@@ -241,9 +389,11 @@ describe("EaEditDrawerShell", () => {
   });
 
   it("clears save guidance hint once all dirty tabs are clean", async () => {
+    mockSuccessfulActivityAcquire();
     const onClose = jest.fn();
     render(<EaEditDrawerShell open onClose={onClose} />);
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    await waitForEaActivity();
 
     await user.click(screen.getByRole("button", { name: /mark dirty/i }));
     await user.click(screen.getByRole("button", { name: /^schließen$/i }));
@@ -261,9 +411,11 @@ describe("EaEditDrawerShell", () => {
   });
 
   it("lists all dirty tabs and switches to the first dirty tab on save-and-close", async () => {
+    mockSuccessfulActivityAcquire();
     const onClose = jest.fn();
     render(<EaEditDrawerShell open onClose={onClose} />);
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    await waitForEaActivity();
 
     await user.click(screen.getByRole("button", { name: /fallzahlen/i }));
     await user.click(screen.getByRole("button", { name: /mark case dirty/i }));
@@ -282,9 +434,11 @@ describe("EaEditDrawerShell", () => {
   });
 
   it("keeps save guidance for remaining dirty tabs when one tab is cleaned", async () => {
+    mockSuccessfulActivityAcquire();
     const onClose = jest.fn();
     render(<EaEditDrawerShell open onClose={onClose} />);
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    await waitForEaActivity();
 
     await user.click(screen.getByRole("button", { name: /fallzahlen/i }));
     await user.click(screen.getByRole("button", { name: /mark case dirty/i }));
@@ -307,8 +461,10 @@ describe("EaEditDrawerShell", () => {
   });
 
   it("focuses 'Weiter bearbeiten' and closes modal on Escape", async () => {
+    mockSuccessfulActivityAcquire();
     render(<EaEditDrawerShell open onClose={jest.fn()} />);
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    await waitForEaActivity();
 
     await user.click(screen.getByRole("button", { name: /mark dirty/i }));
     await user.click(screen.getByRole("button", { name: /^schließen$/i }));
@@ -323,6 +479,7 @@ describe("EaEditDrawerShell", () => {
   });
 
   it("resets dirty close guard when session changes", async () => {
+    mockSuccessfulActivityAcquire();
     const onClose = jest.fn();
     let sessionId = "EA-TEST";
     mockUseApp.mockImplementation(() => ({
@@ -330,6 +487,7 @@ describe("EaEditDrawerShell", () => {
     }));
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     const { rerender } = render(<EaEditDrawerShell open onClose={onClose} />);
+    await waitForEaActivity();
 
     await user.click(screen.getByRole("button", { name: /mark dirty/i }));
     await user.click(screen.getByRole("button", { name: /^schließen$/i }));
@@ -367,9 +525,11 @@ describe("EaEditDrawerShell", () => {
   });
 
   it("resets all EA edits after explicit confirmation", async () => {
+    mockSuccessfulActivityAcquire();
     const dispatchSpy = jest.spyOn(window, "dispatchEvent");
     render(<EaEditDrawerShell open onClose={jest.fn()} />);
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    await waitForEaActivity();
 
     await user.click(
       screen.getByRole("button", {
@@ -391,6 +551,7 @@ describe("EaEditDrawerShell", () => {
     await waitFor(() =>
       expect(mockResetSessionEaEdits).toHaveBeenCalledWith({
         appSessionId: "EA-TEST",
+        eaActivityId: "ea_edit:test",
       })
     );
     expect(dispatchSpy).toHaveBeenCalledWith(expect.objectContaining({ type: "tiles-updated" }));
@@ -401,8 +562,10 @@ describe("EaEditDrawerShell", () => {
   });
 
   it("clears the global reset status when the drawer is reopened", async () => {
+    mockSuccessfulActivityAcquire();
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     const { rerender } = render(<EaEditDrawerShell open onClose={jest.fn()} />);
+    await waitForEaActivity();
 
     await user.click(
       screen.getByRole("button", {
@@ -415,6 +578,7 @@ describe("EaEditDrawerShell", () => {
     ).toBeInTheDocument();
 
     rerender(<EaEditDrawerShell open={false} onClose={jest.fn()} />);
+    mockAcquireEaEditActivity.mockReturnValue(new Promise(() => undefined));
     rerender(<EaEditDrawerShell open onClose={jest.fn()} />);
 
     expect(

--- a/frontend/src/components/ea_edit/__tests__/EaEffortMetricsTab.test.tsx
+++ b/frontend/src/components/ea_edit/__tests__/EaEffortMetricsTab.test.tsx
@@ -17,6 +17,7 @@ const mockGetEditableCaseGroups = apiClient.getEditableCaseGroups as jest.Mock;
 const mockGetEditableProcessSteps = apiClient.getEditableProcessSteps as jest.Mock;
 const mockBulkUpdateProcessSteps = apiClient.bulkUpdateProcessSteps as jest.Mock;
 const mockUpdatePersonnelEffortTime = apiClient.updatePersonnelEffortTime as jest.Mock;
+const EA_ACTIVITY_ID = "ea_edit:test";
 
 describe("EaEffortMetricsTab", () => {
   beforeEach(() => {
@@ -148,7 +149,7 @@ describe("EaEffortMetricsTab", () => {
       ],
     });
     render(
-      <EaEffortMetricsTab normAddressee="business" open active appSessionId="STEP-TAB" runAutoRecompute={jest.fn()} />
+      <EaEffortMetricsTab normAddressee="business" open active appSessionId="STEP-TAB" eaActivityId={EA_ACTIVITY_ID} runAutoRecompute={jest.fn()} />
     );
 
     const trR = (await screen.findByText("Schritt Kunst")).closest("tr") as HTMLElement;
@@ -219,7 +220,7 @@ describe("EaEffortMetricsTab", () => {
     });
 
     render(
-      <EaEffortMetricsTab normAddressee="citizens" open active appSessionId="STEP-TAB" runAutoRecompute={jest.fn()} />
+      <EaEffortMetricsTab normAddressee="citizens" open active appSessionId="STEP-TAB" eaActivityId={EA_ACTIVITY_ID} runAutoRecompute={jest.fn()} />
     );
 
     const tr = (await screen.findByText("Schritt Bürger")).closest("tr") as HTMLElement;
@@ -304,7 +305,7 @@ describe("EaEffortMetricsTab", () => {
   it("renders all qualifications editable under the step's single source", async () => {
     seedPersonnelStep();
     render(
-      <EaEffortMetricsTab normAddressee="administration" open active appSessionId="STEP-TAB" runAutoRecompute={jest.fn()} />
+      <EaEffortMetricsTab normAddressee="administration" open active appSessionId="STEP-TAB" eaActivityId={EA_ACTIVITY_ID} runAutoRecompute={jest.fn()} />
     );
 
     const row = await screen.findByText("Schritt R");
@@ -325,7 +326,7 @@ describe("EaEffortMetricsTab", () => {
     seedPersonnelStep();
     const runAutoRecompute = jest.fn().mockResolvedValue(undefined);
     render(
-      <EaEffortMetricsTab normAddressee="administration" open active appSessionId="STEP-TAB" runAutoRecompute={runAutoRecompute} />
+      <EaEffortMetricsTab normAddressee="administration" open active appSessionId="STEP-TAB" eaActivityId={EA_ACTIVITY_ID} runAutoRecompute={runAutoRecompute} />
     );
 
     const row = await screen.findByText("Schritt R");
@@ -348,6 +349,7 @@ describe("EaEffortMetricsTab", () => {
       wageSourceKind: "verwaltungsebene",
       wageSourceValue: "laender",
       timeRequiredInMinEdited: 5,
+      eaActivityId: EA_ACTIVITY_ID,
     });
     expect(mockBulkUpdateProcessSteps).not.toHaveBeenCalled();
     expect(runAutoRecompute).toHaveBeenCalledTimes(1);
@@ -358,7 +360,7 @@ describe("EaEffortMetricsTab", () => {
     // empty hD column upserts a row under the step's source.
     seedPersonnelStep();
     render(
-      <EaEffortMetricsTab normAddressee="administration" open active appSessionId="STEP-TAB" runAutoRecompute={jest.fn()} />
+      <EaEffortMetricsTab normAddressee="administration" open active appSessionId="STEP-TAB" eaActivityId={EA_ACTIVITY_ID} runAutoRecompute={jest.fn()} />
     );
 
     const row = await screen.findByText("Schritt R");
@@ -380,6 +382,7 @@ describe("EaEffortMetricsTab", () => {
       wageSourceKind: "verwaltungsebene",
       wageSourceValue: "laender",
       timeRequiredInMinEdited: 20,
+      eaActivityId: EA_ACTIVITY_ID,
     });
   });
 
@@ -398,7 +401,7 @@ describe("EaEffortMetricsTab", () => {
     });
     const runAutoRecompute = jest.fn().mockResolvedValue(undefined);
     render(
-      <EaEffortMetricsTab normAddressee="administration" open active appSessionId="STEP-TAB" runAutoRecompute={runAutoRecompute} />
+      <EaEffortMetricsTab normAddressee="administration" open active appSessionId="STEP-TAB" eaActivityId={EA_ACTIVITY_ID} runAutoRecompute={runAutoRecompute} />
     );
 
     await screen.findByText("Schritt R");
@@ -411,6 +414,7 @@ describe("EaEffortMetricsTab", () => {
         stepId: 201,
         period: "current",
         timeRequiredInMinEdited: null,
+        eaActivityId: EA_ACTIVITY_ID,
       })
     );
     // No step-level edits exist, so the slot bulk-update is skipped entirely.
@@ -425,6 +429,7 @@ describe("EaEffortMetricsTab", () => {
         open
         active
         appSessionId="STEP-TAB"
+        eaActivityId={EA_ACTIVITY_ID}
         runAutoRecompute={runAutoRecompute}
       />
     );
@@ -449,6 +454,7 @@ describe("EaEffortMetricsTab", () => {
     await waitFor(() => expect(mockBulkUpdateProcessSteps).toHaveBeenCalledTimes(1));
     expect(mockBulkUpdateProcessSteps).toHaveBeenCalledWith({
       appSessionId: "STEP-TAB",
+      eaActivityId: EA_ACTIVITY_ID,
       rows: [
         {
           step_id: 101,
@@ -517,6 +523,7 @@ describe("EaEffortMetricsTab", () => {
         open
         active
         appSessionId="STEP-TAB"
+        eaActivityId={EA_ACTIVITY_ID}
         runAutoRecompute={jest.fn()}
       />
     );
@@ -539,6 +546,7 @@ describe("EaEffortMetricsTab", () => {
         open
         active
         appSessionId="STEP-TAB"
+        eaActivityId={EA_ACTIVITY_ID}
         runAutoRecompute={jest.fn()}
       />
     );
@@ -556,6 +564,7 @@ describe("EaEffortMetricsTab", () => {
         open
         active
         appSessionId="STEP-TAB"
+        eaActivityId={EA_ACTIVITY_ID}
         runAutoRecompute={jest.fn()}
       />
     );
@@ -624,6 +633,7 @@ describe("EaEffortMetricsTab", () => {
         open
         active
         appSessionId="STEP-TAB"
+        eaActivityId={EA_ACTIVITY_ID}
         runAutoRecompute={runAutoRecompute}
       />
     );
@@ -637,6 +647,7 @@ describe("EaEffortMetricsTab", () => {
     await waitFor(() => expect(mockBulkUpdateProcessSteps).toHaveBeenCalledTimes(1));
     expect(mockBulkUpdateProcessSteps).toHaveBeenCalledWith({
       appSessionId: "STEP-TAB",
+      eaActivityId: EA_ACTIVITY_ID,
       rows: [
         {
           step_id: 101,
@@ -662,6 +673,7 @@ describe("EaEffortMetricsTab", () => {
         open
         active
         appSessionId="STEP-TAB"
+        eaActivityId={EA_ACTIVITY_ID}
         runAutoRecompute={jest.fn()}
       />
     );
@@ -698,6 +710,7 @@ describe("EaEffortMetricsTab", () => {
         open
         active
         appSessionId="STEP-TAB"
+        eaActivityId={EA_ACTIVITY_ID}
         runAutoRecompute={jest.fn()}
       />
     );
@@ -822,6 +835,7 @@ describe("EaEffortMetricsTab", () => {
         open
         active
         appSessionId="STEP-TAB"
+        eaActivityId={EA_ACTIVITY_ID}
         runAutoRecompute={runAutoRecompute}
       />
     );
@@ -877,6 +891,7 @@ describe("EaEffortMetricsTab", () => {
     await waitFor(() => expect(mockBulkUpdateProcessSteps).toHaveBeenCalledTimes(1));
     const call = mockBulkUpdateProcessSteps.mock.calls[0][0];
     expect(call.appSessionId).toBe("STEP-TAB");
+    expect(call.eaActivityId).toBe(EA_ACTIVITY_ID);
     expect(call.rows).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -898,6 +913,7 @@ describe("EaEffortMetricsTab", () => {
         open
         active
         appSessionId="STEP-TAB"
+        eaActivityId={EA_ACTIVITY_ID}
         runAutoRecompute={jest.fn()}
       />
     );
@@ -918,6 +934,7 @@ describe("EaEffortMetricsTab", () => {
         open
         active={false}
         appSessionId="STEP-TAB"
+        eaActivityId={EA_ACTIVITY_ID}
         runAutoRecompute={jest.fn()}
       />
     );
@@ -926,6 +943,7 @@ describe("EaEffortMetricsTab", () => {
         open
         active
         appSessionId="STEP-TAB"
+        eaActivityId={EA_ACTIVITY_ID}
         runAutoRecompute={jest.fn()}
       />
     );

--- a/frontend/src/components/ea_edit/__tests__/EaPayRatesTab.test.tsx
+++ b/frontend/src/components/ea_edit/__tests__/EaPayRatesTab.test.tsx
@@ -13,6 +13,7 @@ jest.mock("@/lib/api", () => ({
 
 const mockGetSessionWageRates = apiClient.getSessionWageRates as jest.Mock;
 const mockUpdateSessionWageRate = apiClient.updateSessionWageRate as jest.Mock;
+const EA_ACTIVITY_ID = "ea_edit:test";
 
 const ADMIN_ROWS = [
   {
@@ -61,7 +62,7 @@ describe("EaPayRatesTab", () => {
 
   it("groups rows under their wage source", async () => {
     render(
-      <EaPayRatesTab normAddressee="administration" open active appSessionId="PAY-TAB" runAutoRecompute={jest.fn()} />
+      <EaPayRatesTab normAddressee="administration" open active appSessionId="PAY-TAB" eaActivityId={EA_ACTIVITY_ID} runAutoRecompute={jest.fn()} />
     );
     expect(await screen.findByText("Bund")).toBeInTheDocument();
     expect(screen.getByText(/Gehobener Dienst \(gD\)/i)).toBeInTheDocument();
@@ -70,7 +71,7 @@ describe("EaPayRatesTab", () => {
   it("saves a single (source, qualification) override and recomputes", async () => {
     const runAutoRecompute = jest.fn().mockResolvedValue(undefined);
     render(
-      <EaPayRatesTab normAddressee="administration" open active appSessionId="PAY-TAB" runAutoRecompute={runAutoRecompute} />
+      <EaPayRatesTab normAddressee="administration" open active appSessionId="PAY-TAB" eaActivityId={EA_ACTIVITY_ID} runAutoRecompute={runAutoRecompute} />
     );
     await screen.findByText("Bund");
     const user = userEvent.setup();
@@ -85,6 +86,7 @@ describe("EaPayRatesTab", () => {
       wageSourceValue: "bund",
       qualification: "einfacher_und_mittlerer_dienst",
       hourlyRateEdited: 99,
+      eaActivityId: EA_ACTIVITY_ID,
     });
     expect(runAutoRecompute).toHaveBeenCalledTimes(1);
   });
@@ -92,7 +94,7 @@ describe("EaPayRatesTab", () => {
   it("clears a previous save status when the user edits again", async () => {
     const runAutoRecompute = jest.fn().mockResolvedValue(undefined);
     render(
-      <EaPayRatesTab normAddressee="administration" open active appSessionId="PAY-TAB" runAutoRecompute={runAutoRecompute} />
+      <EaPayRatesTab normAddressee="administration" open active appSessionId="PAY-TAB" eaActivityId={EA_ACTIVITY_ID} runAutoRecompute={runAutoRecompute} />
     );
 
     const row = await screen.findByText(/Einfacher\/Mittlerer Dienst \(eD\/mD\)/i);
@@ -124,7 +126,7 @@ describe("EaPayRatesTab", () => {
         window.dispatchEvent(new Event("tiles-updated"));
       });
       render(
-        <EaPayRatesTab normAddressee="administration" open active appSessionId="PAY-TAB" runAutoRecompute={runAutoRecompute} />
+        <EaPayRatesTab normAddressee="administration" open active appSessionId="PAY-TAB" eaActivityId={EA_ACTIVITY_ID} runAutoRecompute={runAutoRecompute} />
       );
 
       const row = await screen.findByText(/Einfacher\/Mittlerer Dienst \(eD\/mD\)/i);
@@ -146,7 +148,7 @@ describe("EaPayRatesTab", () => {
 
   it("disables save for invalid numeric input", async () => {
     render(
-      <EaPayRatesTab normAddressee="administration" open active appSessionId="PAY-TAB" runAutoRecompute={jest.fn()} />
+      <EaPayRatesTab normAddressee="administration" open active appSessionId="PAY-TAB" eaActivityId={EA_ACTIVITY_ID} runAutoRecompute={jest.fn()} />
     );
     await screen.findByText("Bund");
     const user = userEvent.setup();
@@ -157,7 +159,7 @@ describe("EaPayRatesTab", () => {
 
   it("disables save when there are no changes", async () => {
     render(
-      <EaPayRatesTab normAddressee="administration" open active appSessionId="PAY-TAB" runAutoRecompute={jest.fn()} />
+      <EaPayRatesTab normAddressee="administration" open active appSessionId="PAY-TAB" eaActivityId={EA_ACTIVITY_ID} runAutoRecompute={jest.fn()} />
     );
     await screen.findByText("Bund");
     expect(screen.getByRole("button", { name: /lohnsätze speichern/i })).toBeDisabled();
@@ -170,7 +172,7 @@ describe("EaPayRatesTab", () => {
     });
     const runAutoRecompute = jest.fn().mockResolvedValue(undefined);
     render(
-      <EaPayRatesTab normAddressee="administration" open active appSessionId="PAY-TAB" runAutoRecompute={runAutoRecompute} />
+      <EaPayRatesTab normAddressee="administration" open active appSessionId="PAY-TAB" eaActivityId={EA_ACTIVITY_ID} runAutoRecompute={runAutoRecompute} />
     );
     await screen.findByText("Bund");
     const user = userEvent.setup();
@@ -184,6 +186,7 @@ describe("EaPayRatesTab", () => {
       wageSourceValue: "bund",
       qualification: "einfacher_und_mittlerer_dienst",
       hourlyRateEdited: null,
+      eaActivityId: EA_ACTIVITY_ID,
     });
     expect(runAutoRecompute).toHaveBeenCalledTimes(1);
   });
@@ -202,7 +205,7 @@ describe("EaPayRatesTab", () => {
       ],
     });
     render(
-      <EaPayRatesTab normAddressee="business" open active appSessionId="PAY-TAB" runAutoRecompute={jest.fn()} />
+      <EaPayRatesTab normAddressee="business" open active appSessionId="PAY-TAB" eaActivityId={EA_ACTIVITY_ID} runAutoRecompute={jest.fn()} />
     );
     expect(
       await screen.findByText(/K · Finanz- und Versicherungsdienstleistungen/i)

--- a/frontend/src/components/ea_edit/useDebouncedSessionRecompute.ts
+++ b/frontend/src/components/ea_edit/useDebouncedSessionRecompute.ts
@@ -11,12 +11,14 @@ type UseDebouncedSessionRecomputeOptions = {
   // Required: without it /costs/compute silently defaults to administration, so an
   // edit of another addressee would recompute the wrong total. Enforced, not optional.
   normAddressee: NormAddressee;
+  eaActivityId: string | null;
   debounceMs?: number;
 };
 
 export function useDebouncedSessionRecompute({
   appSessionId,
   normAddressee,
+  eaActivityId,
   debounceMs = 400,
 }: UseDebouncedSessionRecomputeOptions) {
   const [recomputeStatus, setRecomputeStatus] = useState<string | null>(null);
@@ -65,7 +67,11 @@ export function useDebouncedSessionRecompute({
       return;
     }
     const request = (async () => {
-      await apiClient.computeTotalCost({ appSessionId, normAddressee });
+      await apiClient.computeTotalCost({
+        appSessionId,
+        normAddressee,
+        eaActivityId: eaActivityId ?? undefined,
+      });
       window.dispatchEvent(new Event("tiles-updated"));
     })();
     recomputeInFlightRef.current = request;
@@ -80,7 +86,7 @@ export function useDebouncedSessionRecompute({
     } finally {
       recomputeInFlightRef.current = null;
     }
-  }, [appSessionId, normAddressee, waitForDebounce]);
+  }, [appSessionId, normAddressee, eaActivityId, waitForDebounce]);
 
   return {
     recomputeStatus,

--- a/frontend/src/components/ea_edit/useDrawerCloseGuard.ts
+++ b/frontend/src/components/ea_edit/useDrawerCloseGuard.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 type TabInfo = { title: string };
 
@@ -18,6 +18,7 @@ type UseDrawerCloseGuardResult<TTab extends string> = {
   closeGuardHint: string | null;
   dirtyTabs: TTab[];
   markTabDirty: (tab: TTab, dirty: boolean) => void;
+  resetDirtyState: () => void;
   requestClose: () => void;
   continueEditing: () => void;
   discardAndClose: () => void;
@@ -77,14 +78,20 @@ export function useDrawerCloseGuard<TTab extends string>({
     );
   }, [closeGuardHint, dirtyTabs, tabs]);
 
-  const markTabDirty = (tab: TTab, dirty: boolean) => {
+  const markTabDirty = useCallback((tab: TTab, dirty: boolean) => {
     setUnsavedByTab((prev) => {
       if (prev[tab] === dirty) {
         return prev;
       }
       return { ...prev, [tab]: dirty };
     });
-  };
+  }, []);
+
+  const resetDirtyState = useCallback(() => {
+    setCloseConfirmOpen(false);
+    setCloseGuardHint(null);
+    setUnsavedByTab(emptyUnsavedByTab);
+  }, [emptyUnsavedByTab]);
 
   const requestClose = () => {
     if (!hasUnsavedChanges) {
@@ -126,6 +133,7 @@ export function useDrawerCloseGuard<TTab extends string>({
     closeGuardHint,
     dirtyTabs,
     markTabDirty,
+    resetDirtyState,
     requestClose,
     continueEditing,
     discardAndClose,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -125,7 +125,13 @@ async function parseErrorPayload(response: Response): Promise<{
 }
 
 function resolveDetailMessage(detail: unknown, rawText: string): string | null {
-  return (typeof detail === "string" ? detail : null) || rawText || null;
+  if (typeof detail === "string") {
+    return detail;
+  }
+  if (isRecord(detail) && typeof detail.message === "string") {
+    return detail.message;
+  }
+  return rawText || null;
 }
 
 function extractDetailError(detail: unknown): string | null {
@@ -636,9 +642,66 @@ export const apiClient = {
     }
     return response.json();
   },
-  async computeTotalCost(
-    options: { appSessionId: string; normAddressee?: NormAddressee }
-  ): Promise<TotalCostResponse> {
+  async acquireEaEditActivity(options: {
+    appSessionId: string;
+  }): Promise<{ app_session_id: string; activity_id: string; lease_seconds: number; expires_at?: number | null }> {
+    const response = await fetch(`${API_BASE_URL}/sessions/ea-edit-activity/acquire`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        app_session_id: options.appSessionId,
+      }),
+    });
+    if (!response.ok) {
+      await throwApiClientErrorFromResponse(response, "Failed to acquire EA edit activity");
+    }
+    return response.json();
+  },
+  async heartbeatEaEditActivity(options: {
+    appSessionId: string;
+    activityId: string;
+  }): Promise<{ app_session_id: string; activity_id: string; lease_seconds: number; expires_at?: number | null }> {
+    const response = await fetch(`${API_BASE_URL}/sessions/ea-edit-activity/heartbeat`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        app_session_id: options.appSessionId,
+        activity_id: options.activityId,
+      }),
+    });
+    if (!response.ok) {
+      await throwApiClientErrorFromResponse(response, "Failed to refresh EA edit activity");
+    }
+    return response.json();
+  },
+  async releaseEaEditActivity(options: {
+    appSessionId: string;
+    activityId: string;
+  }): Promise<{ ok: boolean }> {
+    const response = await fetch(`${API_BASE_URL}/sessions/ea-edit-activity/release`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        app_session_id: options.appSessionId,
+        activity_id: options.activityId,
+      }),
+    });
+    if (!response.ok) {
+      await throwApiClientErrorFromResponse(response, "Failed to release EA edit activity");
+    }
+    return response.json();
+  },
+  async computeTotalCost(options: {
+    appSessionId: string;
+    normAddressee?: NormAddressee;
+    eaActivityId?: string;
+  }): Promise<TotalCostResponse> {
     const response = await fetch(`${API_BASE_URL}/costs/compute`, {
       method: "POST",
       headers: {
@@ -647,6 +710,7 @@ export const apiClient = {
       body: JSON.stringify({
         app_session_id: options.appSessionId,
         norm_addressee: options.normAddressee,
+        ea_activity_id: options.eaActivityId,
       }),
     });
     if (!response.ok) {
@@ -657,6 +721,7 @@ export const apiClient = {
 
   async resetSessionEaEdits(options: {
     appSessionId: string;
+    eaActivityId?: string;
   }): Promise<{
     app_session_id: string;
     reset_counts: Record<string, number>;
@@ -669,6 +734,7 @@ export const apiClient = {
       },
       body: JSON.stringify({
         app_session_id: options.appSessionId,
+        ea_activity_id: options.eaActivityId,
       }),
     });
     if (!response.ok) {
@@ -696,6 +762,7 @@ export const apiClient = {
   async updateSessionWageRate(options: {
     appSessionId: string;
     normAddressee?: NormAddressee;
+    eaActivityId?: string;
     wageSourceKind: string;
     wageSourceValue: string;
     qualification: string;
@@ -709,6 +776,7 @@ export const apiClient = {
       body: JSON.stringify({
         app_session_id: options.appSessionId,
         norm_addressee: options.normAddressee,
+        ea_activity_id: options.eaActivityId,
         wage_source_kind: options.wageSourceKind,
         wage_source_value: options.wageSourceValue,
         qualification: options.qualification,
@@ -753,6 +821,7 @@ export const apiClient = {
 
   async bulkUpdateCaseGroups(options: {
     appSessionId: string;
+    eaActivityId?: string;
     rows: Array<{
       case_group_id: number;
       addressees_current: number | null;
@@ -768,6 +837,7 @@ export const apiClient = {
       },
       body: JSON.stringify({
         app_session_id: options.appSessionId,
+        ea_activity_id: options.eaActivityId,
         rows: options.rows,
       }),
     });
@@ -795,6 +865,7 @@ export const apiClient = {
 
   async bulkUpdateProcessSteps(options: {
     appSessionId: string;
+    eaActivityId?: string;
     rows: Array<{
       step_id: number;
       time_required_in_min_a_current: number | null;
@@ -816,6 +887,7 @@ export const apiClient = {
       },
       body: JSON.stringify({
         app_session_id: options.appSessionId,
+        ea_activity_id: options.eaActivityId,
         rows: options.rows,
       }),
     });
@@ -827,6 +899,7 @@ export const apiClient = {
 
   async updatePersonnelEffortTime(options: {
     appSessionId: string;
+    eaActivityId?: string;
     normAddressee: NormAddressee;
     stepId: number;
     period: "current" | "proposed";
@@ -842,6 +915,7 @@ export const apiClient = {
       },
       body: JSON.stringify({
         app_session_id: options.appSessionId,
+        ea_activity_id: options.eaActivityId,
         norm_addressee: options.normAddressee,
         step_id: options.stepId,
         period: options.period,

--- a/tests/activity_helpers.py
+++ b/tests/activity_helpers.py
@@ -1,0 +1,18 @@
+from backend.core import db
+from backend.core.session_activity import EA_EDIT_LEASE_SECONDS, begin_session_activity
+
+
+def ea_activity_id_for_session(session_id: int) -> str:
+    active = db.get_session_activity(session_id)
+    if active is not None:
+        return active["activity_id"]
+    return begin_session_activity(
+        session_id=session_id,
+        activity_type="ea_edit",
+        label="EA bearbeiten",
+        ttl_seconds=EA_EDIT_LEASE_SECONDS,
+    ).activity_id
+
+
+def ea_payload_for_session(session_id: int, payload: dict) -> dict:
+    return {**payload, "ea_activity_id": ea_activity_id_for_session(session_id)}

--- a/tests/test_compliance_text_export.py
+++ b/tests/test_compliance_text_export.py
@@ -9,6 +9,7 @@ from backend.core.deep_research_cases import CASE_GROUP_RESEARCH_PURPOSE
 from backend.core.llm_service import LlmResult
 from backend.core.models import Tile
 from backend.core.norm_addressees import ADMINISTRATION
+from tests.activity_helpers import ea_payload_for_session
 from backend.routers import sessions as sessions_router
 
 
@@ -549,7 +550,10 @@ def test_reset_session_ea_edits_clears_overrides_for_export(test_client):
 
     response = test_client.post(
         "/sessions/ea-edits/reset",
-        json={"app_session_id": "COMP-RESET-EA"},
+        json=ea_payload_for_session(
+            seeded["session_id"],
+            {"app_session_id": "COMP-RESET-EA"},
+        ),
     )
 
     assert response.status_code == 200

--- a/tests/test_costs_flow.py
+++ b/tests/test_costs_flow.py
@@ -5,6 +5,7 @@ import pytest
 from backend.core import db
 from backend.core.models import Tile
 from backend.core.norm_addressees import ADMINISTRATION, BUSINESS, CITIZENS
+from tests.activity_helpers import ea_payload_for_session
 
 
 def test_upsert_process_step_cost_by_addressee_has_no_dead_breakdown_params():
@@ -992,8 +993,12 @@ def _set_admin_pay_rate_override(test_client, app_session_id: str, **edited: flo
         "edited_c": edited.get("c"),
         "edited_d": edited.get("d"),
     }
+    session_id = db.get_session_id_by_app_id(app_session_id)
+    assert session_id is not None
+    payload = ea_payload_for_session(session_id, payload)
     resp = test_client.post("/sessions/pay-rates", json=payload)
     assert resp.status_code == 200, resp.text
+    db.clear_session_activity(session_id, payload["ea_activity_id"])
     return resp.json()
 
 
@@ -1290,8 +1295,12 @@ def _set_business_pay_rate_override(test_client, app_session_id: str, **edited: 
         "edited_c": edited.get("c"),
         "edited_d": edited.get("d"),
     }
+    session_id = db.get_session_id_by_app_id(app_session_id)
+    assert session_id is not None
+    payload = ea_payload_for_session(session_id, payload)
     resp = test_client.post("/sessions/pay-rates", json=payload)
     assert resp.status_code == 200, resp.text
+    db.clear_session_activity(session_id, payload["ea_activity_id"])
     return resp.json()
 
 

--- a/tests/test_edit_metrics_endpoints.py
+++ b/tests/test_edit_metrics_endpoints.py
@@ -1,6 +1,7 @@
 import json
 
 from backend.core import db
+from tests.activity_helpers import ea_payload_for_session
 
 
 def _seed_case_group(session_id: int) -> tuple[int, int]:
@@ -44,14 +45,14 @@ def test_sessions_pay_rates_get_and_post(test_client):
 
     post_response = test_client.post(
         "/sessions/pay-rates",
-        json={
+        json=ea_payload_for_session(session_id, {
             "app_session_id": "EDIT-RATES",
             "administration_level": "bund",
             "edited_a": 99.5,
             "edited_b": None,
             "edited_c": None,
             "edited_d": None,
-        },
+        }),
     )
     assert post_response.status_code == 200
     updated = post_response.json()
@@ -73,17 +74,17 @@ def test_sessions_pay_rates_get_and_post(test_client):
 
 
 def test_sessions_pay_rates_reject_unknown_level(test_client):
-    db.upsert_session("EDIT-RATES-UNKNOWN", "test-model")
+    session_id, _ = db.upsert_session("EDIT-RATES-UNKNOWN", "test-model")
     response = test_client.post(
         "/sessions/pay-rates",
-        json={
+        json=ea_payload_for_session(session_id, {
             "app_session_id": "EDIT-RATES-UNKNOWN",
             "administration_level": "invalid-level",
             "edited_a": None,
             "edited_b": None,
             "edited_c": None,
             "edited_d": None,
-        },
+        }),
     )
     assert response.status_code == 422
     assert "Unknown administration_level" in response.json()["detail"]
@@ -108,7 +109,7 @@ def test_sessions_pay_rates_support_business_overrides(test_client):
 
     post_response = test_client.post(
         "/sessions/pay-rates",
-        json={
+        json=ea_payload_for_session(session_id, {
             "app_session_id": "EDIT-RATES-BUSINESS",
             "norm_addressee": "business",
             "administration_level": None,
@@ -116,7 +117,7 @@ def test_sessions_pay_rates_support_business_overrides(test_client):
             "edited_b": None,
             "edited_c": None,
             "edited_d": None,
-        },
+        }),
     )
     assert post_response.status_code == 200
     updated = post_response.json()
@@ -132,10 +133,10 @@ def test_sessions_pay_rates_support_business_overrides(test_client):
 
 
 def test_sessions_pay_rates_reject_administration_level_for_business(test_client):
-    db.upsert_session("EDIT-RATES-BUSINESS-LEVEL", "test-model")
+    session_id, _ = db.upsert_session("EDIT-RATES-BUSINESS-LEVEL", "test-model")
     response = test_client.post(
         "/sessions/pay-rates",
-        json={
+        json=ea_payload_for_session(session_id, {
             "app_session_id": "EDIT-RATES-BUSINESS-LEVEL",
             "norm_addressee": "business",
             "administration_level": "bund",
@@ -143,14 +144,14 @@ def test_sessions_pay_rates_reject_administration_level_for_business(test_client
             "edited_b": None,
             "edited_c": None,
             "edited_d": None,
-        },
+        }),
     )
     assert response.status_code == 422
     assert "only supported for administration" in response.json()["detail"]
 
 
 def test_sessions_pay_rates_reject_citizens_updates(test_client):
-    db.upsert_session("EDIT-RATES-CITIZENS", "test-model")
+    session_id, _ = db.upsert_session("EDIT-RATES-CITIZENS", "test-model")
 
     get_response = test_client.get(
         "/sessions/pay-rates",
@@ -167,31 +168,31 @@ def test_sessions_pay_rates_reject_citizens_updates(test_client):
 
     post_response = test_client.post(
         "/sessions/pay-rates",
-        json={
+        json=ea_payload_for_session(session_id, {
             "app_session_id": "EDIT-RATES-CITIZENS",
             "norm_addressee": "citizens",
             "edited_a": 1.0,
             "edited_b": None,
             "edited_c": None,
             "edited_d": None,
-        },
+        }),
     )
     assert post_response.status_code == 422
     assert "not editable" in post_response.json()["detail"]
 
 
 def test_sessions_pay_rates_reject_negative_edited_value(test_client):
-    db.upsert_session("EDIT-RATES-NEG", "test-model")
+    session_id, _ = db.upsert_session("EDIT-RATES-NEG", "test-model")
     response = test_client.post(
         "/sessions/pay-rates",
-        json={
+        json=ea_payload_for_session(session_id, {
             "app_session_id": "EDIT-RATES-NEG",
             "administration_level": "bund",
             "edited_a": -1,
             "edited_b": None,
             "edited_c": None,
             "edited_d": None,
-        },
+        }),
     )
     assert response.status_code == 422
     assert "must be non-negative" in response.json()["detail"]
@@ -201,14 +202,14 @@ def test_sessions_pay_rates_reject_noop_payload(test_client):
     session_id, _ = db.upsert_session("EDIT-RATES-NOOP", "test-model")
     response = test_client.post(
         "/sessions/pay-rates",
-        json={
+        json=ea_payload_for_session(session_id, {
             "app_session_id": "EDIT-RATES-NOOP",
             "administration_level": "bund",
             "edited_a": None,
             "edited_b": None,
             "edited_c": None,
             "edited_d": None,
-        },
+        }),
     )
     assert response.status_code == 422
     assert response.json()["detail"] == "No changes in payload"
@@ -216,17 +217,17 @@ def test_sessions_pay_rates_reject_noop_payload(test_client):
 
 
 def test_sessions_edit_audit_returns_logged_changes(test_client):
-    db.upsert_session("EDIT-AUDIT", "test-model")
+    session_id, _ = db.upsert_session("EDIT-AUDIT", "test-model")
     update_response = test_client.post(
         "/sessions/pay-rates",
-        json={
+        json=ea_payload_for_session(session_id, {
             "app_session_id": "EDIT-AUDIT",
             "administration_level": "bund",
             "edited_a": 88.0,
             "edited_b": None,
             "edited_c": None,
             "edited_d": None,
-        },
+        }),
     )
     assert update_response.status_code == 200
 
@@ -266,7 +267,7 @@ def test_case_groups_editable_and_bulk_update(test_client):
 
     update_response = test_client.post(
         "/case-groups/bulk-update",
-        json={
+        json=ea_payload_for_session(session_id, {
             "app_session_id": "EDIT-CASES",
             "rows": [
                 {
@@ -277,7 +278,7 @@ def test_case_groups_editable_and_bulk_update(test_client):
                     "annual_frequency_proposed": 4,
                 }
             ],
-        },
+        }),
     )
     assert update_response.status_code == 200
     assert update_response.json()["updated"] == 1
@@ -310,10 +311,10 @@ def test_case_groups_audit_logs_effective_values(test_client):
 
     response = test_client.post(
         "/case-groups/bulk-update",
-        json={
+        json=ea_payload_for_session(session_id, {
             "app_session_id": "EDIT-CASES-AUDIT-EFFECTIVE",
             "rows": [{"case_group_id": case_group_id, "addressees_current": 13}],
-        },
+        }),
     )
     assert response.status_code == 200
 
@@ -335,7 +336,7 @@ def test_case_groups_bulk_update_rejects_negative_values(test_client):
 
     response = test_client.post(
         "/case-groups/bulk-update",
-        json={
+        json=ea_payload_for_session(session_id, {
             "app_session_id": "EDIT-CASES-NEG",
             "rows": [
                 {
@@ -343,7 +344,7 @@ def test_case_groups_bulk_update_rejects_negative_values(test_client):
                     "addressees_current": -1,
                 }
             ],
-        },
+        }),
     )
     assert response.status_code == 422
     assert "must be non-negative" in response.json()["detail"]
@@ -358,10 +359,10 @@ def test_case_groups_editable_rejects_invalid_app_session_id(test_client):
 
 
 def test_case_groups_bulk_update_rejects_unknown_case_group_ids(test_client):
-    db.upsert_session("EDIT-CASES-MISSING", "test-model")
+    session_id, _ = db.upsert_session("EDIT-CASES-MISSING", "test-model")
     response = test_client.post(
         "/case-groups/bulk-update",
-        json={
+        json=ea_payload_for_session(session_id, {
             "app_session_id": "EDIT-CASES-MISSING",
             "rows": [
                 {
@@ -369,7 +370,7 @@ def test_case_groups_bulk_update_rejects_unknown_case_group_ids(test_client):
                     "addressees_current": 1,
                 }
             ],
-        },
+        }),
     )
     assert response.status_code == 422
     assert "Unknown case_group_id values for this session" in response.json()["detail"]
@@ -378,11 +379,11 @@ def test_case_groups_bulk_update_rejects_unknown_case_group_ids(test_client):
 def test_case_groups_bulk_update_rejects_case_group_from_other_session(test_client):
     session_a_id, _ = db.upsert_session("EDIT-CASES-A", "test-model")
     _process_id, case_group_id = _seed_case_group(session_a_id)
-    db.upsert_session("EDIT-CASES-B", "test-model")
+    session_b_id, _ = db.upsert_session("EDIT-CASES-B", "test-model")
 
     response = test_client.post(
         "/case-groups/bulk-update",
-        json={
+        json=ea_payload_for_session(session_b_id, {
             "app_session_id": "EDIT-CASES-B",
             "rows": [
                 {
@@ -390,7 +391,7 @@ def test_case_groups_bulk_update_rejects_case_group_from_other_session(test_clie
                     "addressees_current": 1,
                 }
             ],
-        },
+        }),
     )
     assert response.status_code == 422
     assert "Unknown case_group_id values for this session" in response.json()["detail"]
@@ -401,23 +402,23 @@ def test_case_groups_bulk_update_rejects_duplicate_ids(test_client):
     _process_id, case_group_id = _seed_case_group(session_id)
     response = test_client.post(
         "/case-groups/bulk-update",
-        json={
+        json=ea_payload_for_session(session_id, {
             "app_session_id": "EDIT-CASES-DUP",
             "rows": [
                 {"case_group_id": case_group_id, "addressees_current": 1},
                 {"case_group_id": case_group_id, "addressees_current": 2},
             ],
-        },
+        }),
     )
     assert response.status_code == 422
     assert "Duplicate case_group_id values in payload" in response.json()["detail"]
 
 
 def test_case_groups_bulk_update_rejects_empty_rows(test_client):
-    db.upsert_session("EDIT-CASES-EMPTY", "test-model")
+    session_id, _ = db.upsert_session("EDIT-CASES-EMPTY", "test-model")
     response = test_client.post(
         "/case-groups/bulk-update",
-        json={"app_session_id": "EDIT-CASES-EMPTY", "rows": []},
+        json=ea_payload_for_session(session_id, {"app_session_id": "EDIT-CASES-EMPTY", "rows": []}),
     )
     assert response.status_code == 422
     assert response.json()["detail"] == "rows must not be empty"
@@ -428,10 +429,10 @@ def test_case_groups_bulk_update_rejects_noop_payload(test_client):
     _process_id, case_group_id = _seed_case_group(session_id)
     response = test_client.post(
         "/case-groups/bulk-update",
-        json={
+        json=ea_payload_for_session(session_id, {
             "app_session_id": "EDIT-CASES-NOOP",
             "rows": [{"case_group_id": case_group_id}],
-        },
+        }),
     )
     assert response.status_code == 422
     assert response.json()["detail"] == "No changes in payload"
@@ -467,7 +468,7 @@ def test_process_steps_editable_and_bulk_update(test_client):
 
     update_response = test_client.post(
         "/process-steps/bulk-update",
-        json={
+        json=ea_payload_for_session(session_id, {
             "app_session_id": "EDIT-STEPS",
             "rows": [
                 {
@@ -478,7 +479,7 @@ def test_process_steps_editable_and_bulk_update(test_client):
                     "expenses_proposed": 10,
                 }
             ],
-        },
+        }),
     )
     assert update_response.status_code == 200
     assert update_response.json()["updated"] == 1
@@ -517,10 +518,10 @@ def test_process_steps_audit_logs_effective_values(test_client):
 
     response = test_client.post(
         "/process-steps/bulk-update",
-        json={
+        json=ea_payload_for_session(session_id, {
             "app_session_id": "EDIT-STEPS-AUDIT-EFFECTIVE",
             "rows": [{"step_id": step_id, "time_required_in_min_a_current": 7}],
-        },
+        }),
     )
     assert response.status_code == 200
 
@@ -543,7 +544,7 @@ def test_process_steps_bulk_update_rejects_negative_values(test_client):
 
     response = test_client.post(
         "/process-steps/bulk-update",
-        json={
+        json=ea_payload_for_session(session_id, {
             "app_session_id": "EDIT-STEPS-NEG",
             "rows": [
                 {
@@ -551,7 +552,7 @@ def test_process_steps_bulk_update_rejects_negative_values(test_client):
                     "time_required_in_min_a_current": -2,
                 }
             ],
-        },
+        }),
     )
     assert response.status_code == 422
     assert "must be non-negative" in response.json()["detail"]
@@ -566,10 +567,10 @@ def test_process_steps_editable_rejects_invalid_app_session_id(test_client):
 
 
 def test_process_steps_bulk_update_rejects_unknown_step_ids(test_client):
-    db.upsert_session("EDIT-STEPS-MISSING", "test-model")
+    session_id, _ = db.upsert_session("EDIT-STEPS-MISSING", "test-model")
     response = test_client.post(
         "/process-steps/bulk-update",
-        json={
+        json=ea_payload_for_session(session_id, {
             "app_session_id": "EDIT-STEPS-MISSING",
             "rows": [
                 {
@@ -577,7 +578,7 @@ def test_process_steps_bulk_update_rejects_unknown_step_ids(test_client):
                     "time_required_in_min_a_current": 1,
                 }
             ],
-        },
+        }),
     )
     assert response.status_code == 422
     assert "Unknown step_id values for this session" in response.json()["detail"]
@@ -587,11 +588,11 @@ def test_process_steps_bulk_update_rejects_step_from_other_session(test_client):
     session_a_id, _ = db.upsert_session("EDIT-STEPS-A", "test-model")
     _process_id, case_group_id = _seed_case_group(session_a_id)
     step_id = _seed_step(session_a_id, case_group_id)
-    db.upsert_session("EDIT-STEPS-B", "test-model")
+    session_b_id, _ = db.upsert_session("EDIT-STEPS-B", "test-model")
 
     response = test_client.post(
         "/process-steps/bulk-update",
-        json={
+        json=ea_payload_for_session(session_b_id, {
             "app_session_id": "EDIT-STEPS-B",
             "rows": [
                 {
@@ -599,7 +600,7 @@ def test_process_steps_bulk_update_rejects_step_from_other_session(test_client):
                     "time_required_in_min_a_current": 1,
                 }
             ],
-        },
+        }),
     )
     assert response.status_code == 422
     assert "Unknown step_id values for this session" in response.json()["detail"]
@@ -611,23 +612,23 @@ def test_process_steps_bulk_update_rejects_duplicate_ids(test_client):
     step_id = _seed_step(session_id, case_group_id)
     response = test_client.post(
         "/process-steps/bulk-update",
-        json={
+        json=ea_payload_for_session(session_id, {
             "app_session_id": "EDIT-STEPS-DUP",
             "rows": [
                 {"step_id": step_id, "time_required_in_min_a_current": 1},
                 {"step_id": step_id, "time_required_in_min_a_current": 2},
             ],
-        },
+        }),
     )
     assert response.status_code == 422
     assert "Duplicate step_id values in payload" in response.json()["detail"]
 
 
 def test_process_steps_bulk_update_rejects_empty_rows(test_client):
-    db.upsert_session("EDIT-STEPS-EMPTY", "test-model")
+    session_id, _ = db.upsert_session("EDIT-STEPS-EMPTY", "test-model")
     response = test_client.post(
         "/process-steps/bulk-update",
-        json={"app_session_id": "EDIT-STEPS-EMPTY", "rows": []},
+        json=ea_payload_for_session(session_id, {"app_session_id": "EDIT-STEPS-EMPTY", "rows": []}),
     )
     assert response.status_code == 422
     assert response.json()["detail"] == "rows must not be empty"
@@ -639,10 +640,10 @@ def test_process_steps_bulk_update_rejects_noop_payload(test_client):
     step_id = _seed_step(session_id, case_group_id)
     response = test_client.post(
         "/process-steps/bulk-update",
-        json={
+        json=ea_payload_for_session(session_id, {
             "app_session_id": "EDIT-STEPS-NOOP",
             "rows": [{"step_id": step_id}],
-        },
+        }),
     )
     assert response.status_code == 422
     assert response.json()["detail"] == "No changes in payload"

--- a/tests/test_personnel_effort_edit.py
+++ b/tests/test_personnel_effort_edit.py
@@ -4,6 +4,7 @@ import pytest
 
 from backend.core import db
 from backend.core.norm_addressees import ADMINISTRATION
+from tests.activity_helpers import ea_activity_id_for_session
 
 
 def _seed(app_id="C2-EDIT"):
@@ -23,8 +24,11 @@ def _seed(app_id="C2-EDIT"):
 
 
 def _edit_payload(app_id, step_id, **overrides):
+    session_id = db.get_session_id_by_app_id(app_id)
+    assert session_id is not None
     payload = {
         "app_session_id": app_id, "norm_addressee": ADMINISTRATION, "step_id": step_id,
+        "ea_activity_id": ea_activity_id_for_session(session_id),
         "period": "proposed", "qualification": "gehobener_dienst",
         "wage_source_kind": "verwaltungsebene", "wage_source_value": "bund",
         "time_required_in_min_edited": 10.0,

--- a/tests/test_session_activity.py
+++ b/tests/test_session_activity.py
@@ -1,0 +1,325 @@
+import asyncio
+import logging
+import time
+
+import pytest
+
+from backend.core import db
+from backend.core.auth import ApiKeys
+from backend.core.models import Tile
+from backend.core.norm_addressees import ADMINISTRATION, BUSINESS, CITIZENS
+from backend.core.session_activity import WORKFLOW_LEASE_SECONDS, begin_session_activity
+from backend.routers import sessions as sessions_router
+
+
+def _seed_total_cost_ready(app_session_id: str) -> int:
+    session_id, _ = db.upsert_session(app_session_id, "test-model")
+    for addressee in (ADMINISTRATION, BUSINESS, CITIZENS):
+        db.upsert_session_total_costs_by_addressee(
+            session_id=session_id,
+            norm_addressee=addressee,
+            total_cost=1.0 if addressee != CITIZENS else None,
+            bureaucracy_cost=1.0 if addressee == BUSINESS else None,
+            total_time_minutes=0.0 if addressee == CITIZENS else None,
+            total_expenses=0.0 if addressee == CITIZENS else None,
+        )
+    return session_id
+
+
+def _seed_computable_admin_costs(app_session_id: str) -> int:
+    session_id, _ = db.upsert_session(app_session_id, "test-model")
+    process_id = db.insert_process(
+        session_id,
+        "Prozess A",
+        "Beschreibung Prozess",
+        norm_addressee=ADMINISTRATION,
+    )
+    case_group_id = db.insert_case_group(
+        session_id,
+        process_id,
+        "Fallgruppe A",
+        "Beschreibung Fallgruppe",
+        norm_addressee=ADMINISTRATION,
+    )
+    step_id = db.insert_process_step(
+        session_id,
+        case_group_id,
+        "Schritt 1",
+        "Beschreibung Schritt 1",
+        norm_addressee=ADMINISTRATION,
+    )
+    db.update_case_group_metrics(
+        session_id=session_id,
+        case_group_id=case_group_id,
+        addressees_proposed=10,
+        annual_frequency_proposed=2,
+    )
+    db.update_process_step_effort_split(
+        session_id=session_id,
+        step_id=step_id,
+        hourly_rates_current={},
+        time_required_current={},
+        expenses_current=None,
+        hourly_rates_proposed={"a": 60, "b": None, "c": None, "d": None},
+        time_required_proposed={"a": 30, "b": None, "c": None, "d": None},
+        expenses_proposed=10,
+    )
+    db.upsert_tile(
+        Tile(
+            id=f"step_{step_id}",
+            title="Schritt 1",
+            text="Beschreibung Schritt 1",
+            meta_information={"step_id": step_id, "case_group_id": case_group_id},
+            column=4,
+            row=0,
+            deletable=True,
+            link_from_tile=[],
+        ),
+        session_id=session_id,
+        norm_addressee=ADMINISTRATION,
+    )
+    return session_id
+
+
+def _wage_payload(app_session_id: str, activity_id: str | None = None) -> dict:
+    return {
+        "app_session_id": app_session_id,
+        "norm_addressee": ADMINISTRATION,
+        "ea_activity_id": activity_id,
+        "wage_source_kind": "verwaltungsebene",
+        "wage_source_value": "bund",
+        "qualification": "einfacher_und_mittlerer_dienst",
+        "hourly_rate_edited": 44.5,
+    }
+
+
+def test_ea_activity_owner_can_write_wage_rate(test_client):
+    _seed_total_cost_ready("EA-ACT-OWNER")
+    activity = test_client.post(
+        "/sessions/ea-edit-activity/acquire",
+        json={"app_session_id": "EA-ACT-OWNER"},
+    )
+    assert activity.status_code == 200
+    activity_id = activity.json()["activity_id"]
+
+    response = test_client.post(
+        "/sessions/wage-rates",
+        json=_wage_payload("EA-ACT-OWNER", activity_id),
+    )
+
+    assert response.status_code == 200
+
+
+def test_ea_write_without_owner_activity_is_rejected(test_client):
+    _seed_total_cost_ready("EA-ACT-STRICT")
+
+    response = test_client.post(
+        "/sessions/wage-rates",
+        json=_wage_payload("EA-ACT-STRICT"),
+    )
+
+    assert response.status_code == 409
+    detail = response.json()["detail"]
+    assert detail["error"] == "session_activity_unavailable"
+    assert detail["activity_type"] == "ea_edit"
+    assert "EA-Bearbeitung ist nicht mehr aktiv" in detail["message"]
+
+
+def test_same_session_workflow_rejected_while_ea_activity_active(test_client):
+    _seed_total_cost_ready("EA-ACT-BLOCK-RUN")
+    activity = test_client.post(
+        "/sessions/ea-edit-activity/acquire",
+        json={"app_session_id": "EA-ACT-BLOCK-RUN"},
+    )
+    assert activity.status_code == 200
+
+    response = test_client.post(
+        "/sessions/run-all/start",
+        json={"app_session_id": "EA-ACT-BLOCK-RUN", "model": "test-model"},
+    )
+
+    assert response.status_code == 409
+    detail = response.json()["detail"]
+    assert detail["error"] == "session_activity_conflict"
+    assert detail["active_type"] == "ea_edit"
+    assert "EA-Bearbeitung" in detail["message"]
+
+
+def test_same_session_ea_write_rejected_while_workflow_activity_active(test_client):
+    session_id = _seed_total_cost_ready("EA-ACT-BLOCK-WRITE")
+    begin_session_activity(
+        session_id=session_id,
+        activity_type="workflow",
+        label="Testlauf",
+        ttl_seconds=WORKFLOW_LEASE_SECONDS,
+    )
+
+    response = test_client.post(
+        "/sessions/wage-rates",
+        json=_wage_payload("EA-ACT-BLOCK-WRITE"),
+    )
+
+    assert response.status_code == 409
+    detail = response.json()["detail"]
+    assert detail["error"] == "session_activity_conflict"
+    assert detail["active_type"] == "workflow"
+    assert "Ausführung" in detail["message"]
+
+
+def test_workflow_activity_allows_total_cost_compute_without_ea_owner(test_client):
+    session_id = _seed_computable_admin_costs("EA-ACT-WORKFLOW-COSTS")
+    begin_session_activity(
+        session_id=session_id,
+        activity_type="workflow",
+        label="Testlauf",
+        ttl_seconds=WORKFLOW_LEASE_SECONDS,
+    )
+
+    response = test_client.post(
+        "/costs/compute",
+        json={"app_session_id": "EA-ACT-WORKFLOW-COSTS", "norm_addressee": ADMINISTRATION},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["total_cost"] == 800
+
+
+def test_ea_activity_release_does_not_clear_workflow_activity(test_client):
+    session_id = _seed_total_cost_ready("EA-ACT-RELEASE-WORKFLOW")
+    workflow_activity = begin_session_activity(
+        session_id=session_id,
+        activity_type="workflow",
+        label="Testlauf",
+        ttl_seconds=WORKFLOW_LEASE_SECONDS,
+    )
+
+    response = test_client.post(
+        "/sessions/ea-edit-activity/release",
+        json={
+            "app_session_id": "EA-ACT-RELEASE-WORKFLOW",
+            "activity_id": workflow_activity.activity_id,
+        },
+    )
+
+    assert response.status_code == 200
+    active = db.get_session_activity(session_id)
+    assert active is not None
+    assert active["activity_id"] == workflow_activity.activity_id
+    assert active["activity_type"] == "workflow"
+
+
+def test_other_session_workflow_allowed_while_ea_activity_active(test_client, monkeypatch):
+    async def fake_run_all_background(
+        run_id,
+        payload,
+        api_keys,
+        model,
+        workflow_activity_id,
+    ):
+        session_id = db.get_session_id_by_app_id(payload.app_session_id)
+        if session_id is not None:
+            db.clear_session_activity(session_id, workflow_activity_id)
+
+    monkeypatch.setattr(sessions_router, "_run_all_background", fake_run_all_background)
+    _seed_total_cost_ready("EA-ACT-ONE")
+    _seed_total_cost_ready("EA-ACT-TWO")
+    activity = test_client.post(
+        "/sessions/ea-edit-activity/acquire",
+        json={"app_session_id": "EA-ACT-ONE"},
+    )
+    assert activity.status_code == 200
+
+    response = test_client.post(
+        "/sessions/run-all/start",
+        json={"app_session_id": "EA-ACT-TWO", "model": "test-model"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["started"] is True
+
+
+def test_expired_session_activity_purge_logs_recovery(caplog):
+    session_id = _seed_total_cost_ready("EA-ACT-EXPIRED")
+    now = time.time()
+    conn = db.get_conn()
+    cur = conn.cursor()
+    cur.execute(
+        """
+        INSERT INTO session_activities (
+            session_id, activity_id, activity_type, label,
+            created_at, updated_at, expires_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            session_id,
+            "workflow:expired-test",
+            "workflow",
+            "Testlauf",
+            now - 2,
+            now - 2,
+            now - 1,
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    with caplog.at_level(logging.WARNING, logger="backend.core.db"):
+        deleted = db.purge_expired_session_activity(session_id)
+
+    assert deleted == 1
+    assert db.get_session_activity(session_id) is None
+    assert "Purged expired session activity" in caplog.text
+    assert "workflow:expired-test" in caplog.text
+
+
+def test_single_step_workflow_activity_released_when_final_publish_fails(monkeypatch):
+    app_session_id = "EA-ACT-FINAL-PUBLISH"
+    session_id = _seed_total_cost_ready(app_session_id)
+    activity = begin_session_activity(
+        session_id=session_id,
+        activity_type="workflow",
+        label="Testlauf",
+        ttl_seconds=WORKFLOW_LEASE_SECONDS,
+    )
+    run_id = "activity-final-publish"
+    sessions_router._RUNS_BY_ID[run_id] = sessions_router._RunRecord(
+        run_id=run_id,
+        app_session_id=app_session_id,
+    )
+    sessions_router._ACTIVE_RUN_BY_SESSION[app_session_id] = run_id
+
+    async def fake_execute_single_step(**_kwargs):
+        return [], sessions_router._as_session_status_response(app_session_id), True
+
+    publish_calls = 0
+
+    async def flaky_publish_event(*_args, **_kwargs):
+        nonlocal publish_calls
+        publish_calls += 1
+        if publish_calls == 2:
+            raise RuntimeError("final publish failed")
+
+    monkeypatch.setattr(sessions_router, "_execute_single_step", fake_execute_single_step)
+    monkeypatch.setattr(sessions_router, "_publish_run_event", flaky_publish_event)
+
+    try:
+        with pytest.raises(RuntimeError, match="final publish failed"):
+            asyncio.run(
+                sessions_router._run_single_step_background(
+                    run_id,
+                    "effort",
+                    sessions_router.SessionRunAllRequest(
+                        app_session_id=app_session_id,
+                        model="test-model",
+                    ),
+                    ApiKeys(),
+                    "test-model",
+                    activity.activity_id,
+                )
+            )
+
+        assert db.get_session_activity(session_id) is None
+    finally:
+        sessions_router._RUNS_BY_ID.pop(run_id, None)
+        sessions_router._ACTIVE_RUN_BY_SESSION.pop(app_session_id, None)

--- a/tests/test_session_activity.py
+++ b/tests/test_session_activity.py
@@ -9,6 +9,7 @@ from backend.core.auth import ApiKeys
 from backend.core.models import Tile
 from backend.core.norm_addressees import ADMINISTRATION, BUSINESS, CITIZENS
 from backend.core.session_activity import WORKFLOW_LEASE_SECONDS, begin_session_activity
+from backend.main import startup
 from backend.routers import sessions as sessions_router
 
 
@@ -271,6 +272,21 @@ def test_expired_session_activity_purge_logs_recovery(caplog):
     assert db.get_session_activity(session_id) is None
     assert "Purged expired session activity" in caplog.text
     assert "workflow:expired-test" in caplog.text
+
+
+def test_startup_clears_orphaned_session_activities_after_restart():
+    session_id = _seed_total_cost_ready("EA-ACT-STARTUP-CLEAR")
+    begin_session_activity(
+        session_id=session_id,
+        activity_type="workflow",
+        label="Testlauf",
+        ttl_seconds=WORKFLOW_LEASE_SECONDS,
+    )
+    assert db.get_session_activity(session_id) is not None
+
+    startup()
+
+    assert db.get_session_activity(session_id) is None
 
 
 def test_single_step_workflow_activity_released_when_final_publish_fails(monkeypatch):

--- a/tests/test_session_wage_rates.py
+++ b/tests/test_session_wage_rates.py
@@ -8,6 +8,7 @@ import pytest
 
 from backend.core import db
 from backend.core.norm_addressees import ADMINISTRATION
+from tests.activity_helpers import ea_activity_id_for_session
 
 
 def _seed_session_with_rows(app_id="WAGE-C1"):
@@ -54,13 +55,15 @@ def test_wage_rates_lists_used_source_with_all_qualifications(test_client):
 
 
 def test_wage_rate_override_set_clear_and_validation(test_client):
-    app_id, _session_id, _cg, _step = _seed_session_with_rows("WAGE-C1-SET")
+    app_id, session_id, _cg, _step = _seed_session_with_rows("WAGE-C1-SET")
+    ea_activity_id = ea_activity_id_for_session(session_id)
 
     # set override
     resp = test_client.post(
         "/sessions/wage-rates",
         json={
             "app_session_id": app_id, "norm_addressee": ADMINISTRATION,
+            "ea_activity_id": ea_activity_id,
             "wage_source_kind": "verwaltungsebene", "wage_source_value": "bund",
             "qualification": "gehobener_dienst", "hourly_rate_edited": 55.0,
         },
@@ -74,6 +77,7 @@ def test_wage_rate_override_set_clear_and_validation(test_client):
         "/sessions/wage-rates",
         json={
             "app_session_id": app_id, "norm_addressee": ADMINISTRATION,
+            "ea_activity_id": ea_activity_id,
             "wage_source_kind": "verwaltungsebene", "wage_source_value": "nonexistent",
             "qualification": "gehobener_dienst", "hourly_rate_edited": 55.0,
         },
@@ -85,6 +89,7 @@ def test_wage_rate_override_set_clear_and_validation(test_client):
         "/sessions/wage-rates",
         json={
             "app_session_id": app_id, "norm_addressee": ADMINISTRATION,
+            "ea_activity_id": ea_activity_id,
             "wage_source_kind": "verwaltungsebene", "wage_source_value": "bund",
             "qualification": "gehobener_dienst", "hourly_rate_edited": None,
         },
@@ -102,6 +107,7 @@ def test_wage_rate_override_noop_rejection_and_audit(test_client):
     body = {
         "app_session_id": app_id,
         "norm_addressee": ADMINISTRATION,
+        "ea_activity_id": ea_activity_id_for_session(session_id),
         "wage_source_kind": "verwaltungsebene",
         "wage_source_value": "bund",
         "qualification": "gehobener_dienst",

--- a/tests/test_sessions_contract.py
+++ b/tests/test_sessions_contract.py
@@ -4,6 +4,7 @@ import time
 from backend.core import db, llm_monitor
 from backend.core.config import settings
 from backend.routers import sessions as sessions_router
+from tests.activity_helpers import ea_payload_for_session
 
 
 def _parse_contract(model_cls, payload):
@@ -138,14 +139,17 @@ def test_sessions_edit_audit_contract(test_client):
 
     update_resp = test_client.post(
         "/sessions/pay-rates",
-        json={
-            "app_session_id": app_session_id,
-            "administration_level": "bund",
-            "edited_a": 77,
-            "edited_b": None,
-            "edited_c": None,
-            "edited_d": None,
-        },
+        json=ea_payload_for_session(
+            db.get_session_id_by_app_id(app_session_id),
+            {
+                "app_session_id": app_session_id,
+                "administration_level": "bund",
+                "edited_a": 77,
+                "edited_b": None,
+                "edited_c": None,
+                "edited_d": None,
+            },
+        ),
     )
     assert update_resp.status_code == 200
 
@@ -262,28 +266,34 @@ def test_pay_rates_save_and_reset_for_laender_session_no_422(test_client):
     # Saving with the used level must NOT raise 422.
     save_resp = test_client.post(
         "/sessions/pay-rates",
-        json={
-            "app_session_id": app_session_id,
-            "administration_level": "laender",
-            "edited_a": 50,
-            "edited_b": None,
-            "edited_c": None,
-            "edited_d": None,
-        },
+        json=ea_payload_for_session(
+            session_id,
+            {
+                "app_session_id": app_session_id,
+                "administration_level": "laender",
+                "edited_a": 50,
+                "edited_b": None,
+                "edited_c": None,
+                "edited_d": None,
+            },
+        ),
     )
     assert save_resp.status_code == 200
 
     # Resetting with the same level: also no 422.
     reset_resp = test_client.post(
         "/sessions/pay-rates",
-        json={
-            "app_session_id": app_session_id,
-            "administration_level": "laender",
-            "edited_a": None,
-            "edited_b": None,
-            "edited_c": None,
-            "edited_d": None,
-        },
+        json=ea_payload_for_session(
+            session_id,
+            {
+                "app_session_id": app_session_id,
+                "administration_level": "laender",
+                "edited_a": None,
+                "edited_b": None,
+                "edited_c": None,
+                "edited_d": None,
+            },
+        ),
     )
     assert reset_resp.status_code == 200
 

--- a/tests/test_sessions_run_all.py
+++ b/tests/test_sessions_run_all.py
@@ -60,6 +60,11 @@ def _detect_addressee_from_prompt(prompt: str) -> str:
     return ADMINISTRATION
 
 
+def _json_for_prompt(prompt: str, payload: dict) -> str:
+    payload.setdefault("normadressat", _detect_addressee_from_prompt(prompt))
+    return json.dumps(payload)
+
+
 def _personalaufwand_row(addressee: str, minutes: str) -> dict:
     """Build a single row-based personnel-effort entry for org addressees.
 
@@ -177,11 +182,12 @@ def _patch_run_all_llms(monkeypatch, app_session_id: str) -> None:
             )
         return json.dumps({"title": "Kurz", "blurb": "Ein Satz."})
 
-    async def fake_processes_llm(*_args, **_kwargs):
+    async def fake_processes_llm(prompt, *_args, **_kwargs):
         session_id = db.get_session_id_by_app_id(app_session_id)
         assert session_id is not None
         regulations = db.list_regulations_for_session(session_id)
-        return json.dumps(
+        return _json_for_prompt(
+            prompt,
             {
                 "prozesse": [
                     {
@@ -210,11 +216,12 @@ def _patch_run_all_llms(monkeypatch, app_session_id: str) -> None:
             }
         )
 
-    async def fake_case_groups_llm(*_args, **_kwargs):
+    async def fake_case_groups_llm(prompt, *_args, **_kwargs):
         session_id = db.get_session_id_by_app_id(app_session_id)
         assert session_id is not None
         processes = db.list_processes_for_session(session_id)
-        return json.dumps(
+        return _json_for_prompt(
+            prompt,
             {
                 "prozesse": [
                     {
@@ -243,12 +250,13 @@ def _patch_run_all_llms(monkeypatch, app_session_id: str) -> None:
             }
         )
 
-    async def fake_steps_llm(*_args, **_kwargs):
+    async def fake_steps_llm(prompt, *_args, **_kwargs):
         session_id = db.get_session_id_by_app_id(app_session_id)
         assert session_id is not None
         processes = db.list_processes_for_session(session_id)
         case_groups = db.list_case_groups_for_session(session_id)
-        return json.dumps(
+        return _json_for_prompt(
+            prompt,
             {
                 "prozesse": [
                     {
@@ -297,7 +305,8 @@ def _patch_run_all_llms(monkeypatch, app_session_id: str) -> None:
         for step in steps:
             steps_by_group.setdefault(int(step["case_group_id"]), []).append(step)
         if not _is_effort_prompt(prompt):
-            return json.dumps(
+            return _json_for_prompt(
+                prompt,
                 {
                     "prozesse": [
                         {
@@ -347,7 +356,8 @@ def _patch_run_all_llms(monkeypatch, app_session_id: str) -> None:
                     "taetigkeiten": taetigkeiten,
                 }
             )
-        return json.dumps(
+        return _json_for_prompt(
+            prompt,
             {
                 "prozesse": [
                     {
@@ -403,7 +413,8 @@ def _patch_run_all_llms_for_all_addressees(monkeypatch, app_session_id: str) -> 
         regulations = db.list_regulations_for_session_and_addressee(session_id, addressee)
         assert len(regulations) == 1
         regulation = regulations[0]
-        return json.dumps(
+        return _json_for_prompt(
+            prompt,
             {
                 "prozesse": [
                     {
@@ -428,7 +439,8 @@ def _patch_run_all_llms_for_all_addressees(monkeypatch, app_session_id: str) -> 
         processes = db.list_processes_for_session_and_addressee(session_id, addressee)
         assert len(processes) == 1
         process = processes[0]
-        return json.dumps(
+        return _json_for_prompt(
+            prompt,
             {
                 "prozesse": [
                     {
@@ -454,7 +466,8 @@ def _patch_run_all_llms_for_all_addressees(monkeypatch, app_session_id: str) -> 
         case_groups = db.list_case_groups_for_session_and_addressee(session_id, addressee)
         assert len(processes) == 1
         assert len(case_groups) == 1
-        return json.dumps(
+        return _json_for_prompt(
+            prompt,
             {
                 "prozesse": [
                     {
@@ -486,7 +499,8 @@ def _patch_run_all_llms_for_all_addressees(monkeypatch, app_session_id: str) -> 
         assert len(case_groups) == 1
         assert len(steps) == 1
         if not _is_effort_prompt(prompt):
-            return json.dumps(
+            return _json_for_prompt(
+                prompt,
                 {
                     "prozesse": [
                         {
@@ -520,7 +534,8 @@ def _patch_run_all_llms_for_all_addressees(monkeypatch, app_session_id: str) -> 
                 ],
                 "sachaufwand_vorschlag": "10",
             }
-        return json.dumps(
+        return _json_for_prompt(
+            prompt,
             {
                 "prozesse": [
                     {
@@ -567,7 +582,8 @@ def _patch_run_all_llms_for_business_only(monkeypatch, app_session_id: str) -> N
         regulations = db.list_regulations_for_session_and_addressee(session_id, addressee)
         assert len(regulations) == 1
         regulation = regulations[0]
-        return json.dumps(
+        return _json_for_prompt(
+            prompt,
             {
                 "prozesse": [
                     {
@@ -592,7 +608,8 @@ def _patch_run_all_llms_for_business_only(monkeypatch, app_session_id: str) -> N
         processes = db.list_processes_for_session_and_addressee(session_id, addressee)
         assert len(processes) == 1
         process = processes[0]
-        return json.dumps(
+        return _json_for_prompt(
+            prompt,
             {
                 "prozesse": [
                     {
@@ -618,7 +635,8 @@ def _patch_run_all_llms_for_business_only(monkeypatch, app_session_id: str) -> N
         case_groups = db.list_case_groups_for_session_and_addressee(session_id, addressee)
         assert len(processes) == 1
         assert len(case_groups) == 1
-        return json.dumps(
+        return _json_for_prompt(
+            prompt,
             {
                 "prozesse": [
                     {
@@ -650,7 +668,8 @@ def _patch_run_all_llms_for_business_only(monkeypatch, app_session_id: str) -> N
         assert len(case_groups) == 1
         assert len(steps) == 1
         if not _is_effort_prompt(prompt):
-            return json.dumps(
+            return _json_for_prompt(
+                prompt,
                 {
                     "prozesse": [
                         {
@@ -666,7 +685,8 @@ def _patch_run_all_llms_for_business_only(monkeypatch, app_session_id: str) -> N
                     ]
                 }
             )
-        return json.dumps(
+        return _json_for_prompt(
+            prompt,
             {
                 "prozesse": [
                     {


### PR DESCRIPTION
## Summary

This PR adds session activity locking around EA editing and workflow execution.

The main goal is to prevent same-session conflicts: an EA drawer in one tab should not be able to write while a workflow/reset is running, and a workflow/reset should not proceed while EA editing owns the session. Different sessions can still be used independently.

## Changes

- Add backend session activity leases for `ea_edit` and `workflow`.
- Add EA edit acquire, heartbeat, and release endpoints.
- Require EA activity ownership for EA write/reset/recompute routes.
- Wrap workflow runs, single-step runs, and undo/reset in workflow activity ownership.
- Update the EA drawer to:
  - acquire and heartbeat edit ownership,
  - pass the activity id to saves/resets/recomputes,
  - become read-only when blocked by another tab/window or workflow,
  - release ownership on close/unmount,
  - close when EA editing is no longer available.
- Improve reset/undo conflict messaging in the session menu.
- Add regression tests for backend ownership rules and frontend blocked states.

## Reviewer Notes

Please especially check:

- Same-session locking behavior:
  - EA drawer open blocks run/reset for that session.
  - Workflow/reset running blocks EA edits for that session.
  - Different sessions can still run/edit independently.
- Reload/close behavior:
  - If a tab reloads while the EA drawer is open, the stale lock expires after the lease (2min).
- EA drawer blocked state:
  - First tab can view and save (update costs) fine.
  - Second tab can view the drawer read-only, but cannot save.
  - Warning messages explain why editing is blocked.
- Session menu reset message:
  - Reset blocked by EA editing should show the EA-edit conflict, not a generic failure.
- Tests:
  - Backend session activity tests.
  - EA drawer and session menu frontend tests.

## Tests

- `npm --prefix frontend test -- --runInBand`
- `.venv/bin/python -m pytest tests/test_session_activity.py tests/test_costs_flow.py tests/test_sessions_contract.py tests/test_sessions_run_all.py -q`