### PR TITLE
Docker deployment stack + built-in auth with per-user sessions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,46 @@
+# Build-context exclusions for the backend image (context = repo root).
+# Keeps the context small and avoids copying secrets, caches, and dev artifacts.
+
+.git
+.gitignore
+
+# Python caches / virtualenvs
+.venv
+__pycache__
+**/__pycache__
+*.pyc
+*.pyo
+*.pyd
+.pytest_cache
+.mypy_cache
+.ruff_cache
+.coverage
+htmlcov
+
+# Node / frontend build artifacts (frontend has its own image/context)
+**/node_modules
+frontend/.next
+frontend/out
+
+# Tests and local working artifacts
+tests
+tests_review
+review
+fixer
+workplans
+prompt_audits
+
+# Databases and local data
+*.db
+
+# Docs (not needed in the runtime image)
+*.md
+
+# Env files and tooling
+.env
+.env.*
+.devcontainer
+.github
+.idea
+.vscode
+.DS_Store

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Public domain for Caddy / production HTTPS.
+DOMAIN=ccc.example.com
+
+# Authentication.
+AUTH_SECRET_KEY=replace-me-with-a-long-random-secret
+AUTH_COOKIE_SECURE=true
+ADMIN_BOOTSTRAP_EMAIL=admin@example.com
+ADMIN_BOOTSTRAP_PASSWORD=choose-a-password-8+chars
+
+# LLM provider keys.
+OPENAI_API_KEY=
+DEEPINFRA_API_KEY=
+GEMINI_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # Env
 .env
 .env.*
+!.env.example
 CLAUDE.local.md
 
 # IDE
@@ -28,6 +29,8 @@ results/
 regulations/
 *.db
 *.db.backup*
+*.db-shm
+*.db-wal
 tmp/
 REVIEW_*.md
 

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,25 @@
+# Caddy reverse proxy for the Compliance-Cost Computer (CCC).
+#
+# Terminates TLS (automatic HTTPS via the public domain) and serves the app
+# same-origin: /api/* -> backend (prefix stripped), everything else -> frontend.
+#
+# The site address comes from the DOMAIN env var (set in .env / passed to the
+# caddy container). Caddy obtains and renews certificates automatically for it.
+
+{$DOMAIN} {
+	encode gzip
+
+	# API requests: strip the /api prefix so the backend sees /sessions, etc.
+	# flush_interval -1 disables response buffering so SSE streams
+	# (run-all events, llm-monitor) are delivered immediately.
+	handle_path /api/* {
+		reverse_proxy backend:5000 {
+			flush_interval -1
+		}
+	}
+
+	# Everything else goes to the Next.js frontend.
+	handle {
+		reverse_proxy frontend:3000
+	}
+}

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -28,12 +28,14 @@ Edit `.env` and set at minimum:
 
 - `DOMAIN` — the public domain (e.g. `ccc.example.com`). Must match DNS.
 - `AUTH_SECRET_KEY` — a long, random secret (e.g. `openssl rand -hex 32`).
+- `AUTH_COOKIE_SECURE=true` — required for production HTTPS auth cookies.
 - `ADMIN_BOOTSTRAP_EMAIL` / `ADMIN_BOOTSTRAP_PASSWORD` — the first admin login.
 - At least one LLM provider key (`OPENAI_API_KEY`, `DEEPINFRA_API_KEY`,
-  and/or `GEMINI_API_KEY`) consistent with `DEFAULT_MODEL`.
+  and/or `GEMINI_API_KEY`).
 
-`DB_PATH` and `REGULATIONS_PATH` are already set to `/data/...` and should not
-normally be changed (they point at the persistent volume).
+`docker-compose.yml` sets `DB_PATH=/data/ccc.db` and
+`REGULATIONS_PATH=/data/regulations` for the backend. These point at the
+persistent volume and should not normally be changed.
 
 ## 2. Build and start
 
@@ -118,6 +120,18 @@ docker compose down -v
 ## Single-replica note
 
 The backend runs as a **single replica with a single Uvicorn worker by design**.
+
+## Build quality gates
+
+The frontend Docker build is optimized for producing the production image. It is
+not the quality gate for TypeScript, lint, or Jest checks. Run CI or the local
+test commands before deploying:
+
+```bash
+python3 -m pytest
+npm --prefix frontend test
+npm --prefix frontend run lint -- --max-warnings=0
+```
 The workflow holds in-process session/run-all state and uses a single SQLite
 database file, so it must not be horizontally scaled or run with multiple
 workers. Do not add `--workers` or a `deploy.replicas` setting for the backend.

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,0 +1,123 @@
+# Deploying the Compliance-Cost Computer (CCC)
+
+This is the production deployment guide for the CCC Docker stack. The stack runs
+three services behind a Caddy reverse proxy:
+
+- **caddy** — terminates TLS (automatic HTTPS) and serves everything same-origin.
+- **backend** — FastAPI (single worker) on port 5000, reached via `/api/*`.
+- **frontend** — Next.js 15 standalone server on port 3000.
+
+Only Caddy is exposed publicly (ports 80/443). The backend and frontend are
+reachable only on the internal Docker network.
+
+## Prerequisites
+
+- A host with **Docker** and the **Docker Compose** plugin installed.
+- A **public domain name** with a DNS A/AAAA record pointing at the host's
+  public IP.
+- Inbound **ports 80 and 443** open to the host (Caddy needs both: 80 for the
+  ACME HTTP challenge and HTTP→HTTPS redirect, 443 for HTTPS).
+
+## 1. Configure the environment
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env` and set at minimum:
+
+- `DOMAIN` — the public domain (e.g. `ccc.example.com`). Must match DNS.
+- `AUTH_SECRET_KEY` — a long, random secret (e.g. `openssl rand -hex 32`).
+- `ADMIN_BOOTSTRAP_EMAIL` / `ADMIN_BOOTSTRAP_PASSWORD` — the first admin login.
+- At least one LLM provider key (`OPENAI_API_KEY`, `DEEPINFRA_API_KEY`,
+  and/or `GEMINI_API_KEY`) consistent with `DEFAULT_MODEL`.
+
+`DB_PATH` and `REGULATIONS_PATH` are already set to `/data/...` and should not
+normally be changed (they point at the persistent volume).
+
+## 2. Build and start
+
+```bash
+docker compose up -d --build
+```
+
+This builds the backend and frontend images and starts all three services. The
+frontend's API base URL is baked in at build time as `/api`
+(`NEXT_PUBLIC_API_BASE_URL`), so requests stay same-origin and Caddy strips the
+`/api` prefix before forwarding to the backend.
+
+Check status and logs:
+
+```bash
+docker compose ps
+docker compose logs -f caddy
+```
+
+## 3. TLS / HTTPS
+
+TLS is fully automatic. On first start, Caddy contacts Let's Encrypt, completes
+the ACME challenge for `DOMAIN`, installs the certificate, and renews it before
+expiry. No manual certificate handling is required. Certificates and ACME state
+are stored in the `caddy_data` volume, so they survive restarts and rebuilds.
+
+For this to succeed, DNS for `DOMAIN` must already resolve to the host and ports
+80/443 must be reachable from the internet.
+
+## Data persistence
+
+All backend state lives on the named Docker volume **`ccc-data`**, mounted at
+`/data` inside the backend container:
+
+- `/data/ccc.db` — the SQLite database (sessions, users, results).
+- `/data/regulations` — stored regulation files.
+
+This volume persists across `docker compose up`, `down`, and `--build`. It is
+only removed if you explicitly run `docker compose down -v`.
+
+Caddy's certificates live on the separate `caddy_data` volume.
+
+### Backup
+
+Back up the `ccc-data` volume regularly. For example, to write a timestamped
+tarball to the current directory:
+
+```bash
+docker run --rm \
+  -v ccc-data:/data:ro \
+  -v "$PWD":/backup \
+  alpine tar czf /backup/ccc-data-$(date +%F).tar.gz -C /data .
+```
+
+Restore into a fresh volume:
+
+```bash
+docker run --rm \
+  -v ccc-data:/data \
+  -v "$PWD":/backup \
+  alpine sh -c "cd /data && tar xzf /backup/ccc-data-YYYY-MM-DD.tar.gz"
+```
+
+(Stop the backend with `docker compose stop backend` before restoring.)
+
+## Operations
+
+```bash
+# Apply config/code changes (rebuild images):
+docker compose up -d --build
+
+# Tail logs:
+docker compose logs -f backend frontend caddy
+
+# Stop (keeps volumes/data):
+docker compose down
+
+# Stop AND delete volumes (DESTROYS data — be careful):
+docker compose down -v
+```
+
+## Single-replica note
+
+The backend runs as a **single replica with a single Uvicorn worker by design**.
+The workflow holds in-process session/run-all state and uses a single SQLite
+database file, so it must not be horizontally scaled or run with multiple
+workers. Do not add `--workers` or a `deploy.replicas` setting for the backend.

--- a/DEPLOY_LOCAL.md
+++ b/DEPLOY_LOCAL.md
@@ -1,0 +1,164 @@
+# Running CCC locally
+
+This guide covers running the Compliance-Cost Computer (CCC) **on your own
+machine**. For internet-facing production deployment with automatic TLS, see
+[DEPLOY.md](DEPLOY.md) instead.
+
+The production stack ([DEPLOY.md](DEPLOY.md)) assumes a public domain so Caddy can
+obtain a real TLS certificate. Locally there is no public domain, so we point
+Caddy at `localhost`. Two small `.env` changes are all that differ.
+
+---
+
+## Option A — Docker stack on `localhost` (recommended)
+
+Runs the real production stack (Caddy + frontend + backend, same-origin) on your
+machine.
+
+### Prerequisites
+- **Docker** and the **Docker Compose** plugin installed and running
+  (e.g. Docker Desktop).
+- Host **port 80** free (see "Port 80 in use" below if it isn't).
+
+### 1. Configure `.env`
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env` and set the following for a local run:
+
+```dotenv
+# Plain HTTP on localhost (no public certificate, no browser warning).
+DOMAIN=http://localhost
+# The auth cookie must be allowed over HTTP when running without TLS.
+AUTH_COOKIE_SECURE=false
+
+# A long random secret for signing auth tokens (generate one, see below).
+AUTH_SECRET_KEY=replace-me
+
+# First admin account, created automatically on first start.
+ADMIN_BOOTSTRAP_EMAIL=admin@example.com
+ADMIN_BOOTSTRAP_PASSWORD=choose-a-password-8+chars
+
+# LLM provider keys are optional here — you can also paste them in the UI.
+OPENAI_API_KEY=
+DEEPINFRA_API_KEY=
+GEMINI_API_KEY=
+```
+
+Generate a secret for `AUTH_SECRET_KEY`:
+
+```bash
+openssl rand -hex 32
+```
+
+Leave `DB_PATH`, `REGULATIONS_PATH`, and `NEXT_PUBLIC_API_BASE_URL=/api` at their
+defaults.
+
+### 2. Build and start
+
+```bash
+docker compose up -d --build
+```
+
+The first build takes a few minutes (pip + npm). Fonts are vendored
+(`@fontsource`), so the build needs **no** Google Fonts network access.
+
+### 3. Open the app
+
+Visit **http://localhost** and log in with the `ADMIN_BOOTSTRAP_EMAIL` /
+`ADMIN_BOOTSTRAP_PASSWORD` you set. As an admin you can create more users via the
+**Benutzer** button in the header (there is no public self-registration).
+
+### 4. Operate
+
+```bash
+docker compose ps                                  # service status
+docker compose logs -f backend frontend caddy      # tail logs
+docker compose down                                # stop (keeps data)
+docker compose down -v                             # stop AND wipe the DB volume
+```
+
+Data (SQLite DB, regulations) persists in the `ccc-data` Docker volume across
+restarts; it is only deleted by `docker compose down -v`.
+
+### Variant: HTTPS on `localhost`
+
+To exercise the Secure-cookie / HTTPS path locally, set instead:
+
+```dotenv
+DOMAIN=localhost
+AUTH_COOKIE_SECURE=true
+```
+
+Then open **https://localhost**. Caddy serves it with its own internal CA, so the
+browser shows a one-time certificate warning. To trust Caddy's local root CA and
+remove the warning:
+
+```bash
+docker compose exec caddy caddy trust
+```
+
+### Port 80 in use
+
+If something else already uses port 80, remap Caddy's published port in
+`docker-compose.yml`:
+
+```yaml
+  caddy:
+    ports:
+      - "8080:80"     # was "80:80"
+      - "443:443"
+```
+
+Then browse **http://localhost:8080**.
+
+---
+
+## Option B — No Docker (fast iteration)
+
+Run the backend and frontend directly in two terminals. This uses the env-based
+CORS defaults (which already allow `http://localhost:3000`) rather than the
+same-origin Caddy proxy.
+
+### Backend (terminal 1)
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+
+export AUTH_SECRET_KEY="$(openssl rand -hex 32)"
+export AUTH_COOKIE_SECURE=false
+export ADMIN_BOOTSTRAP_EMAIL=admin@example.com
+export ADMIN_BOOTSTRAP_PASSWORD=choose-a-password-8+chars
+
+uvicorn backend.main:app --reload --port 5000
+```
+
+(These can also live in a `.env` file at the repo root, which the backend reads.)
+
+### Frontend (terminal 2)
+
+```bash
+npm --prefix frontend install
+npm --prefix frontend run dev
+```
+
+Then open **http://localhost:3000** and log in with the bootstrap admin. The
+frontend talks to the backend at `http://localhost:5000` by default
+(`NEXT_PUBLIC_API_BASE_URL` is unset in dev).
+
+---
+
+## Tests
+
+```bash
+# Backend
+python3 -m pytest
+
+# Frontend
+npm --prefix frontend test
+npm --prefix frontend run lint -- --max-warnings=0
+```

--- a/DEPLOY_LOCAL.md
+++ b/DEPLOY_LOCAL.md
@@ -53,8 +53,9 @@ Generate a secret for `AUTH_SECRET_KEY`:
 openssl rand -hex 32
 ```
 
-Leave `DB_PATH`, `REGULATIONS_PATH`, and `NEXT_PUBLIC_API_BASE_URL=/api` at their
-defaults.
+`docker-compose.yml` sets `DB_PATH=/data/ccc.db`,
+`REGULATIONS_PATH=/data/regulations`, and `NEXT_PUBLIC_API_BASE_URL=/api` for the
+Docker services. Leave those Docker defaults unchanged.
 
 ### 2. Build and start
 
@@ -69,7 +70,7 @@ The first build takes a few minutes (pip + npm). Fonts are vendored
 
 Visit **http://localhost** and log in with the `ADMIN_BOOTSTRAP_EMAIL` /
 `ADMIN_BOOTSTRAP_PASSWORD` you set. As an admin you can create more users via the
-**Benutzer** button in the header (there is no public self-registration).
+**Benutzerverwaltung** button in the header (there is no public self-registration).
 
 ### 4. Operate
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ npm run dev
 
 Frontend runs on `http://localhost:3000`. Open it and log in with the
 `ADMIN_BOOTSTRAP_EMAIL` / `ADMIN_BOOTSTRAP_PASSWORD` above; as an admin you can
-provision more users from the header (there is no public self-registration).
+provision more users from the `Benutzerverwaltung` button in the header (there
+is no public self-registration).
 
 The default CORS config already allows `http://localhost:3000` → the backend on
 `:5000`, so no reverse proxy is needed for local development.
@@ -71,7 +72,7 @@ The default CORS config already allows `http://localhost:3000` → the backend o
   - `GEMINI_API_KEY`
 - Authentication:
   - `AUTH_SECRET_KEY` (required; signs the auth cookie/JWT)
-  - `AUTH_COOKIE_SECURE` (default `false`; set `true` behind TLS)
+  - `AUTH_COOKIE_SECURE` (`true` for HTTPS production; set `false` only for local plain HTTP)
   - `AUTH_TOKEN_TTL_MINUTES` (default `1440`)
   - `ADMIN_BOOTSTRAP_EMAIL` / `ADMIN_BOOTSTRAP_PASSWORD` (first admin, seeded on startup)
   - `AUTH_ALLOWED_EMAILS` (optional comma-separated allowlist for provisioning)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ CCC is a web app to estimate compliance costs for German legislation across a 7-
 - Backend: FastAPI + SQLite
 - Frontend: Next.js (App Router) + React + React Flow
 - LLM providers: OpenAI, DeepInfra, Gemini
+- Auth: built-in email + password accounts; sessions are private per user
+
+## Deployment
+- Production (Docker + Caddy TLS): see [DEPLOY.md](DEPLOY.md).
+- Local run (with or without Docker): see [DEPLOY_LOCAL.md](DEPLOY_LOCAL.md).
+- The quick "run without Docker" steps are below.
 
 ## Repository Layout
 - `backend/main.py`: FastAPI app entry point
@@ -14,17 +20,28 @@ CCC is a web app to estimate compliance costs for German legislation across a 7-
 - `frontend/src/`: UI components, context, API client, tests
 - `tests/`: backend tests
 
-## Local Setup
+## Local Setup (without Docker)
+
+The app requires authentication, so the backend needs an auth secret and a
+bootstrap admin account to log in with.
 
 ### 1) Backend
 ```bash
 python3 -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
+
+# Required for auth (login returns 500 without a secret):
+export AUTH_SECRET_KEY="$(openssl rand -hex 32)"
+export AUTH_COOKIE_SECURE=false          # allow the auth cookie over plain HTTP
+export ADMIN_BOOTSTRAP_EMAIL=admin@example.com
+export ADMIN_BOOTSTRAP_PASSWORD=changeme123   # 8+ chars
+
 uvicorn backend.main:app --reload --port 5000
 ```
 
-Backend runs on `http://localhost:5000`.
+Backend runs on `http://localhost:5000`. These env vars can also live in a root
+`.env` file (read via Pydantic settings) instead of being exported.
 
 ### 2) Frontend
 From repository root:
@@ -39,14 +56,26 @@ npm install
 npm run dev
 ```
 
-Frontend runs on `http://localhost:3000`.
+Frontend runs on `http://localhost:3000`. Open it and log in with the
+`ADMIN_BOOTSTRAP_EMAIL` / `ADMIN_BOOTSTRAP_PASSWORD` above; as an admin you can
+provision more users from the header (there is no public self-registration).
+
+The default CORS config already allows `http://localhost:3000` → the backend on
+`:5000`, so no reverse proxy is needed for local development.
 
 ## Environment
-- Backend reads `.env` via Pydantic settings.
-- Supported keys:
+- Backend reads `.env` via Pydantic settings. See [.env.example](.env.example) for the full list.
+- LLM provider keys:
   - `OPENAI_API_KEY`
   - `DEEPINFRA_API_KEY`
   - `GEMINI_API_KEY`
+- Authentication:
+  - `AUTH_SECRET_KEY` (required; signs the auth cookie/JWT)
+  - `AUTH_COOKIE_SECURE` (default `false`; set `true` behind TLS)
+  - `AUTH_TOKEN_TTL_MINUTES` (default `1440`)
+  - `ADMIN_BOOTSTRAP_EMAIL` / `ADMIN_BOOTSTRAP_PASSWORD` (first admin, seeded on startup)
+  - `AUTH_ALLOWED_EMAILS` (optional comma-separated allowlist for provisioning)
+  - `CORS_ALLOW_ORIGINS` (comma-separated; defaults to localhost dev origins, empty for same-origin prod)
 - Optional:
   - `DEFAULT_MODEL`
   - `DB_PATH`
@@ -59,6 +88,9 @@ Frontend can override API base URL with:
 - `NEXT_PUBLIC_ENABLE_LLM_CONSOLE` (`true`/`false`; default: `true`)
 
 ## Testing
+
+The test suites do not need the auth env vars — the backend `tests/conftest.py`
+overrides authentication and seeds a test user automatically.
 
 ### Backend tests
 ```bash
@@ -75,8 +107,15 @@ npm --prefix frontend test -- --runInBand
 npm --prefix frontend run lint -- --max-warnings=0
 ```
 
+## Authentication & Ownership
+- Accounts are email + password; there is no public self-registration. The
+  bootstrap admin (from env) provisions further users via the header UI.
+- Requests are authenticated with an httpOnly cookie; every app endpoint requires it.
+- Sessions are private per user: `app_session_id` is server-generated, `GET /sessions`
+  is scoped to the caller, and accessing another user's session returns 404.
+
 ## Core Concepts
-- `app_session_id`: user-facing session identifier (used by frontend and API).
+- `app_session_id`: user-facing session identifier (server-generated, owned by a user).
 - `session_id`: internal integer DB key.
 - Tile operations are strictly session-scoped (`app_session_id` is required).
 - Workflow state is persisted in DB and mirrored in frontend session state.
@@ -95,4 +134,4 @@ npm --prefix frontend run lint -- --max-warnings=0
 - API keys entered in the UI are kept in browser storage and removed when fields are cleared.
 
 ## Notes
-- If `next build` fails offline due to Google Fonts fetch, run development server or provide network access for font fetch at build time.
+- Fonts are self-hosted via `@fontsource`, so `next build` does not fetch Google Fonts and works offline.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,49 @@
+# syntax=docker/dockerfile:1
+#
+# Backend image for the Compliance-Cost Computer (CCC).
+# Build context MUST be the repository root (requirements.txt lives there):
+#   docker build -f backend/Dockerfile -t ccc-backend .
+#
+FROM python:3.12-slim
+
+# Standard Python container hygiene.
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+WORKDIR /app
+
+# Install only what some wheels may need to build, then clean up.
+# Most dependencies ship manylinux wheels, but build-essential keeps the
+# build robust for any source-only package. curl is used by the healthcheck.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install dependencies first for better layer caching.
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the backend package.
+COPY backend/ ./backend/
+
+# Create a non-root user and a persistent data directory it owns.
+RUN useradd --create-home --uid 10001 appuser \
+    && mkdir -p /data \
+    && chown -R appuser:appuser /data /app
+
+ENV DB_PATH=/data/ccc.db \
+    REGULATIONS_PATH=/data/regulations
+
+USER appuser
+
+EXPOSE 5000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+    CMD curl -fsS http://localhost:5000/health || exit 1
+
+# Single worker by design (the workflow holds in-process state).
+CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "5000"]

--- a/backend/core/auth.py
+++ b/backend/core/auth.py
@@ -144,10 +144,12 @@ def email_is_allowed(email: str) -> bool:
 
 
 def ensure_bootstrap_admin() -> None:
-    """Seed the configured bootstrap admin if it does not exist yet."""
+    """Seed the configured bootstrap admin only for an empty admin set."""
     email = (settings.admin_bootstrap_email or "").strip()
     password = settings.admin_bootstrap_password or ""
     if not email or not password:
+        return
+    if db.count_admins() > 0:
         return
     if db.get_user_by_email(email) is not None:
         return

--- a/backend/core/auth.py
+++ b/backend/core/auth.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 
-from fastapi import Header
+import bcrypt
+import jwt
+from fastapi import Depends, Header, HTTPException, Request, status
 
+from . import db
 from .config import settings
 
 
@@ -25,3 +29,126 @@ def get_api_keys(
         deepinfra_api_key=x_deepinfra_key or settings.deepinfra_api_key,
         gemini_api_key=x_gemini_key or settings.gemini_api_key,
     )
+
+
+# ---------------------------------------------------------------------------
+# Accounts / authentication
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AuthUser:
+    user_id: int
+    email: str
+    is_admin: bool
+
+
+def hash_password(password: str) -> str:
+    return bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
+
+
+def verify_password(password: str, password_hash: str) -> bool:
+    try:
+        return bcrypt.checkpw(password.encode("utf-8"), password_hash.encode("utf-8"))
+    except (ValueError, TypeError):
+        return False
+
+
+def _require_secret() -> str:
+    secret = (settings.auth_secret_key or "").strip()
+    if not secret:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="AUTH_SECRET_KEY is not configured",
+        )
+    return secret
+
+
+def create_access_token(user_id: int) -> str:
+    secret = _require_secret()
+    now = datetime.now(timezone.utc)
+    payload = {
+        "sub": str(int(user_id)),
+        "iat": now,
+        "exp": now + timedelta(minutes=settings.auth_token_ttl_minutes),
+    }
+    return jwt.encode(payload, secret, algorithm="HS256")
+
+
+def _decode_user_id(token: str) -> int | None:
+    try:
+        payload = jwt.decode(token, _require_secret(), algorithms=["HS256"])
+    except HTTPException:
+        raise
+    except jwt.PyJWTError:
+        return None
+    sub = payload.get("sub")
+    try:
+        return int(sub)
+    except (TypeError, ValueError):
+        return None
+
+
+def _unauthorized() -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Not authenticated",
+    )
+
+
+def get_current_user(request: Request) -> AuthUser:
+    """FastAPI dependency: resolve the authenticated user from the auth cookie."""
+    # Surfaces a clear 500 when the deployment forgot to set AUTH_SECRET_KEY.
+    _require_secret()
+    token = request.cookies.get(settings.auth_cookie_name)
+    if not token:
+        raise _unauthorized()
+    user_id = _decode_user_id(token)
+    if user_id is None:
+        raise _unauthorized()
+    user = db.get_user_by_id(user_id)
+    if user is None or not user.get("is_active"):
+        raise _unauthorized()
+    return AuthUser(
+        user_id=int(user["user_id"]),
+        email=str(user["email"]),
+        is_admin=bool(user.get("is_admin")),
+    )
+
+
+def require_admin(user: AuthUser = Depends(get_current_user)) -> AuthUser:
+    if not user.is_admin:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin privileges required",
+        )
+    return user
+
+
+def email_is_allowed(email: str) -> bool:
+    """Whether an admin may provision this email, per AUTH_ALLOWED_EMAILS.
+
+    Empty allowlist = no extra restriction (accounts are still admin-provisioned;
+    there is no public self-signup). Entries may be full emails or `@domain`.
+    """
+    entries = [e.strip().lower() for e in (settings.auth_allowed_emails or "").split(",") if e.strip()]
+    if not entries:
+        return True
+    email_l = str(email).strip().lower()
+    for entry in entries:
+        if entry.startswith("@") and email_l.endswith(entry):
+            return True
+        if entry == email_l:
+            return True
+    return False
+
+
+def ensure_bootstrap_admin() -> None:
+    """Seed the configured bootstrap admin if it does not exist yet."""
+    email = (settings.admin_bootstrap_email or "").strip()
+    password = settings.admin_bootstrap_password or ""
+    if not email or not password:
+        return
+    if db.get_user_by_email(email) is not None:
+        return
+    db.create_user(email, hash_password(password), is_admin=True, is_active=True)

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -42,6 +42,22 @@ class Settings(BaseSettings):
     db_path: Path = DEFAULT_DB_PATH
     regulations_path: Path = DEFAULT_REGULATIONS_PATH
 
+    # Authentication / accounts.
+    auth_secret_key: str = ""
+    auth_token_ttl_minutes: int = 1440
+    auth_cookie_name: str = "ccc_auth"
+    # Set true behind a TLS-terminating proxy so the auth cookie is Secure-only.
+    auth_cookie_secure: bool = False
+    # Bootstrap admin seeded on startup when the users table has no admin yet.
+    admin_bootstrap_email: str = ""
+    admin_bootstrap_password: str = ""
+    # Comma-separated allowlist of emails an admin may provision. Empty = no
+    # additional restriction beyond "admin-provisioned only" (no self-signup).
+    auth_allowed_emails: str = ""
+    # Comma-separated CORS origins. Defaults to local dev; production behind the
+    # same-origin proxy should set this empty.
+    cors_allow_origins: str = "http://localhost:3000,http://localhost:3001"
+
     model_config = ConfigDict(env_file=".env")
 
 

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -58,7 +58,7 @@ class Settings(BaseSettings):
     # same-origin proxy should set this empty.
     cors_allow_origins: str = "http://localhost:3000,http://localhost:3001"
 
-    model_config = ConfigDict(env_file=".env")
+    model_config = ConfigDict(env_file=".env", extra="ignore")
 
 
 settings = Settings()

--- a/backend/core/db.py
+++ b/backend/core/db.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import secrets
 import sqlite3
 import time
 from contextlib import contextmanager
@@ -32,6 +33,9 @@ from .norm_addressees import (
 logger = logging.getLogger(__name__)
 
 _TX_CONN: ContextVar[sqlite3.Connection | None] = ContextVar("tx_conn", default=None)
+
+CROCKFORD_BASE32_ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+APP_SESSION_ID_LENGTH = 6
 
 
 LLM_ANSWER_STATE_PENDING = "pending"
@@ -152,9 +156,13 @@ def _ensure_parent(path: Path) -> None:
 
 def _open_connection() -> sqlite3.Connection:
     _ensure_parent(settings.db_path)
-    conn = sqlite3.connect(settings.db_path)
+    # timeout/busy_timeout: wait (up to 30s) instead of failing immediately when
+    # another writer holds the lock. Relevant once work runs off the event loop
+    # (e.g. deep-research via asyncio.to_thread) so concurrent writers can overlap.
+    conn = sqlite3.connect(settings.db_path, timeout=30.0)
     conn.row_factory = sqlite3.Row
     conn.execute("PRAGMA foreign_keys = ON;")
+    conn.execute("PRAGMA busy_timeout = 30000;")
     return conn
 
 
@@ -595,6 +603,25 @@ def _ensure_columns(
 ) -> None:
     for column, column_ddl in columns.items():
         _ensure_column(cur, table, column, column_ddl)
+
+
+def _create_users_table(cur: sqlite3.Cursor) -> None:
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS users (
+            user_id        INTEGER PRIMARY KEY,
+            email          TEXT NOT NULL,
+            password_hash  TEXT NOT NULL,
+            is_admin       INTEGER NOT NULL DEFAULT 0,
+            is_active      INTEGER NOT NULL DEFAULT 1,
+            created_at     TEXT NOT NULL DEFAULT current_timestamp
+        )
+        """
+    )
+    # Case-insensitive unique email.
+    cur.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_users_email_lower ON users(lower(email))"
+    )
 
 
 def _create_process_steps_table(cur: sqlite3.Cursor, table_name: str = "process_steps") -> None:
@@ -1634,7 +1661,9 @@ def init_db() -> None:
             file_name       TEXT NOT NULL,
             law_text        TEXT NOT NULL,
             text_length     INTEGER NOT NULL,
-            uploaded_at     TEXT NOT NULL DEFAULT current_timestamp
+            uploaded_at     TEXT NOT NULL DEFAULT current_timestamp,
+            owner_user_id   INTEGER REFERENCES users(user_id),
+            is_builtin      INTEGER NOT NULL DEFAULT 1
         )
         """
     )
@@ -1679,6 +1708,21 @@ def init_db() -> None:
     )
     cur.execute(
         "CREATE UNIQUE INDEX IF NOT EXISTS idx_sessions_app_session_id ON sessions(app_session_id)"
+    )
+    _create_users_table(cur)
+    _ensure_column(cur, "laws", "owner_user_id", "INTEGER REFERENCES users(user_id)")
+    _ensure_column(cur, "laws", "is_builtin", "INTEGER NOT NULL DEFAULT 1")
+    cur.execute("UPDATE laws SET is_builtin = 1 WHERE is_builtin IS NULL")
+    cur.execute(
+        "CREATE INDEX IF NOT EXISTS idx_laws_owner_file ON laws(owner_user_id, file_name)"
+    )
+    cur.execute(
+        "CREATE INDEX IF NOT EXISTS idx_laws_builtin_file ON laws(is_builtin, file_name)"
+    )
+    # Migration-only: add the ownership column to legacy/dev session tables.
+    _ensure_column(cur, "sessions", "owner_user_id", "INTEGER REFERENCES users(user_id)")
+    cur.execute(
+        "CREATE INDEX IF NOT EXISTS idx_sessions_owner ON sessions(owner_user_id)"
     )
     _create_session_activities_table(cur)
     _create_session_total_costs_by_addressee_table(cur)
@@ -2031,29 +2075,59 @@ def fetch_tiles(session_id: int, norm_addressee: str = ADMINISTRATION) -> List[T
     return tiles
 
 
-def list_law_file_names() -> List[str]:
+def list_law_file_names(owner_user_id: int | None = None) -> List[str]:
     conn = get_conn()
     cur = conn.cursor()
-    cur.execute(
-        "SELECT file_name FROM laws ORDER BY uploaded_at DESC, document_id DESC"
-    )
+    if owner_user_id is None:
+        cur.execute(
+            "SELECT file_name FROM laws ORDER BY uploaded_at DESC, document_id DESC"
+        )
+    else:
+        cur.execute(
+            """
+            SELECT file_name
+            FROM laws
+            WHERE is_builtin = 1 OR owner_user_id = ?
+            ORDER BY is_builtin DESC, uploaded_at DESC, document_id DESC
+            """,
+            (int(owner_user_id),),
+        )
     names = [row["file_name"] for row in cur.fetchall()]
     _maybe_close(conn)
     return names
 
 
-def get_law_by_filename(file_name: str) -> dict | None:
+def get_law_by_filename(
+    file_name: str,
+    owner_user_id: int | None = None,
+) -> dict | None:
     conn = get_conn()
     cur = conn.cursor()
-    cur.execute(
-        """
-        SELECT document_id, file_name, law_text, text_length, uploaded_at
-        FROM laws
-        WHERE file_name = ?
-        LIMIT 1
-        """,
-        (file_name,),
-    )
+    if owner_user_id is None:
+        cur.execute(
+            """
+            SELECT document_id, file_name, law_text, text_length, uploaded_at,
+                   owner_user_id, is_builtin
+            FROM laws
+            WHERE file_name = ?
+            ORDER BY is_builtin DESC, uploaded_at DESC, document_id DESC
+            LIMIT 1
+            """,
+            (file_name,),
+        )
+    else:
+        cur.execute(
+            """
+            SELECT document_id, file_name, law_text, text_length, uploaded_at,
+                   owner_user_id, is_builtin
+            FROM laws
+            WHERE file_name = ?
+              AND (is_builtin = 1 OR owner_user_id = ?)
+            ORDER BY is_builtin DESC, owner_user_id DESC, uploaded_at DESC, document_id DESC
+            LIMIT 1
+            """,
+            (file_name, int(owner_user_id)),
+        )
     row = cur.fetchone()
     _maybe_close(conn)
     if row is None:
@@ -2066,7 +2140,8 @@ def get_law_by_id(document_id: int) -> dict | None:
     cur = conn.cursor()
     cur.execute(
         """
-        SELECT document_id, file_name, law_text, text_length, uploaded_at
+        SELECT document_id, file_name, law_text, text_length, uploaded_at,
+               owner_user_id, is_builtin
         FROM laws
         WHERE document_id = ?
         LIMIT 1
@@ -2080,15 +2155,26 @@ def get_law_by_id(document_id: int) -> dict | None:
     return dict(row)
 
 
-def insert_law(file_name: str, law_text: str) -> int:
+def insert_law(
+    file_name: str,
+    law_text: str,
+    owner_user_id: int | None = None,
+    is_builtin: bool = True,
+) -> int:
     conn = get_conn()
     cur = conn.cursor()
     cur.execute(
         """
-        INSERT INTO laws (file_name, law_text, text_length)
-        VALUES (?, ?, ?)
+        INSERT INTO laws (file_name, law_text, text_length, owner_user_id, is_builtin)
+        VALUES (?, ?, ?, ?, ?)
         """,
-        (file_name, law_text, len(law_text)),
+        (
+            file_name,
+            law_text,
+            len(law_text),
+            None if is_builtin else owner_user_id,
+            int(bool(is_builtin)),
+        ),
     )
     _maybe_commit(conn)
     document_id = int(cur.lastrowid)
@@ -2355,11 +2441,17 @@ def get_latest_session() -> dict | None:
     return dict(row)
 
 
-def list_sessions(limit: int = 50) -> List[dict]:
+def list_sessions(limit: int = 50, owner_user_id: int | None = None) -> List[dict]:
     conn = get_conn()
     cur = conn.cursor()
+    where = ""
+    params: list = []
+    if owner_user_id is not None:
+        where = "WHERE s.owner_user_id = ?"
+        params.append(int(owner_user_id))
+    params.append(limit)
     cur.execute(
-        """
+        f"""
         SELECT
             s.app_session_id,
             s.created_at,
@@ -2367,14 +2459,138 @@ def list_sessions(limit: int = 50) -> List[dict]:
             s.used_llm_models,
             s.case_group_research_enabled
         FROM sessions AS s
+        {where}
         ORDER BY s.created_at DESC, s.session_id DESC
         LIMIT ?
         """,
-        (limit,),
+        tuple(params),
     )
     rows = [dict(row) for row in cur.fetchall()]
     _maybe_close(conn)
     return rows
+
+
+def _row_to_user_dict(row: sqlite3.Row | None) -> dict | None:
+    if row is None:
+        return None
+    data = dict(row)
+    data["is_admin"] = bool(data.get("is_admin"))
+    data["is_active"] = bool(data.get("is_active"))
+    return data
+
+
+def get_user_by_id(user_id: int) -> dict | None:
+    conn = get_conn()
+    cur = conn.cursor()
+    cur.execute("SELECT * FROM users WHERE user_id = ? LIMIT 1", (int(user_id),))
+    row = cur.fetchone()
+    _maybe_close(conn)
+    return _row_to_user_dict(row)
+
+
+def get_user_by_email(email: str) -> dict | None:
+    conn = get_conn()
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT * FROM users WHERE lower(email) = lower(?) LIMIT 1",
+        (str(email).strip(),),
+    )
+    row = cur.fetchone()
+    _maybe_close(conn)
+    return _row_to_user_dict(row)
+
+
+def list_users() -> List[dict]:
+    conn = get_conn()
+    cur = conn.cursor()
+    cur.execute("SELECT * FROM users ORDER BY user_id ASC")
+    rows = [_row_to_user_dict(row) for row in cur.fetchall()]
+    _maybe_close(conn)
+    return [row for row in rows if row is not None]
+
+
+def count_admins() -> int:
+    conn = get_conn()
+    cur = conn.cursor()
+    cur.execute("SELECT COUNT(*) AS n FROM users WHERE is_admin = 1 AND is_active = 1")
+    row = cur.fetchone()
+    _maybe_close(conn)
+    return int(row["n"]) if row else 0
+
+
+def create_user(
+    email: str,
+    password_hash: str,
+    *,
+    is_admin: bool = False,
+    is_active: bool = True,
+) -> dict:
+    normalized_email = str(email).strip()
+    if not normalized_email:
+        raise ValueError("Email is required")
+    conn = get_conn()
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            """
+            INSERT INTO users (email, password_hash, is_admin, is_active)
+            VALUES (?, ?, ?, ?)
+            """,
+            (normalized_email, password_hash, int(is_admin), int(is_active)),
+        )
+    except sqlite3.IntegrityError as exc:
+        raise ValueError("A user with this email already exists") from exc
+    user_id = int(cur.lastrowid)
+    _maybe_commit(conn)
+    created = get_user_by_id(user_id)
+    assert created is not None
+    return created
+
+
+def update_user(
+    user_id: int,
+    *,
+    password_hash: str | None = None,
+    is_active: bool | None = None,
+    is_admin: bool | None = None,
+) -> dict | None:
+    fields: list[str] = []
+    params: list = []
+    if password_hash is not None:
+        fields.append("password_hash = ?")
+        params.append(password_hash)
+    if is_active is not None:
+        fields.append("is_active = ?")
+        params.append(int(is_active))
+    if is_admin is not None:
+        fields.append("is_admin = ?")
+        params.append(int(is_admin))
+    if not fields:
+        return get_user_by_id(user_id)
+    params.append(int(user_id))
+    conn = get_conn()
+    cur = conn.cursor()
+    cur.execute(f"UPDATE users SET {', '.join(fields)} WHERE user_id = ?", tuple(params))
+    _maybe_commit(conn)
+    return get_user_by_id(user_id)
+
+
+def create_owned_session(owner_user_id: int, llm_model: str) -> tuple[str, int]:
+    """Create a new session owned by the given user with a server-generated id."""
+    if not str(llm_model or "").strip():
+        raise ValueError("Model is required for new session")
+    for _ in range(5):
+        app_session_id = "".join(
+            secrets.choice(CROCKFORD_BASE32_ALPHABET)
+            for _ in range(APP_SESSION_ID_LENGTH)
+        )
+        if get_session_by_app_id(app_session_id) is not None:
+            continue
+        session_id, _created = upsert_session(
+            app_session_id, llm_model, owner_user_id=int(owner_user_id)
+        )
+        return app_session_id, session_id
+    raise RuntimeError("Could not allocate a unique app_session_id")
 
 
 def get_case_group_research_enabled(session_id: int) -> bool:
@@ -3106,10 +3322,13 @@ def get_session_id_by_app_id(app_session_id: str) -> int | None:
 def ensure_session(
     app_session_id: str,
     llm_model: str | None = None,
+    owner_user_id: int | None = None,
 ) -> tuple[int, bool, str]:
     requested_model = str(llm_model or "").strip()
     existing = get_session_by_app_id(app_session_id)
     if existing:
+        if owner_user_id is not None and existing.get("owner_user_id") != owner_user_id:
+            raise PermissionError("Session is owned by another user")
         session_id = int(existing["session_id"])
         existing_model = str(existing.get("llm_model") or "").strip()
         if not existing_model:
@@ -3122,11 +3341,15 @@ def ensure_session(
     if not requested_model:
         raise ValueError("Model is required for new session")
     model = requested_model
-    session_id, created = upsert_session(app_session_id, model)
+    session_id, created = upsert_session(app_session_id, model, owner_user_id=owner_user_id)
     return session_id, created, model
 
 
-def upsert_session(app_session_id: str, llm_model: str) -> tuple[int, bool]:
+def upsert_session(
+    app_session_id: str,
+    llm_model: str,
+    owner_user_id: int | None = None,
+) -> tuple[int, bool]:
     conn = get_conn()
     cur = conn.cursor()
     defaults = _resolve_pay_rate_defaults(ADMINISTRATION, PAY_RATE_LEVEL_BUND)
@@ -3167,17 +3390,19 @@ def upsert_session(app_session_id: str, llm_model: str) -> tuple[int, bool]:
             INSERT INTO sessions (
                 app_session_id,
                 llm_model,
+                owner_user_id,
                 pay_rate_administration_level,
                 pay_rate_default_a,
                 pay_rate_default_b,
                 pay_rate_default_c,
                 pay_rate_default_d
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 app_session_id,
                 llm_model,
+                owner_user_id,
                 PAY_RATE_LEVEL_BUND,
                 defaults["a"],
                 defaults["b"],
@@ -5260,16 +5485,17 @@ def update_session_documents(
     app_session_id: str,
     current_filename: str | None,
     proposed_filename: str | None,
+    owner_user_id: int | None = None,
 ) -> None:
     current_id = None
     proposed_id = None
     if current_filename:
-        current = get_law_by_filename(current_filename)
+        current = get_law_by_filename(current_filename, owner_user_id=owner_user_id)
         if current is None:
             raise ValueError("Current law not found")
         current_id = current["document_id"]
     if proposed_filename:
-        proposed = get_law_by_filename(proposed_filename)
+        proposed = get_law_by_filename(proposed_filename, owner_user_id=owner_user_id)
         if proposed is None:
             raise ValueError("Proposed law not found")
         proposed_id = proposed["document_id"]

--- a/backend/main.py
+++ b/backend/main.py
@@ -10,10 +10,13 @@ from fastapi import FastAPI
 from fastapi import Request
 from fastapi.middleware.cors import CORSMiddleware
 
+from backend.core import auth as auth_core
 from backend.core import db
 from backend.core import llm_trace
+from backend.core.config import settings
 from backend.core.request_context import bind_request_context, reset_request_context
 from backend.routers import (
+    auth,
     models,
     regulations,
     tiles,
@@ -32,14 +35,17 @@ logger = logging.getLogger("uvicorn.error")
 _MAX_JSON_LOG_BYTES = 65_536
 _QUIET_PATHS = {"/health"}
 
+_cors_allow_origins = [
+    origin.strip()
+    for origin in (settings.cors_allow_origins or "").split(",")
+    if origin.strip()
+]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[
-        "http://localhost:3000",
-        "http://localhost:3001",
-    ],
+    allow_origins=_cors_allow_origins,
     allow_credentials=True,
-    allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+    allow_methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"],
     allow_headers=["*"],
 )
 
@@ -162,18 +168,35 @@ async def log_backend_communication(request: Request, call_next):
 @app.on_event("startup")
 def startup() -> None:
     db.ensure_db()
+    auth_core.ensure_bootstrap_admin()
     db.clear_all_session_activities()
 
 
-app.include_router(tiles.router)
-app.include_router(models.router)
-app.include_router(regulations.router)
-app.include_router(processes.router)
-app.include_router(case_groups.router)
-app.include_router(process_steps.router)
-app.include_router(effort.router)
-app.include_router(costs.router)
-app.include_router(sessions.router)
+# Authentication is required on every application router; session-scoped routers
+# additionally enforce per-user ownership. `require_session_owner` itself depends
+# on `get_current_user`, so the owner gate also covers authentication.
+from fastapi import Depends  # noqa: E402
+from backend.core.auth import get_current_user  # noqa: E402
+from backend.routers._llm_router_utils import require_session_owner  # noqa: E402
+
+_auth_only = [Depends(get_current_user)]
+_owner_gate = [Depends(require_session_owner)]
+
+app.include_router(auth.router)
+# tiles and costs only ever operate on an existing session, so the owner gate
+# (which requires the session to already exist and be owned) fits the whole router.
+app.include_router(tiles.router, dependencies=_owner_gate)
+app.include_router(costs.router, dependencies=_owner_gate)
+app.include_router(models.router, dependencies=_auth_only)
+# The remaining routers expose workflow-step endpoints that create the session on
+# first use (owned by the caller via ensure_session_or_400) alongside read/edit
+# endpoints; ownership is enforced inside each handler / per-endpoint dependency.
+app.include_router(regulations.router, dependencies=_auth_only)
+app.include_router(processes.router, dependencies=_auth_only)
+app.include_router(case_groups.router, dependencies=_auth_only)
+app.include_router(process_steps.router, dependencies=_auth_only)
+app.include_router(effort.router, dependencies=_auth_only)
+app.include_router(sessions.router, dependencies=_auth_only)
 
 
 @app.get("/")

--- a/backend/routers/_llm_router_utils.py
+++ b/backend/routers/_llm_router_utils.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from typing import Awaitable, Callable, TypeVar
 
-from fastapi import HTTPException
+from fastapi import Depends, HTTPException, Request
 
 from backend.core import db
-from backend.core.auth import ApiKeys
+from backend.core.auth import ApiKeys, AuthUser, get_current_user
 from backend.core.llm_attempts import (
     llm_query_error_to_status_detail,
     mark_llm_answer_apply_failed,
@@ -17,12 +17,56 @@ from backend.core.llm_service import LlmResult
 ApplyResultT = TypeVar("ApplyResultT")
 
 
+def require_owned_session(app_session_id: str, user: AuthUser) -> dict:
+    """Return the session row if it exists and is owned by ``user``, else 404.
+
+    A 404 (rather than 403) is used so the existence of another user's session
+    is not revealed.
+    """
+    session = db.get_session_by_app_id(app_session_id)
+    if session is None or session.get("owner_user_id") != user.user_id:
+        raise HTTPException(status_code=404, detail="Session not found")
+    return session
+
+
+async def require_session_owner(
+    request: Request,
+    user: AuthUser = Depends(get_current_user),
+) -> AuthUser:
+    """Route dependency: enforce that the request's session is owned by the user.
+
+    Reads ``app_session_id`` from the query string or, failing that, the JSON
+    body (Starlette caches the body, so the handler still parses it normally).
+    """
+    app_session_id = request.query_params.get("app_session_id")
+    if not app_session_id and request.method not in {"GET", "HEAD", "DELETE"}:
+        try:
+            body = await request.json()
+        except Exception:
+            body = None
+        if isinstance(body, dict):
+            app_session_id = body.get("app_session_id")
+    if not app_session_id:
+        raise HTTPException(status_code=422, detail="app_session_id is required")
+    require_owned_session(str(app_session_id), user)
+    return user
+
+
 def ensure_session_or_400(
     app_session_id: str,
     model: str | None,
+    user: AuthUser,
 ) -> tuple[int, bool, str]:
+    """Resolve or create the session, scoped to ``user`` ownership.
+
+    Creates a new session owned by ``user`` when it does not exist yet (the
+    first step of a workflow), resolves it when already owned, and rejects it
+    with 404 when it exists but belongs to another user.
+    """
     try:
-        return db.ensure_session(app_session_id, model)
+        return db.ensure_session(app_session_id, model, owner_user_id=user.user_id)
+    except PermissionError as exc:
+        raise HTTPException(status_code=404, detail="Session not found") from exc
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from pydantic import BaseModel, Field
+
+from backend.core import auth as auth_core
+from backend.core import db
+from backend.core.config import settings
+
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+_MIN_PASSWORD_LENGTH = 8
+
+
+class LoginRequest(BaseModel):
+    email: str
+    password: str
+
+
+class MeResponse(BaseModel):
+    user_id: int
+    email: str
+    is_admin: bool
+
+
+class UserOut(BaseModel):
+    user_id: int
+    email: str
+    is_admin: bool
+    is_active: bool
+    created_at: str | None = None
+
+
+class CreateUserRequest(BaseModel):
+    email: str = Field(min_length=1, max_length=320)
+    password: str
+    is_admin: bool = False
+
+
+class UpdateUserRequest(BaseModel):
+    is_active: bool | None = None
+    is_admin: bool | None = None
+    password: str | None = None
+
+
+def _user_out(user: dict) -> UserOut:
+    return UserOut(
+        user_id=int(user["user_id"]),
+        email=str(user["email"]),
+        is_admin=bool(user.get("is_admin")),
+        is_active=bool(user.get("is_active")),
+        created_at=user.get("created_at"),
+    )
+
+
+def _set_auth_cookie(response: Response, token: str) -> None:
+    response.set_cookie(
+        key=settings.auth_cookie_name,
+        value=token,
+        httponly=True,
+        secure=settings.auth_cookie_secure,
+        samesite="lax",
+        max_age=settings.auth_token_ttl_minutes * 60,
+        path="/",
+    )
+
+
+@router.post("/login", response_model=MeResponse)
+async def login(payload: LoginRequest, response: Response) -> MeResponse:
+    user = db.get_user_by_email(payload.email)
+    if (
+        user is None
+        or not user.get("is_active")
+        or not auth_core.verify_password(payload.password, str(user["password_hash"]))
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid email or password",
+        )
+    token = auth_core.create_access_token(int(user["user_id"]))
+    _set_auth_cookie(response, token)
+    return MeResponse(
+        user_id=int(user["user_id"]),
+        email=str(user["email"]),
+        is_admin=bool(user.get("is_admin")),
+    )
+
+
+@router.post("/logout", status_code=status.HTTP_204_NO_CONTENT)
+async def logout(response: Response) -> Response:
+    response.delete_cookie(settings.auth_cookie_name, path="/")
+    response.status_code = status.HTTP_204_NO_CONTENT
+    return response
+
+
+@router.get("/me", response_model=MeResponse)
+async def me(user: auth_core.AuthUser = Depends(auth_core.get_current_user)) -> MeResponse:
+    return MeResponse(user_id=user.user_id, email=user.email, is_admin=user.is_admin)
+
+
+@router.get("/users", response_model=list[UserOut])
+async def list_users(
+    _admin: auth_core.AuthUser = Depends(auth_core.require_admin),
+) -> list[UserOut]:
+    return [_user_out(user) for user in db.list_users()]
+
+
+@router.post("/users", response_model=UserOut, status_code=status.HTTP_201_CREATED)
+async def create_user(
+    payload: CreateUserRequest,
+    _admin: auth_core.AuthUser = Depends(auth_core.require_admin),
+) -> UserOut:
+    if len(payload.password) < _MIN_PASSWORD_LENGTH:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Password must be at least {_MIN_PASSWORD_LENGTH} characters",
+        )
+    if not auth_core.email_is_allowed(payload.email):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Email is not in the allowlist",
+        )
+    try:
+        user = db.create_user(
+            payload.email,
+            auth_core.hash_password(payload.password),
+            is_admin=payload.is_admin,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    return _user_out(user)
+
+
+@router.patch("/users/{user_id}", response_model=UserOut)
+async def update_user(
+    user_id: int,
+    payload: UpdateUserRequest,
+    _admin: auth_core.AuthUser = Depends(auth_core.require_admin),
+) -> UserOut:
+    target = db.get_user_by_id(user_id)
+    if target is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+    # Guard against locking out the last active admin.
+    demotes_admin = (payload.is_active is False) or (payload.is_admin is False)
+    if demotes_admin and target.get("is_admin") and db.count_admins() <= 1:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Cannot remove the last active admin",
+        )
+    password_hash = None
+    if payload.password is not None:
+        if len(payload.password) < _MIN_PASSWORD_LENGTH:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Password must be at least {_MIN_PASSWORD_LENGTH} characters",
+            )
+        password_hash = auth_core.hash_password(payload.password)
+    user = db.update_user(
+        user_id,
+        password_hash=password_hash,
+        is_active=payload.is_active,
+        is_admin=payload.is_admin,
+    )
+    assert user is not None
+    return _user_out(user)

--- a/backend/routers/case_groups.py
+++ b/backend/routers/case_groups.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from backend.core import db
@@ -10,7 +10,6 @@ from backend.core.llm_service import query_llm
 from backend.core.models import Tile
 from backend.core.norm_addressees import (
     ADMINISTRATION,
-    NORM_ADDRESSEE_ECHO_MISMATCH,
     check_norm_addressee_echo,
 )
 from backend.core.parsing import parse_first_int
@@ -28,6 +27,7 @@ from backend.routers._edit_validation import validate_non_negative_fields
 from backend.routers._edit_validation import validate_non_empty_rows
 from backend.routers._edit_validation import validate_non_noop_update_count
 from backend.routers._edit_validation import validate_unique_ids
+from backend.routers._llm_router_utils import require_session_owner
 from backend.routers._norm_addressee import normalize_norm_addressee_or_422
 from backend.routers._session_activity_guard import guarded_session_activity
 from backend.routers._session_validation import (
@@ -190,7 +190,7 @@ def format_case_group_development_response(
     }
 
 
-@router.get("/editable", response_model=EditableCaseGroupsResponse)
+@router.get("/editable", response_model=EditableCaseGroupsResponse, dependencies=[Depends(require_session_owner)])
 async def list_editable_case_groups(
     app_session_id: str = APP_SESSION_ID_QUERY_VALIDATION,
 ) -> EditableCaseGroupsResponse:
@@ -201,7 +201,7 @@ async def list_editable_case_groups(
     return EditableCaseGroupsResponse(rows=rows)
 
 
-@router.post("/bulk-update", response_model=BulkUpdateResponse)
+@router.post("/bulk-update", response_model=BulkUpdateResponse, dependencies=[Depends(require_session_owner)])
 async def bulk_update_case_groups(payload: CaseGroupBulkUpdateRequest) -> BulkUpdateResponse:
     session_id = db.get_session_id_by_app_id(payload.app_session_id)
     if session_id is None:
@@ -257,14 +257,8 @@ def _parse_case_groups(
     data, _parse_mode = require_json_object(
         payload,
         error_context="case group development",
-        required_top_level_key="prozesse",
     )
     fallback_kinds = check_norm_addressee_echo(data, norm_addressee)
-    if NORM_ADDRESSEE_ECHO_MISMATCH in fallback_kinds:
-        raise HTTPException(
-            status_code=422,
-            detail=f"normadressat mismatch (expected {norm_addressee})",
-        )
     processes = data.get("prozesse")
     if not isinstance(processes, list):
         return [], fallback_kinds

--- a/backend/routers/case_groups.py
+++ b/backend/routers/case_groups.py
@@ -10,6 +10,7 @@ from backend.core.llm_service import query_llm
 from backend.core.models import Tile
 from backend.core.norm_addressees import (
     ADMINISTRATION,
+    NORM_ADDRESSEE_ECHO_MISMATCH,
     check_norm_addressee_echo,
 )
 from backend.core.parsing import parse_first_int
@@ -257,8 +258,14 @@ def _parse_case_groups(
     data, _parse_mode = require_json_object(
         payload,
         error_context="case group development",
+        required_top_level_key="prozesse",
     )
     fallback_kinds = check_norm_addressee_echo(data, norm_addressee)
+    if NORM_ADDRESSEE_ECHO_MISMATCH in fallback_kinds:
+        raise HTTPException(
+            status_code=422,
+            detail=f"normadressat mismatch (expected {norm_addressee})",
+        )
     processes = data.get("prozesse")
     if not isinstance(processes, list):
         return [], fallback_kinds

--- a/backend/routers/effort.py
+++ b/backend/routers/effort.py
@@ -14,7 +14,6 @@ from backend.core.norm_addressees import (
     ADMINISTRATION,
     BUSINESS,
     CITIZENS,
-    NORM_ADDRESSEE_ECHO_MISMATCH,
     check_norm_addressee_echo,
 )
 from backend.core.parsing import parse_first_int, parse_optional_number
@@ -60,18 +59,11 @@ def _parse_cases_payload(
     data, parse_mode = require_json_object(
         payload,
         error_context="Invalid cases_calculation payload",
-        required_top_level_key="prozesse",
     )
     fallback_kinds: set[str] = set()
     if parse_mode == "extract_last_json_object":
         fallback_kinds.add("json_extract_last_object")
-    echo_kinds = check_norm_addressee_echo(data, norm_addressee)
-    if NORM_ADDRESSEE_ECHO_MISMATCH in echo_kinds:
-        raise HTTPException(
-            status_code=422,
-            detail=f"normadressat mismatch (expected {norm_addressee})",
-        )
-    fallback_kinds.update(echo_kinds)
+    fallback_kinds.update(check_norm_addressee_echo(data, norm_addressee))
     fallgruppen = extract_fallgruppen(data)
     parsed: list[dict] = []
     for fallgruppe in fallgruppen:
@@ -578,18 +570,11 @@ def _parse_effort_payload(payload: str, norm_addressee: str) -> tuple[list[dict]
     data, parse_mode = require_json_object(
         payload,
         error_context=f"Invalid effort_calculation payload for {norm_addressee}",
-        required_top_level_key="prozesse",
     )
     fallback_kinds: set[str] = set()
     if parse_mode == "extract_last_json_object":
         fallback_kinds.add("json_extract_last_object")
-    echo_kinds = check_norm_addressee_echo(data, norm_addressee)
-    if NORM_ADDRESSEE_ECHO_MISMATCH in echo_kinds:
-        raise HTTPException(
-            status_code=422,
-            detail=f"normadressat mismatch (expected {norm_addressee})",
-        )
-    fallback_kinds.update(echo_kinds)
+    fallback_kinds.update(check_norm_addressee_echo(data, norm_addressee))
     fallgruppen = extract_fallgruppen(data)
     parsed: list[dict] = []
     for fallgruppe in fallgruppen:
@@ -768,33 +753,6 @@ def parse_effort_calculation_outputs(
                 detail="Unknown fallgruppen_id values: " + ", ".join(missing_case_groups),
             )
 
-        # #13/#25: Jede fallgruppen_id genau einmal (kein stilles last-write-wins)
-        # und jede Fallgruppe des Normadressaten muss Kennzahlen erhalten.
-        seen_case_group_ids: set[int] = set()
-        duplicate_case_groups: list[str] = []
-        for entry in parsed_cases:
-            case_group_id = int(entry["case_group_id"])
-            if case_group_id in seen_case_group_ids:
-                duplicate_case_groups.append(str(case_group_id))
-            else:
-                seen_case_group_ids.add(case_group_id)
-        if duplicate_case_groups:
-            raise HTTPException(
-                status_code=422,
-                detail="Duplicate fallgruppen_id values: "
-                + ", ".join(sorted(set(duplicate_case_groups))),
-            )
-
-        uncovered_case_groups = sorted(
-            str(cg_id) for cg_id in case_group_ids - seen_case_group_ids
-        )
-        if uncovered_case_groups:
-            raise HTTPException(
-                status_code=422,
-                detail="Missing metrics for fallgruppen_id values: "
-                + ", ".join(uncovered_case_groups),
-            )
-
     missing_steps = [
         str(entry["step_id"])
         for entry in parsed_effort
@@ -806,29 +764,13 @@ def parse_effort_calculation_outputs(
             detail="Unknown taetigkeiten_id values: " + ", ".join(missing_steps),
         )
 
-    # #13/#25: Jede taetigkeiten_id genau einmal und jeder Schritt des
-    # Normadressaten muss einen Aufwandswert erhalten (symmetrisch zu den
-    # Fallgruppen oben).
-    seen_step_ids: set[int] = set()
-    duplicate_steps: list[str] = []
-    for entry in parsed_effort:
-        step_id = int(entry["step_id"])
-        if step_id in seen_step_ids:
-            duplicate_steps.append(str(step_id))
-        else:
-            seen_step_ids.add(step_id)
-    if duplicate_steps:
+    parsed_step_ids = {int(entry["step_id"]) for entry in parsed_effort}
+    omitted_steps = sorted(step_ids - parsed_step_ids)
+    if omitted_steps:
         raise HTTPException(
             status_code=422,
-            detail="Duplicate taetigkeiten_id values: "
-            + ", ".join(sorted(set(duplicate_steps))),
-        )
-
-    uncovered_steps = sorted(str(step_id) for step_id in step_ids - seen_step_ids)
-    if uncovered_steps:
-        raise HTTPException(
-            status_code=422,
-            detail="Missing effort for taetigkeiten_id values: " + ", ".join(uncovered_steps),
+            detail="Missing taetigkeiten_id values: "
+            + ", ".join(str(step_id) for step_id in omitted_steps),
         )
 
     return parsed_cases, parsed_effort

--- a/backend/routers/effort.py
+++ b/backend/routers/effort.py
@@ -14,6 +14,7 @@ from backend.core.norm_addressees import (
     ADMINISTRATION,
     BUSINESS,
     CITIZENS,
+    NORM_ADDRESSEE_ECHO_MISMATCH,
     check_norm_addressee_echo,
 )
 from backend.core.parsing import parse_first_int, parse_optional_number
@@ -59,11 +60,18 @@ def _parse_cases_payload(
     data, parse_mode = require_json_object(
         payload,
         error_context="Invalid cases_calculation payload",
+        required_top_level_key="prozesse",
     )
     fallback_kinds: set[str] = set()
     if parse_mode == "extract_last_json_object":
         fallback_kinds.add("json_extract_last_object")
-    fallback_kinds.update(check_norm_addressee_echo(data, norm_addressee))
+    echo_kinds = check_norm_addressee_echo(data, norm_addressee)
+    if NORM_ADDRESSEE_ECHO_MISMATCH in echo_kinds:
+        raise HTTPException(
+            status_code=422,
+            detail=f"normadressat mismatch (expected {norm_addressee})",
+        )
+    fallback_kinds.update(echo_kinds)
     fallgruppen = extract_fallgruppen(data)
     parsed: list[dict] = []
     for fallgruppe in fallgruppen:
@@ -570,11 +578,18 @@ def _parse_effort_payload(payload: str, norm_addressee: str) -> tuple[list[dict]
     data, parse_mode = require_json_object(
         payload,
         error_context=f"Invalid effort_calculation payload for {norm_addressee}",
+        required_top_level_key="prozesse",
     )
     fallback_kinds: set[str] = set()
     if parse_mode == "extract_last_json_object":
         fallback_kinds.add("json_extract_last_object")
-    fallback_kinds.update(check_norm_addressee_echo(data, norm_addressee))
+    echo_kinds = check_norm_addressee_echo(data, norm_addressee)
+    if NORM_ADDRESSEE_ECHO_MISMATCH in echo_kinds:
+        raise HTTPException(
+            status_code=422,
+            detail=f"normadressat mismatch (expected {norm_addressee})",
+        )
+    fallback_kinds.update(echo_kinds)
     fallgruppen = extract_fallgruppen(data)
     parsed: list[dict] = []
     for fallgruppe in fallgruppen:
@@ -607,6 +622,141 @@ def _parse_effort_payload(payload: str, norm_addressee: str) -> tuple[list[dict]
             if parsed_entry is not None:
                 parsed.append(parsed_entry)
     return parsed, fallback_kinds
+
+
+def _expected_case_group_ids(context: dict) -> set[int]:
+    return {int(group["case_group_id"]) for group in context["case_groups"]}
+
+
+def _expected_step_ids(context: dict) -> set[int]:
+    return {int(step["step_id"]) for step in context["steps"]}
+
+
+def _validate_parsed_cases(parsed_cases: list[dict], context: dict) -> None:
+    if not parsed_cases:
+        raise HTTPException(status_code=422, detail="No case group metrics parsed")
+
+    case_group_ids = _expected_case_group_ids(context)
+    missing_case_groups = [
+        str(entry["case_group_id"])
+        for entry in parsed_cases
+        if entry["case_group_id"] not in case_group_ids
+    ]
+    if missing_case_groups:
+        raise HTTPException(
+            status_code=422,
+            detail="Unknown fallgruppen_id values: " + ", ".join(missing_case_groups),
+        )
+
+    # #13/#25: Jede fallgruppen_id genau einmal (kein stilles last-write-wins)
+    # und jede Fallgruppe des Normadressaten muss Kennzahlen erhalten.
+    seen_case_group_ids: set[int] = set()
+    duplicate_case_groups: list[str] = []
+    for entry in parsed_cases:
+        case_group_id = int(entry["case_group_id"])
+        if case_group_id in seen_case_group_ids:
+            duplicate_case_groups.append(str(case_group_id))
+        else:
+            seen_case_group_ids.add(case_group_id)
+    if duplicate_case_groups:
+        raise HTTPException(
+            status_code=422,
+            detail="Duplicate fallgruppen_id values: "
+            + ", ".join(sorted(set(duplicate_case_groups))),
+        )
+
+    uncovered_case_groups = sorted(
+        str(case_group_id) for case_group_id in case_group_ids - seen_case_group_ids
+    )
+    if uncovered_case_groups:
+        raise HTTPException(
+            status_code=422,
+            detail="Missing metrics for fallgruppen_id values: "
+            + ", ".join(uncovered_case_groups),
+        )
+
+
+def _validate_parsed_effort(parsed_effort: list[dict], context: dict) -> None:
+    if not parsed_effort:
+        raise HTTPException(status_code=422, detail="No effort metrics parsed")
+
+    step_ids = _expected_step_ids(context)
+    missing_steps = [
+        str(entry["step_id"])
+        for entry in parsed_effort
+        if entry["step_id"] not in step_ids
+    ]
+    if missing_steps:
+        raise HTTPException(
+            status_code=422,
+            detail="Unknown taetigkeiten_id values: " + ", ".join(missing_steps),
+        )
+
+    # #13/#25: Jede taetigkeiten_id genau einmal und jeder Schritt des
+    # Normadressaten muss einen Aufwandswert erhalten (symmetrisch zu den
+    # Fallgruppen oben).
+    seen_step_ids: set[int] = set()
+    duplicate_steps: list[str] = []
+    for entry in parsed_effort:
+        step_id = int(entry["step_id"])
+        if step_id in seen_step_ids:
+            duplicate_steps.append(str(step_id))
+        else:
+            seen_step_ids.add(step_id)
+    if duplicate_steps:
+        raise HTTPException(
+            status_code=422,
+            detail="Duplicate taetigkeiten_id values: "
+            + ", ".join(sorted(set(duplicate_steps))),
+        )
+
+    uncovered_steps = sorted(str(step_id) for step_id in step_ids - seen_step_ids)
+    if uncovered_steps:
+        raise HTTPException(
+            status_code=422,
+            detail="Missing effort for taetigkeiten_id values: "
+            + ", ".join(uncovered_steps),
+        )
+
+
+def parse_cases_calculation_output(
+    *,
+    session_id: int,
+    norm_addressee: str,
+    context: dict,
+    cases_text: str,
+    cases_answer_id: int | None,
+) -> list[dict]:
+    parsed_cases, fallback_kinds = _parse_cases_payload(cases_text, norm_addressee)
+    for fallback_kind in sorted(fallback_kinds):
+        mark_llm_parse_fallback(
+            answer_id=cases_answer_id,
+            session_id=session_id,
+            prompt_id=PromptId.CASES_CALCULATION,
+            fallback_kind=fallback_kind,
+        )
+    _validate_parsed_cases(parsed_cases, context)
+    return parsed_cases
+
+
+def parse_effort_calculation_output(
+    *,
+    session_id: int,
+    norm_addressee: str,
+    context: dict,
+    effort_text: str,
+    effort_answer_id: int | None,
+) -> list[dict]:
+    parsed_effort, fallback_kinds = _parse_effort_payload(effort_text, norm_addressee)
+    for fallback_kind in sorted(fallback_kinds):
+        mark_llm_parse_fallback(
+            answer_id=effort_answer_id,
+            session_id=session_id,
+            prompt_id=PromptId.EFFORT_CALCULATION,
+            fallback_kind=fallback_kind,
+        )
+    _validate_parsed_effort(parsed_effort, context)
+    return parsed_effort
 
 
 def prepare_effort_calculation(
@@ -710,68 +860,20 @@ def parse_effort_calculation_outputs(
     if not skip_cases_calculation:
         if cases_text is None:
             raise HTTPException(status_code=500, detail="Missing cases_calculation answer")
-        parsed_cases, cases_fallback_kinds = _parse_cases_payload(
-            cases_text,
-            norm_addressee,
-        )
-        for fallback_kind in sorted(cases_fallback_kinds):
-            mark_llm_parse_fallback(
-                answer_id=cases_answer_id,
-                session_id=session_id,
-                prompt_id=PromptId.CASES_CALCULATION,
-                fallback_kind=fallback_kind,
-            )
-        if not parsed_cases:
-            raise HTTPException(status_code=422, detail="No case group metrics parsed")
-
-    parsed_effort, effort_fallback_kinds = _parse_effort_payload(
-        effort_text,
-        norm_addressee,
-    )
-    for fallback_kind in sorted(effort_fallback_kinds):
-        mark_llm_parse_fallback(
-            answer_id=effort_answer_id,
+        parsed_cases = parse_cases_calculation_output(
             session_id=session_id,
-            prompt_id=PromptId.EFFORT_CALCULATION,
-            fallback_kind=fallback_kind,
+            norm_addressee=norm_addressee,
+            context=context,
+            cases_text=cases_text,
+            cases_answer_id=cases_answer_id,
         )
-    if not parsed_effort:
-        raise HTTPException(status_code=422, detail="No effort metrics parsed")
-
-    case_group_ids = {int(group["case_group_id"]) for group in context["case_groups"]}
-    step_ids = {int(step["step_id"]) for step in context["steps"]}
-
-    if not skip_cases_calculation:
-        missing_case_groups = [
-            str(entry["case_group_id"])
-            for entry in parsed_cases
-            if entry["case_group_id"] not in case_group_ids
-        ]
-        if missing_case_groups:
-            raise HTTPException(
-                status_code=422,
-                detail="Unknown fallgruppen_id values: " + ", ".join(missing_case_groups),
-            )
-
-    missing_steps = [
-        str(entry["step_id"])
-        for entry in parsed_effort
-        if entry["step_id"] not in step_ids
-    ]
-    if missing_steps:
-        raise HTTPException(
-            status_code=422,
-            detail="Unknown taetigkeiten_id values: " + ", ".join(missing_steps),
-        )
-
-    parsed_step_ids = {int(entry["step_id"]) for entry in parsed_effort}
-    omitted_steps = sorted(step_ids - parsed_step_ids)
-    if omitted_steps:
-        raise HTTPException(
-            status_code=422,
-            detail="Missing taetigkeiten_id values: "
-            + ", ".join(str(step_id) for step_id in omitted_steps),
-        )
+    parsed_effort = parse_effort_calculation_output(
+        session_id=session_id,
+        norm_addressee=norm_addressee,
+        context=context,
+        effort_text=effort_text,
+        effort_answer_id=effort_answer_id,
+    )
 
     return parsed_cases, parsed_effort
 

--- a/backend/routers/process_steps.py
+++ b/backend/routers/process_steps.py
@@ -11,6 +11,7 @@ from backend.core.parsing import parse_first_int
 from backend.core.models import Tile
 from backend.core.norm_addressees import (
     ADMINISTRATION,
+    NORM_ADDRESSEE_ECHO_MISMATCH,
     check_norm_addressee_echo,
 )
 from backend.core.payload_builders import build_case_groups_payload, dump_prompt_json
@@ -155,6 +156,37 @@ def parse_process_step_analysis_answer(
         raise HTTPException(
             status_code=422,
             detail="Unknown fallgruppen_id values: " + ", ".join(missing),
+        )
+
+    # #13/#25: Dieselbe fallgruppen_id darf nicht unter mehreren Prozessen
+    # auftauchen (sonst zwei Step-Ketten fuer eine Fallgruppe) -> 422 vor der
+    # Persistenz statt stillem last-write-wins.
+    seen_case_group_ids: set[int] = set()
+    duplicate_case_group_ids: list[str] = []
+    for entry in parsed:
+        case_group_id = entry["case_group_id"]
+        if case_group_id in seen_case_group_ids:
+            duplicate_case_group_ids.append(str(case_group_id))
+        else:
+            seen_case_group_ids.add(case_group_id)
+    if duplicate_case_group_ids:
+        raise HTTPException(
+            status_code=422,
+            detail="Duplicate fallgruppen_id values: "
+            + ", ".join(sorted(set(duplicate_case_group_ids))),
+        )
+
+    # #13/#25: Jede Fallgruppe des Normadressaten muss Prozessschritte erhalten
+    # (Schritt-5-Vollstaendigkeit) -> 422 vor der Persistenz, statt die Luecke
+    # erst spaeter in Schritt 6 aufzudecken.
+    uncovered_case_groups = sorted(
+        str(case_group_id) for case_group_id in set(case_group_lookup) - seen_case_group_ids
+    )
+    if uncovered_case_groups:
+        raise HTTPException(
+            status_code=422,
+            detail="Missing process steps for fallgruppen_id values: "
+            + ", ".join(uncovered_case_groups),
         )
 
     invalid_regulation_links: list[str] = []
@@ -335,11 +367,18 @@ def _parse_process_steps(
     data, parse_mode = require_json_object(
         payload,
         error_context="Invalid process_step_analysis payload",
+        required_top_level_key="prozesse",
     )
     fallback_kinds: set[str] = set()
     if parse_mode == "extract_last_json_object":
         fallback_kinds.add("json_extract_last_object")
-    fallback_kinds.update(check_norm_addressee_echo(data, norm_addressee))
+    echo_kinds = check_norm_addressee_echo(data, norm_addressee)
+    if NORM_ADDRESSEE_ECHO_MISMATCH in echo_kinds:
+        raise HTTPException(
+            status_code=422,
+            detail=f"normadressat mismatch (expected {norm_addressee})",
+        )
+    fallback_kinds.update(echo_kinds)
 
     parsed: list[dict] = []
     processes = data.get("prozesse")
@@ -552,7 +591,43 @@ def _add_step_tiles(
                 }
             )
             prev_step_id = step_id
+    _assert_single_chain_start_per_case_group(session_id, norm_addressee)
     return created
+
+
+def _assert_single_chain_start_per_case_group(
+    session_id: int,
+    norm_addressee: str,
+) -> None:
+    """#64 (P5): Verteidigung in der Tiefe nach dem Step-Insert.
+
+    Jede Fallgruppe darf hoechstens eine Prozessschritt-Kette besitzen, also
+    genau einen Schritt mit ``previous_id IS NULL``. Der Parse-Guard weist
+    doppelte ``fallgruppen_id`` bereits vor der Persistenz ab; sollte dieser je
+    umgangen werden, faengt diese Invariante den stillen Zwei-Ketten-Fall noch
+    innerhalb der laufenden Transaktion ab und erzwingt einen Rollback statt
+    einer halb gespeicherten, fuer Schritt 6 unvollstaendigen Session.
+    """
+    chain_starts: dict[int, int] = {}
+    for row in db.list_process_steps_for_session_and_addressee(
+        session_id, norm_addressee
+    ):
+        if row.get("previous_id") is None:
+            case_group_id = int(row["case_group_id"])
+            chain_starts[case_group_id] = chain_starts.get(case_group_id, 0) + 1
+    multi_chain = sorted(
+        str(case_group_id)
+        for case_group_id, count in chain_starts.items()
+        if count > 1
+    )
+    if multi_chain:
+        raise HTTPException(
+            status_code=500,
+            detail=(
+                "Invariant violated: multiple process-step chains for "
+                "fallgruppen_id values: " + ", ".join(multi_chain)
+            ),
+        )
 
 
 def _parse_regulation_ids(raw_value: object) -> list[int]:

--- a/backend/routers/process_steps.py
+++ b/backend/routers/process_steps.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from backend.core import db
@@ -11,7 +11,6 @@ from backend.core.parsing import parse_first_int
 from backend.core.models import Tile
 from backend.core.norm_addressees import (
     ADMINISTRATION,
-    NORM_ADDRESSEE_ECHO_MISMATCH,
     check_norm_addressee_echo,
 )
 from backend.core.payload_builders import build_case_groups_payload, dump_prompt_json
@@ -26,6 +25,7 @@ from backend.routers._edit_validation import validate_non_empty_rows
 from backend.routers._edit_validation import validate_non_noop_update_count
 from backend.routers._edit_validation import validate_unique_ids
 from backend.routers._edit_validation import validate_wage_source_kind
+from backend.routers._llm_router_utils import require_session_owner
 from backend.routers._norm_addressee import normalize_norm_addressee_or_422
 from backend.routers._session_activity_guard import guarded_session_activity
 from backend.routers._session_validation import (
@@ -157,37 +157,6 @@ def parse_process_step_analysis_answer(
             detail="Unknown fallgruppen_id values: " + ", ".join(missing),
         )
 
-    # #13/#25: Dieselbe fallgruppen_id darf nicht unter mehreren Prozessen
-    # auftauchen (sonst zwei Step-Ketten fuer eine Fallgruppe) -> 422 vor der
-    # Persistenz statt stillem last-write-wins.
-    seen_case_group_ids: set[int] = set()
-    duplicate_case_group_ids: list[str] = []
-    for entry in parsed:
-        case_group_id = entry["case_group_id"]
-        if case_group_id in seen_case_group_ids:
-            duplicate_case_group_ids.append(str(case_group_id))
-        else:
-            seen_case_group_ids.add(case_group_id)
-    if duplicate_case_group_ids:
-        raise HTTPException(
-            status_code=422,
-            detail="Duplicate fallgruppen_id values: "
-            + ", ".join(sorted(set(duplicate_case_group_ids))),
-        )
-
-    # #13/#25: Jede Fallgruppe des Normadressaten muss Prozessschritte erhalten
-    # (Schritt-5-Vollstaendigkeit) -> 422 vor der Persistenz, statt die Luecke
-    # erst spaeter in Schritt 6 aufzudecken.
-    uncovered_case_groups = sorted(
-        str(cg_id) for cg_id in set(case_group_lookup) - seen_case_group_ids
-    )
-    if uncovered_case_groups:
-        raise HTTPException(
-            status_code=422,
-            detail="Missing process steps for fallgruppen_id values: "
-            + ", ".join(uncovered_case_groups),
-        )
-
     invalid_regulation_links: list[str] = []
     for entry in parsed:
         process_id = int(case_group_lookup[entry["case_group_id"]]["process_id"])
@@ -230,7 +199,7 @@ def apply_process_step_analysis(
     )
 
 
-@router.get("/editable", response_model=EditableProcessStepsResponse)
+@router.get("/editable", response_model=EditableProcessStepsResponse, dependencies=[Depends(require_session_owner)])
 async def list_editable_process_steps(
     app_session_id: str = APP_SESSION_ID_QUERY_VALIDATION,
     case_group_id: int | None = None,
@@ -264,7 +233,7 @@ async def list_editable_process_steps(
     return EditableProcessStepsResponse(rows=rows)
 
 
-@router.post("/bulk-update", response_model=BulkUpdateResponse)
+@router.post("/bulk-update", response_model=BulkUpdateResponse, dependencies=[Depends(require_session_owner)])
 async def bulk_update_process_steps(
     payload: ProcessStepBulkUpdateRequest,
 ) -> BulkUpdateResponse:
@@ -318,7 +287,7 @@ async def bulk_update_process_steps(
     return BulkUpdateResponse(updated=updated)
 
 
-@router.post("/personnel-effort-edit", response_model=BulkUpdateResponse)
+@router.post("/personnel-effort-edit", response_model=BulkUpdateResponse, dependencies=[Depends(require_session_owner)])
 async def edit_personnel_effort_time(
     payload: PersonnelEffortTimeEditRequest,
 ) -> BulkUpdateResponse:
@@ -366,18 +335,11 @@ def _parse_process_steps(
     data, parse_mode = require_json_object(
         payload,
         error_context="Invalid process_step_analysis payload",
-        required_top_level_key="prozesse",
     )
     fallback_kinds: set[str] = set()
     if parse_mode == "extract_last_json_object":
         fallback_kinds.add("json_extract_last_object")
-    echo_kinds = check_norm_addressee_echo(data, norm_addressee)
-    if NORM_ADDRESSEE_ECHO_MISMATCH in echo_kinds:
-        raise HTTPException(
-            status_code=422,
-            detail=f"normadressat mismatch (expected {norm_addressee})",
-        )
-    fallback_kinds.update(echo_kinds)
+    fallback_kinds.update(check_norm_addressee_echo(data, norm_addressee))
 
     parsed: list[dict] = []
     processes = data.get("prozesse")
@@ -590,43 +552,7 @@ def _add_step_tiles(
                 }
             )
             prev_step_id = step_id
-    _assert_single_chain_start_per_case_group(session_id, norm_addressee)
     return created
-
-
-def _assert_single_chain_start_per_case_group(
-    session_id: int,
-    norm_addressee: str,
-) -> None:
-    """#64 (P5): Verteidigung in der Tiefe nach dem Step-Insert.
-
-    Jede Fallgruppe darf hoechstens eine Prozessschritt-Kette besitzen, also
-    genau einen Schritt mit ``previous_id IS NULL``. Der Parse-Guard weist
-    doppelte ``fallgruppen_id`` bereits vor der Persistenz ab; sollte dieser je
-    umgangen werden, faengt diese Invariante den stillen Zwei-Ketten-Fall noch
-    innerhalb der laufenden Transaktion ab und erzwingt einen Rollback statt
-    einer halb gespeicherten, fuer Schritt 6 unvollstaendigen Session.
-    """
-    chain_starts: dict[int, int] = {}
-    for row in db.list_process_steps_for_session_and_addressee(
-        session_id, norm_addressee
-    ):
-        if row.get("previous_id") is None:
-            case_group_id = int(row["case_group_id"])
-            chain_starts[case_group_id] = chain_starts.get(case_group_id, 0) + 1
-    multi_chain = sorted(
-        str(case_group_id)
-        for case_group_id, count in chain_starts.items()
-        if count > 1
-    )
-    if multi_chain:
-        raise HTTPException(
-            status_code=500,
-            detail=(
-                "Invariant violated: multiple process-step chains for "
-                "fallgruppen_id values: " + ", ".join(multi_chain)
-            ),
-        )
 
 
 def _parse_regulation_ids(raw_value: object) -> list[int]:

--- a/backend/routers/processes.py
+++ b/backend/routers/processes.py
@@ -9,7 +9,6 @@ from backend.core.llm_service import query_llm
 from backend.core.models import Tile
 from backend.core.norm_addressees import (
     ADMINISTRATION,
-    NORM_ADDRESSEE_ECHO_MISMATCH,
     check_norm_addressee_echo,
 )
 from backend.core.parsing import parse_first_int
@@ -113,14 +112,8 @@ def _parse_processes(
     data, _parse_mode = require_json_object(
         payload,
         error_context="process compilation",
-        required_top_level_key="prozesse",
     )
     fallback_kinds = check_norm_addressee_echo(data, norm_addressee)
-    if NORM_ADDRESSEE_ECHO_MISMATCH in fallback_kinds:
-        raise HTTPException(
-            status_code=422,
-            detail=f"normadressat mismatch (expected {norm_addressee})",
-        )
     processes = data.get("prozesse")
     if not isinstance(processes, list):
         return [], fallback_kinds

--- a/backend/routers/processes.py
+++ b/backend/routers/processes.py
@@ -9,6 +9,7 @@ from backend.core.llm_service import query_llm
 from backend.core.models import Tile
 from backend.core.norm_addressees import (
     ADMINISTRATION,
+    NORM_ADDRESSEE_ECHO_MISMATCH,
     check_norm_addressee_echo,
 )
 from backend.core.parsing import parse_first_int
@@ -112,8 +113,14 @@ def _parse_processes(
     data, _parse_mode = require_json_object(
         payload,
         error_context="process compilation",
+        required_top_level_key="prozesse",
     )
     fallback_kinds = check_norm_addressee_echo(data, norm_addressee)
+    if NORM_ADDRESSEE_ECHO_MISMATCH in fallback_kinds:
+        raise HTTPException(
+            status_code=422,
+            detail=f"normadressat mismatch (expected {norm_addressee})",
+        )
     processes = data.get("prozesse")
     if not isinstance(processes, list):
         return [], fallback_kinds

--- a/backend/routers/regulations.py
+++ b/backend/routers/regulations.py
@@ -24,6 +24,7 @@ from backend.core.prompts import PromptId, render_prompt
 from backend.core.session_graph import sync_all_norm_addressee_tile_snapshots
 from backend.core.models import Tile
 from backend.core.norm_addressees import ADMINISTRATION, BUSINESS, CITIZENS
+from backend.core.auth import AuthUser, get_current_user
 from backend.routers._llm_router_utils import (
     ensure_session_or_400,
     query_and_stage_or_http,
@@ -389,10 +390,12 @@ def _render_law_mode_context(prompt_id: str, law_mode: str) -> str:
 async def identify_regulations(
     payload: RegulationIdentifyRequest,
     api_keys: ApiKeys = Depends(get_api_keys),
+    user: AuthUser = Depends(get_current_user),
 ) -> dict:
     session_id, _created, model = ensure_session_or_400(
         payload.app_session_id,
         payload.model,
+        user,
     )
     current_text, proposed_text = db.get_session_law_texts(session_id)
     law_mode, current_prompt_text = _resolve_law_mode(current_text, proposed_text)
@@ -455,6 +458,7 @@ async def identify_regulations(
 async def summarize_regulation(
     payload: RegulationSummaryRequest,
     api_keys: ApiKeys = Depends(get_api_keys),
+    user: AuthUser = Depends(get_current_user),
 ) -> dict:
     filename = Path(payload.filename).name
     if not filename:
@@ -491,6 +495,7 @@ async def summarize_regulation(
         session_id, _created, model = ensure_session_or_400(
             payload.app_session_id,
             payload.model,
+            user,
         )
     else:
         model = str(payload.model or "").strip()

--- a/backend/routers/regulations.py
+++ b/backend/routers/regulations.py
@@ -96,8 +96,10 @@ class RegulationIdentifyRequest(BaseModel):
 
 
 @router.get("")
-async def list_regulations() -> dict:
-    files = db.list_law_file_names()
+async def list_regulations(
+    user: AuthUser = Depends(get_current_user),
+) -> dict:
+    files = db.list_law_file_names(owner_user_id=user.user_id)
     return {"files": files}
 
 
@@ -105,13 +107,14 @@ async def list_regulations() -> dict:
 async def upload_regulation(
     file: UploadFile = File(...),
     filename: str | None = Form(default=None),
+    user: AuthUser = Depends(get_current_user),
 ) -> dict:
     if not file.filename:
         raise HTTPException(status_code=400, detail="Missing filename")
     desired_name = Path(filename or file.filename).name
     if not desired_name:
         raise HTTPException(status_code=400, detail="Invalid filename")
-    if db.get_law_by_filename(desired_name):
+    if db.get_law_by_filename(desired_name, owner_user_id=user.user_id):
         raise HTTPException(
             status_code=409,
             detail={"error": "exists", "filename": desired_name},
@@ -122,7 +125,12 @@ async def upload_regulation(
     law_text = content.decode("utf-8", errors="ignore").strip()
     if not law_text:
         raise HTTPException(status_code=400, detail="Empty file")
-    document_id = db.insert_law(desired_name, law_text)
+    document_id = db.insert_law(
+        desired_name,
+        law_text,
+        owner_user_id=user.user_id,
+        is_builtin=False,
+    )
     return {"ok": True, "filename": desired_name, "document_id": document_id}
 
 
@@ -460,10 +468,18 @@ async def summarize_regulation(
     api_keys: ApiKeys = Depends(get_api_keys),
     user: AuthUser = Depends(get_current_user),
 ) -> dict:
+    if not payload.app_session_id:
+        raise HTTPException(status_code=400, detail="app_session_id is required")
+    session_id, _created, model = ensure_session_or_400(
+        payload.app_session_id,
+        payload.model,
+        user,
+    )
+
     filename = Path(payload.filename).name
     if not filename:
         raise HTTPException(status_code=400, detail="Invalid filename")
-    proposed_law = db.get_law_by_filename(filename)
+    proposed_law = db.get_law_by_filename(filename, owner_user_id=user.user_id)
     if not proposed_law:
         raise HTTPException(status_code=404, detail="File not found")
     content = str(proposed_law.get("law_text", "")).strip()
@@ -476,7 +492,7 @@ async def summarize_regulation(
         current_filename = Path(payload.current_filename).name
         if not current_filename:
             raise HTTPException(status_code=400, detail="Invalid current filename")
-        current_law = db.get_law_by_filename(current_filename)
+        current_law = db.get_law_by_filename(current_filename, owner_user_id=user.user_id)
         if not current_law:
             raise HTTPException(status_code=404, detail="Current file not found")
         current_content = str(current_law.get("law_text", "")).strip()
@@ -491,21 +507,6 @@ async def summarize_regulation(
         law_mode_context=_render_law_mode_context(PromptId.LAW_SUMMARY, law_mode),
     )
 
-    if payload.app_session_id:
-        session_id, _created, model = ensure_session_or_400(
-            payload.app_session_id,
-            payload.model,
-            user,
-        )
-    else:
-        model = str(payload.model or "").strip()
-        if not model:
-            raise HTTPException(status_code=400, detail="Model is required")
-        latest = db.get_latest_session()
-        if latest:
-            session_id = int(latest["session_id"])
-        else:
-            session_id, _created = db.upsert_session("SUMMARY-AUTO", model)
     answer_id, llm_result = await query_and_stage_or_http(
         session_id=session_id,
         prompt_id=PromptId.LAW_SUMMARY,
@@ -522,15 +523,15 @@ async def summarize_regulation(
 
     def _apply() -> None:
         with db.transaction():
-            if payload.app_session_id:
-                try:
-                    db.update_session_documents(
-                        payload.app_session_id,
-                        current_filename,
-                        filename,
-                    )
-                except ValueError as exc:
-                    raise HTTPException(status_code=404, detail=str(exc)) from exc
+            try:
+                db.update_session_documents(
+                    payload.app_session_id,
+                    current_filename,
+                    filename,
+                    owner_user_id=user.user_id,
+                )
+            except ValueError as exc:
+                raise HTTPException(status_code=404, detail=str(exc)) from exc
             _clear_existing_tiles(session_id)
             _update_law_tile(
                 session_id,
@@ -540,16 +541,15 @@ async def summarize_regulation(
                 model,
                 current_filename=current_filename,
             )
-            if payload.app_session_id:
-                db.update_session_summary(
-                    payload.app_session_id,
-                    title,
-                    summary,
-                    law_diff_blurb=blurb,
-                )
-                session = db.get_session_by_app_id(payload.app_session_id)
-                if session:
-                    sync_all_norm_addressee_tile_snapshots(session)
+            db.update_session_summary(
+                payload.app_session_id,
+                title,
+                summary,
+                law_diff_blurb=blurb,
+            )
+            session = db.get_session_by_app_id(payload.app_session_id)
+            if session:
+                sync_all_norm_addressee_tile_snapshots(session)
             mark_llm_answer_applied(
                 answer_id=answer_id,
                 session_id=session_id,

--- a/backend/routers/sessions.py
+++ b/backend/routers/sessions.py
@@ -16,7 +16,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import Response, StreamingResponse
 from pydantic import BaseModel, StringConstraints
 
-from backend.core.auth import ApiKeys, get_api_keys
+from backend.core.auth import ApiKeys, AuthUser, get_api_keys, get_current_user
 from backend.core.compliance_text_export import (
     USER_EDIT_REJECT,
     USER_EDIT_USE,
@@ -67,6 +67,8 @@ from backend.core.workflow import (
 from backend.routers._llm_router_utils import (
     ensure_session_or_400,
     query_and_stage_or_http,
+    require_owned_session,
+    require_session_owner,
     run_with_answer_apply_guard,
 )
 from backend.routers._edit_validation import validate_wage_source_kind
@@ -102,7 +104,7 @@ ModelName = Annotated[
 
 
 class SessionUpsertRequest(BaseModel):
-    app_session_id: AppSessionId
+    # app_session_id is server-generated; only the model is supplied by the client.
     llm_model: ModelName
 
 
@@ -1611,6 +1613,7 @@ async def _run_single_step(
     payload: SessionRunAllRequest,
     api_keys: ApiKeys,
     model: str,
+    user: AuthUser,
     event_hook: Callable[[str, dict], Awaitable[None] | None] | None = None,
 ) -> None:
     addressee_labels = {
@@ -1691,7 +1694,7 @@ async def _run_single_step(
             model=model,
             provider=payload.provider,
         )
-        await regulations_router.summarize_regulation(summary_payload, api_keys)
+        await regulations_router.summarize_regulation(summary_payload, api_keys, user)
         return
 
     if step_key == "regulations":
@@ -1700,7 +1703,7 @@ async def _run_single_step(
             model=model,
             provider=payload.provider,
         )
-        await regulations_router.identify_regulations(identify_payload, api_keys)
+        await regulations_router.identify_regulations(identify_payload, api_keys, user)
         return
 
     if step_key == "processes":
@@ -1807,6 +1810,7 @@ async def _execute_run_all_steps(
     payload: SessionRunAllRequest,
     api_keys: ApiKeys,
     model: str,
+    user: AuthUser,
     event_hook: Callable[[str, dict], Awaitable[None] | None] | None = None,
 ) -> tuple[list[SessionRunStepResult], SessionStatusResponse, bool]:
     step_results: list[SessionRunStepResult] = []
@@ -1850,6 +1854,7 @@ async def _execute_run_all_steps(
                 payload,
                 api_keys,
                 model,
+                user,
                 event_hook=event_hook,
             )
         except Exception as exc:
@@ -1936,6 +1941,7 @@ async def _execute_single_step(
     payload: SessionRunAllRequest,
     api_keys: ApiKeys,
     model: str,
+    user: AuthUser,
     event_hook: Callable[[str, dict], Awaitable[None] | None] | None = None,
 ) -> tuple[list[SessionRunStepResult], SessionStatusResponse, bool]:
     step_definition = RUN_ALL_STEP_BY_KEY.get(step_key)
@@ -1981,6 +1987,7 @@ async def _execute_single_step(
             payload,
             api_keys,
             model,
+            user,
             event_hook=event_hook,
         )
     except Exception as exc:
@@ -2073,21 +2080,33 @@ async def _execute_single_step(
 
 
 @router.post("", response_model=SessionUpsertResponse)
-async def upsert_session(payload: SessionUpsertRequest) -> SessionUpsertResponse:
-    _, created = db.upsert_session(payload.app_session_id, payload.llm_model)
-    return SessionUpsertResponse(
-        app_session_id=payload.app_session_id,
-        created=created,
-    )
+async def upsert_session(
+    payload: SessionUpsertRequest,
+    user: AuthUser = Depends(get_current_user),
+) -> SessionUpsertResponse:
+    try:
+        app_session_id, _session_id = db.create_owned_session(
+            user.user_id, payload.llm_model
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return SessionUpsertResponse(app_session_id=app_session_id, created=True)
 
 
 @router.get("", response_model=SessionListResponse)
-async def list_sessions(limit: int = Query(default=50, ge=1, le=200)) -> SessionListResponse:
-    sessions = db.list_sessions(limit=limit)
+async def list_sessions(
+    limit: int = Query(default=50, ge=1, le=200),
+    user: AuthUser = Depends(get_current_user),
+) -> SessionListResponse:
+    sessions = db.list_sessions(limit=limit, owner_user_id=user.user_id)
     return SessionListResponse(sessions=sessions)
 
 
-@router.get("/status", response_model=SessionStatusResponse)
+@router.get(
+    "/status",
+    response_model=SessionStatusResponse,
+    dependencies=[Depends(require_session_owner)],
+)
 async def session_status(
     app_session_id: str = APP_SESSION_ID_QUERY_VALIDATION
 ) -> SessionStatusResponse:
@@ -2112,7 +2131,7 @@ def _ensure_ea_edit_allowed(app_session_id: str) -> None:
         )
 
 
-@router.post("/ea-edit-activity/acquire", response_model=SessionEaEditActivityResponse)
+@router.post("/ea-edit-activity/acquire", response_model=SessionEaEditActivityResponse, dependencies=[Depends(require_session_owner)])
 async def acquire_ea_edit_activity(
     payload: SessionEaEditActivityRequest,
 ) -> SessionEaEditActivityResponse:
@@ -2137,7 +2156,7 @@ async def acquire_ea_edit_activity(
     )
 
 
-@router.post("/ea-edit-activity/heartbeat", response_model=SessionEaEditActivityResponse)
+@router.post("/ea-edit-activity/heartbeat", response_model=SessionEaEditActivityResponse, dependencies=[Depends(require_session_owner)])
 async def heartbeat_ea_edit_activity(
     payload: SessionEaEditActivityRequest,
 ) -> SessionEaEditActivityResponse:
@@ -2161,7 +2180,7 @@ async def heartbeat_ea_edit_activity(
     )
 
 
-@router.post("/ea-edit-activity/release")
+@router.post("/ea-edit-activity/release", dependencies=[Depends(require_session_owner)])
 async def release_ea_edit_activity(payload: SessionEaEditActivityRequest) -> dict:
     session_id = _session_id_or_404(payload.app_session_id)
     if payload.activity_id:
@@ -2173,7 +2192,7 @@ async def release_ea_edit_activity(payload: SessionEaEditActivityRequest) -> dic
     return {"ok": True}
 
 
-@router.get("/pay-rates", response_model=SessionPayRatesResponse)
+@router.get("/pay-rates", response_model=SessionPayRatesResponse, dependencies=[Depends(require_session_owner)])
 async def session_pay_rates(
     app_session_id: str = APP_SESSION_ID_QUERY_VALIDATION,
     norm_addressee: str | None = None,
@@ -2181,7 +2200,7 @@ async def session_pay_rates(
     return _as_session_pay_rates_response(app_session_id, norm_addressee=norm_addressee)
 
 
-@router.post("/pay-rates", response_model=SessionPayRatesResponse)
+@router.post("/pay-rates", response_model=SessionPayRatesResponse, dependencies=[Depends(require_session_owner)])
 async def session_pay_rates_update(
     payload: SessionPayRatesUpdateRequest,
 ) -> SessionPayRatesResponse:
@@ -2228,7 +2247,7 @@ def _as_session_wage_rates_response(
     )
 
 
-@router.get("/wage-rates", response_model=SessionWageRatesResponse)
+@router.get("/wage-rates", response_model=SessionWageRatesResponse, dependencies=[Depends(require_session_owner)])
 async def session_wage_rates(
     app_session_id: str = APP_SESSION_ID_QUERY_VALIDATION,
     norm_addressee: str | None = None,
@@ -2240,7 +2259,7 @@ async def session_wage_rates(
     return _as_session_wage_rates_response(app_session_id, session_id, resolved)
 
 
-@router.post("/wage-rates", response_model=SessionWageRatesResponse)
+@router.post("/wage-rates", response_model=SessionWageRatesResponse, dependencies=[Depends(require_session_owner)])
 async def session_wage_rates_update(
     payload: SessionWageRateUpdateRequest,
 ) -> SessionWageRatesResponse:
@@ -2283,7 +2302,7 @@ async def session_wage_rates_update(
     return _as_session_wage_rates_response(payload.app_session_id, session_id, resolved)
 
 
-@router.get("/edit-audit", response_model=SessionEditAuditResponse)
+@router.get("/edit-audit", response_model=SessionEditAuditResponse, dependencies=[Depends(require_session_owner)])
 async def session_edit_audit(
     app_session_id: str = APP_SESSION_ID_QUERY_VALIDATION,
     limit: int = Query(default=200, ge=1, le=1000),
@@ -2295,7 +2314,7 @@ async def session_edit_audit(
     return SessionEditAuditResponse(app_session_id=app_session_id, rows=rows)
 
 
-@router.post("/ea-edits/reset", response_model=SessionEaEditResetResponse)
+@router.post("/ea-edits/reset", response_model=SessionEaEditResetResponse, dependencies=[Depends(require_session_owner)])
 async def reset_session_ea_edits(
     payload: SessionEaEditResetRequest,
 ) -> SessionEaEditResetResponse:
@@ -2352,14 +2371,14 @@ def _research_settings_response(app_session_id: str) -> CaseGroupResearchSetting
     )
 
 
-@router.get("/case-group-research", response_model=CaseGroupResearchSettingsResponse)
+@router.get("/case-group-research", response_model=CaseGroupResearchSettingsResponse, dependencies=[Depends(require_session_owner)])
 async def case_group_research_settings(
     app_session_id: str = APP_SESSION_ID_QUERY_VALIDATION,
 ) -> CaseGroupResearchSettingsResponse:
     return _research_settings_response(app_session_id)
 
 
-@router.post("/case-group-research", response_model=CaseGroupResearchSettingsResponse)
+@router.post("/case-group-research", response_model=CaseGroupResearchSettingsResponse, dependencies=[Depends(require_session_owner)])
 async def case_group_research_settings_update(
     payload: CaseGroupResearchSettingsRequest,
 ) -> CaseGroupResearchSettingsResponse:
@@ -2393,6 +2412,10 @@ def _compliance_export_filename(app_session_id: str, user_edit_policy: str) -> s
     return f"ccc_vorblatt_begruendung_{app_session_id}{suffix}.pdf"
 
 
+async def _render_research_report_pdf_async(*args, **kwargs) -> bytes:
+    return await asyncio.to_thread(_render_research_report_pdf, *args, **kwargs)
+
+
 def _compliance_metadata_for_pdf(
     *,
     app_session_id: str,
@@ -2405,6 +2428,10 @@ def _compliance_metadata_for_pdf(
     used_user_edits: bool,
     reused: bool,
     created_at: str | None = None,
+    input_tokens: int | None = None,
+    output_tokens: int | None = None,
+    hidden_thinking_tokens: int | None = None,
+    estimated_cost_usd: float | None = None,
 ) -> dict[str, object]:
     if not has_user_edits:
         user_edit_status = "Keine bearbeiteten EA-Werte im Quellstand."
@@ -2429,17 +2456,23 @@ def _compliance_metadata_for_pdf(
         "deep_research_status": dr_status,
         "user_edit_status": user_edit_status,
         "source_snapshot_sha256": source_snapshot_sha256[:12],
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "hidden_thinking_tokens": hidden_thinking_tokens,
+        "estimated_cost_usd": estimated_cost_usd,
     }
 
 
-@router.post("/compliance-text-export")
+@router.post("/compliance-text-export", dependencies=[Depends(require_session_owner)])
 async def export_compliance_text(
     payload: ComplianceTextExportRequest,
     api_keys: ApiKeys = Depends(get_api_keys),
+    user: AuthUser = Depends(get_current_user),
 ) -> Response:
     session_id, _created, model = ensure_session_or_400(
         payload.app_session_id,
         payload.model,
+        user,
     )
     status = db.get_session_status(payload.app_session_id)
     if not status or not bool(status.get("total_cost_ready")):
@@ -2491,8 +2524,12 @@ async def export_compliance_text(
             used_user_edits=bool(cached.get("used_user_edits")),
             reused=True,
             created_at=cached.get("created_at"),
+            input_tokens=cached.get("input_tokens"),
+            output_tokens=cached.get("output_tokens"),
+            hidden_thinking_tokens=cached.get("hidden_thinking_tokens"),
+            estimated_cost_usd=cached.get("estimated_cost_usd"),
         )
-        pdf = _render_research_report_pdf(
+        pdf = await _render_research_report_pdf_async(
             str(cached["generated_markdown"]),
             f"Vorblatt und Begründung {payload.app_session_id}",
             metadata_lines=_format_compliance_export_metadata_lines(pdf_metadata),
@@ -2575,8 +2612,12 @@ async def export_compliance_text(
         has_user_edits=context.has_user_edits,
         used_user_edits=context.used_user_edits,
         reused=False,
+        input_tokens=llm_result.input_tokens,
+        output_tokens=llm_result.output_tokens,
+        hidden_thinking_tokens=llm_result.hidden_thinking_tokens,
+        estimated_cost_usd=llm_result.estimated_cost_usd,
     )
-    pdf = _render_research_report_pdf(
+    pdf = await _render_research_report_pdf_async(
         llm_result.text,
         f"Vorblatt und Begründung {payload.app_session_id}",
         metadata_lines=_format_compliance_export_metadata_lines(pdf_metadata),
@@ -2660,34 +2701,28 @@ def _should_render_research_pdf_bold(escaped_text: str) -> bool:
     return True
 
 
-_BOLD_MARKUP = re.compile(r"\*\*(?=\S)(.+?)(?<=\S)\*\*", re.DOTALL)
-_ITALIC_MARKUP = re.compile(r"(?<!\*)\*(?=\S)([^*]+?)(?<=\S)\*(?!\*)", re.DOTALL)
-_ESCAPED_LINE_BREAK = re.compile(r"&lt;br\s*/?&gt;", re.IGNORECASE)
-
-
 def _research_pdf_inline_markup(text: str) -> str:
     escaped = html.escape(text).replace("\n", "<br/>")
-    escaped = _ESCAPED_LINE_BREAK.sub("<br/>", escaped)
-
-    def bold(match: re.Match[str]) -> str:
-        inner = match.group(1)
-        if not _should_render_research_pdf_bold(inner):
-            return inner
-        return f"<b>{inner}</b>"
-
-    marked = _BOLD_MARKUP.sub(bold, escaped)
-    marked = _ITALIC_MARKUP.sub(lambda match: f"<i>{match.group(1)}</i>", marked)
-    return _linkify_research_pdf_urls(marked)
+    parts = escaped.split("**")
+    if len(parts) == 1:
+        return _linkify_research_pdf_urls(escaped)
+    rendered: list[str] = []
+    for index, part in enumerate(parts):
+        linked_part = _linkify_research_pdf_urls(part)
+        if index % 2 == 1 and _should_render_research_pdf_bold(part):
+            rendered.append(f"<b>{linked_part}</b>")
+        else:
+            rendered.append(linked_part)
+    return "".join(rendered)
 
 
 def _is_research_pdf_heading(text: str) -> bool:
-    level = len(text) - len(text.lstrip("#"))
     heading = text.lstrip("#").strip()
     if not heading:
         return False
     if "\n" in heading:
         return False
-    if level >= 2 and re.match(r"^\d+\.\s+", heading):
+    if re.match(r"^\d+\.\s+", heading):
         return False
     if len(heading) > 85:
         return False
@@ -2698,38 +2733,6 @@ def _is_research_pdf_heading(text: str) -> bool:
 
 def _strip_markdown_heading_prefix(text: str) -> str:
     return re.sub(r"^#{1,6}\s*", "", text, count=1).strip()
-
-
-_LIST_ITEM = re.compile(r"^(\s*)[-*]\s+(\S.*)$")
-
-
-def _parse_markdown_list(text: str) -> tuple[str, list[tuple[int, str]]] | None:
-    """Trennt einen Block in Einleitungstext und (Einrueckungstiefe, Text)-Items.
-
-    Gibt ``None`` zurueck, wenn der Block keine Aufzaehlung enthaelt. Die
-    Aufzaehlung darf direkt an einen Absatz anschliessen, weil das Modell die
-    Leerzeile davor nicht zuverlaessig setzt. Zeilen nach einem Item gelten als
-    dessen Fortsetzung, damit umgebrochene Eintraege nicht zu eigenen Bullets
-    werden.
-    """
-    lead_lines: list[str] = []
-    items: list[tuple[int, str]] = []
-    for line in text.split("\n"):
-        if not line.strip():
-            continue
-        match = _LIST_ITEM.match(line)
-        if match:
-            depth = 1 if len(match.group(1)) >= 2 else 0
-            items.append((depth, match.group(2).strip()))
-            continue
-        if not items:
-            lead_lines.append(line.strip())
-            continue
-        depth, current = items[-1]
-        items[-1] = (depth, f"{current} {line.strip()}")
-    if not items:
-        return None
-    return "\n".join(lead_lines), items
 
 
 def _linkify_research_pdf_urls(escaped_text: str) -> str:
@@ -2792,8 +2795,9 @@ def _format_compliance_export_metadata_lines(metadata: dict[str, object]) -> lis
         "<b>Analyseumfang:</b> Die Darstellung umfasst ausschliesslich jaehrlichen "
         "Erfuellungsaufwand. Einmaliger Erfuellungsaufwand ist nicht Gegenstand "
         "dieser Analyse.",
-        "<b>Verwaltung:</b> Der Erfuellungsaufwand der Verwaltung wird getrennt nach "
-        "Bundesebene und Landesebene (einschliesslich Kommunen) ausgewiesen.",
+        "<b>Verwaltung:</b> Fuer die Verwaltung werden ausschliesslich Effekte auf "
+        "die Bundesverwaltung dargestellt; Laender und Kommunen sind nicht "
+        "Gegenstand dieser Analyse.",
     ]
     for label, value in (
         ("Session", metadata.get("app_session_id")),
@@ -2807,6 +2811,24 @@ def _format_compliance_export_metadata_lines(metadata: dict[str, object]) -> lis
     ):
         if value:
             lines.append(f"<b>{label}:</b> {html.escape(str(value))}")
+    token_parts = [
+        f"in {metadata.get('input_tokens')}" if metadata.get("input_tokens") is not None else None,
+        f"out {metadata.get('output_tokens')}" if metadata.get("output_tokens") is not None else None,
+        (
+            f"thinking {metadata.get('hidden_thinking_tokens')}"
+            if metadata.get("hidden_thinking_tokens") is not None
+            else None
+        ),
+    ]
+    tokens = " / ".join(part for part in token_parts if part)
+    if tokens:
+        lines.append(f"<b>Token:</b> {html.escape(tokens)}")
+    cost = metadata.get("estimated_cost_usd")
+    if cost is not None:
+        try:
+            lines.append(f"<b>Geschaetzte API-Kosten:</b> ${float(cost):.4f}")
+        except (TypeError, ValueError):
+            lines.append(f"<b>Geschaetzte API-Kosten:</b> {html.escape(str(cost))}")
     return lines
 
 
@@ -2847,22 +2869,6 @@ def _render_research_report_pdf(
         fontSize=8,
         leading=10,
     )
-    sub_heading_style = ParagraphStyle(
-        "ResearchSubHeading",
-        parent=styles["Heading2"],
-        fontSize=12,
-        leading=15,
-    )
-    list_item_styles = [
-        ParagraphStyle(
-            f"ResearchListItem{depth}",
-            parent=styles["BodyText"],
-            leftIndent=16 + depth * 14,
-            bulletIndent=4 + depth * 14,
-            spaceAfter=2,
-        )
-        for depth in (0, 1)
-    ]
     available_width = A4[0] - doc.leftMargin - doc.rightMargin
     story = [Paragraph(html.escape(title), styles["Title"]), Spacer(1, 12)]
     if metadata or metadata_lines:
@@ -2893,10 +2899,8 @@ def _render_research_report_pdf(
         if not text:
             continue
         if text.startswith("#") and _is_research_pdf_heading(text):
-            level = len(text) - len(text.lstrip("#"))
             heading = text.lstrip("#").strip()
-            heading_style = sub_heading_style if level >= 3 else styles["Heading2"]
-            story.append(Paragraph(html.escape(heading), heading_style))
+            story.append(Paragraph(html.escape(heading), styles["Heading2"]))
         elif table_rows := _parse_pipe_table(text):
             column_count = len(table_rows[0])
             table_data = [
@@ -2925,23 +2929,6 @@ def _render_research_report_pdf(
                 )
             )
             story.append(table)
-        elif parsed_list := _parse_markdown_list(text):
-            lead, list_items = parsed_list
-            if lead:
-                story.append(
-                    Paragraph(
-                        _research_pdf_inline_markup(_strip_markdown_heading_prefix(lead)),
-                        styles["BodyText"],
-                    )
-                )
-            for depth, item in list_items:
-                story.append(
-                    Paragraph(
-                        _research_pdf_inline_markup(item),
-                        list_item_styles[depth],
-                        bulletText="•" if depth == 0 else "–",
-                    )
-                )
         else:
             story.append(
                 Paragraph(
@@ -2971,7 +2958,7 @@ def _render_research_report_pdf(
     return buffer.getvalue()
 
 
-@router.get("/deep-research-report")
+@router.get("/deep-research-report", dependencies=[Depends(require_session_owner)])
 async def download_deep_research_report(
     app_session_id: str = APP_SESSION_ID_QUERY_VALIDATION,
     format: Literal["pdf", "md"] = "pdf",
@@ -3002,7 +2989,7 @@ async def download_deep_research_report(
             media_type="text/markdown; charset=utf-8",
             headers={"Content-Disposition": f'attachment; filename="{base_filename}.md"'},
         )
-    pdf = _render_research_report_pdf(
+    pdf = await _render_research_report_pdf_async(
         report_md,
         f"Deep Research Report {app_session_id}",
         metadata={
@@ -3024,7 +3011,7 @@ async def download_deep_research_report(
     )
 
 
-@router.post("/undo", response_model=SessionUndoResponse)
+@router.post("/undo", response_model=SessionUndoResponse, dependencies=[Depends(require_session_owner)])
 async def undo_last_step(payload: SessionUndoRequest) -> SessionUndoResponse:
     session = db.get_session_by_app_id(payload.app_session_id)
     if not session:
@@ -3120,6 +3107,7 @@ async def _run_all_background(
     api_keys: ApiKeys,
     model: str,
     workflow_activity_id: str,
+    user: AuthUser,
 ) -> None:
     session_id = db.get_session_id_by_app_id(payload.app_session_id)
     try:
@@ -3144,6 +3132,7 @@ async def _run_all_background(
                     payload=payload,
                     api_keys=api_keys,
                     model=model,
+                    user=user,
                     event_hook=lambda event, data: _publish_run_event(run_id, event, data),
                 )
         except asyncio.CancelledError:
@@ -3210,6 +3199,7 @@ async def _run_single_step_background(
     api_keys: ApiKeys,
     model: str,
     workflow_activity_id: str,
+    user: AuthUser,
 ) -> None:
     session_id = db.get_session_id_by_app_id(payload.app_session_id)
     try:
@@ -3227,6 +3217,7 @@ async def _run_single_step_background(
                     payload=payload,
                     api_keys=api_keys,
                     model=model,
+                    user=user,
                     event_hook=lambda event, data: _publish_run_event(run_id, event, data),
                 )
         except asyncio.CancelledError:
@@ -3275,12 +3266,14 @@ async def _run_single_step_background(
 async def start_step_run(
     payload: SessionStepRunRequest,
     api_keys: ApiKeys = Depends(get_api_keys),
+    user: AuthUser = Depends(get_current_user),
 ) -> SessionRunAllStartResponse:
     if payload.step_key not in RUN_ALL_STEP_BY_KEY:
         raise HTTPException(status_code=400, detail=f"Unknown step: {payload.step_key}")
     _session_id, _created, model = ensure_session_or_400(
         payload.app_session_id,
         payload.model,
+        user,
     )
     workflow_activity_id: str | None = None
 
@@ -3333,6 +3326,7 @@ async def start_step_run(
             api_keys,
             model,
             workflow_activity_id,
+            user,
         )
     )
     async with _RUN_REGISTRY_LOCK:
@@ -3348,31 +3342,41 @@ async def start_step_run(
 
 
 @router.get("/step-runs/{run_id}", response_model=SessionRunStatusResponse)
-async def get_step_run_status(run_id: str) -> SessionRunStatusResponse:
-    return await get_run_all_status(run_id)
+async def get_step_run_status(
+    run_id: str,
+    user: AuthUser = Depends(get_current_user),
+) -> SessionRunStatusResponse:
+    return await get_run_all_status(run_id, user)
 
 
 @router.post("/step-runs/{run_id}/cancel", response_model=SessionRunCancelResponse)
 async def cancel_step_run(
     run_id: str,
     api_keys: ApiKeys = Depends(get_api_keys),
+    user: AuthUser = Depends(get_current_user),
 ) -> SessionRunCancelResponse:
-    return await cancel_run_all(run_id, api_keys)
+    return await cancel_run_all(run_id, api_keys, user)
 
 
 @router.get("/step-runs/{run_id}/events")
-async def stream_step_run_events(run_id: str, request: Request) -> StreamingResponse:
-    return await stream_run_all_events(run_id, request)
+async def stream_step_run_events(
+    run_id: str,
+    request: Request,
+    user: AuthUser = Depends(get_current_user),
+) -> StreamingResponse:
+    return await stream_run_all_events(run_id, request, user)
 
 
 @router.post("/run-all/start", response_model=SessionRunAllStartResponse)
 async def start_run_all_steps(
     payload: SessionRunAllRequest,
     api_keys: ApiKeys = Depends(get_api_keys),
+    user: AuthUser = Depends(get_current_user),
 ) -> SessionRunAllStartResponse:
     _session_id, _created, model = ensure_session_or_400(
         payload.app_session_id,
         payload.model,
+        user,
     )
     workflow_activity_id: str | None = None
 
@@ -3411,7 +3415,7 @@ async def start_run_all_steps(
         _ACTIVE_RUN_BY_SESSION[payload.app_session_id] = run_id
 
     task = asyncio.create_task(
-        _run_all_background(run_id, payload, api_keys, model, workflow_activity_id)
+        _run_all_background(run_id, payload, api_keys, model, workflow_activity_id, user)
     )
     async with _RUN_REGISTRY_LOCK:
         active = _RUNS_BY_ID.get(run_id)
@@ -3429,11 +3433,13 @@ async def start_run_all_steps(
 async def cancel_run_all(
     run_id: str,
     api_keys: ApiKeys = Depends(get_api_keys),
+    user: AuthUser = Depends(get_current_user),
 ) -> SessionRunCancelResponse:
     async with _RUN_REGISTRY_LOCK:
         record = _RUNS_BY_ID.get(run_id)
         if record is None:
             raise HTTPException(status_code=404, detail="Run not found")
+        require_owned_session(record.app_session_id, user)
         if record.status != "running":
             return SessionRunCancelResponse(
                 run_id=record.run_id,
@@ -3467,8 +3473,12 @@ async def cancel_run_all(
 
 
 @router.get("/run-all/{run_id}", response_model=SessionRunStatusResponse)
-async def get_run_all_status(run_id: str) -> SessionRunStatusResponse:
+async def get_run_all_status(
+    run_id: str,
+    user: AuthUser = Depends(get_current_user),
+) -> SessionRunStatusResponse:
     record = await _get_run_record(run_id)
+    require_owned_session(record.app_session_id, user)
     return SessionRunStatusResponse(
         run_id=record.run_id,
         app_session_id=record.app_session_id,
@@ -3484,8 +3494,13 @@ async def get_run_all_status(run_id: str) -> SessionRunStatusResponse:
 
 
 @router.get("/run-all/{run_id}/events")
-async def stream_run_all_events(run_id: str, request: Request) -> StreamingResponse:
-    await _get_run_record(run_id)
+async def stream_run_all_events(
+    run_id: str,
+    request: Request,
+    user: AuthUser = Depends(get_current_user),
+) -> StreamingResponse:
+    record = await _get_run_record(run_id)
+    require_owned_session(record.app_session_id, user)
 
     async def _event_generator() -> AsyncGenerator[str, None]:
         queue: asyncio.Queue[tuple[str, dict]] = asyncio.Queue(maxsize=128)
@@ -3537,7 +3552,7 @@ async def stream_run_all_events(run_id: str, request: Request) -> StreamingRespo
     )
 
 
-@router.get("/llm-monitor", response_model=SessionLlmMonitorSnapshotResponse)
+@router.get("/llm-monitor", response_model=SessionLlmMonitorSnapshotResponse, dependencies=[Depends(require_session_owner)])
 async def get_llm_monitor_snapshot(
     app_session_id: str = APP_SESSION_ID_QUERY_VALIDATION,
     limit: int = Query(default=80, ge=1, le=500),
@@ -3563,7 +3578,7 @@ async def get_llm_monitor_snapshot(
     )
 
 
-@router.get("/llm-monitor/events")
+@router.get("/llm-monitor/events", dependencies=[Depends(require_session_owner)])
 async def stream_llm_monitor_events(
     request: Request,
     app_session_id: str = APP_SESSION_ID_QUERY_VALIDATION,
@@ -3618,6 +3633,7 @@ async def stream_llm_monitor_events(
 @router.get(
     "/llm-monitor/stream/{attempt_id}",
     response_model=SessionLlmMonitorStreamAttemptResponse,
+    dependencies=[Depends(require_session_owner)],
 )
 async def get_llm_monitor_stream_attempt(
     attempt_id: str,

--- a/backend/routers/sessions.py
+++ b/backend/routers/sessions.py
@@ -2701,28 +2701,34 @@ def _should_render_research_pdf_bold(escaped_text: str) -> bool:
     return True
 
 
+_BOLD_MARKUP = re.compile(r"\*\*(?=\S)(.+?)(?<=\S)\*\*", re.DOTALL)
+_ITALIC_MARKUP = re.compile(r"(?<!\*)\*(?=\S)([^*]+?)(?<=\S)\*(?!\*)", re.DOTALL)
+_ESCAPED_LINE_BREAK = re.compile(r"&lt;br\s*/?&gt;", re.IGNORECASE)
+
+
 def _research_pdf_inline_markup(text: str) -> str:
     escaped = html.escape(text).replace("\n", "<br/>")
-    parts = escaped.split("**")
-    if len(parts) == 1:
-        return _linkify_research_pdf_urls(escaped)
-    rendered: list[str] = []
-    for index, part in enumerate(parts):
-        linked_part = _linkify_research_pdf_urls(part)
-        if index % 2 == 1 and _should_render_research_pdf_bold(part):
-            rendered.append(f"<b>{linked_part}</b>")
-        else:
-            rendered.append(linked_part)
-    return "".join(rendered)
+    escaped = _ESCAPED_LINE_BREAK.sub("<br/>", escaped)
+
+    def bold(match: re.Match[str]) -> str:
+        inner = match.group(1)
+        if not _should_render_research_pdf_bold(inner):
+            return inner
+        return f"<b>{inner}</b>"
+
+    marked = _BOLD_MARKUP.sub(bold, escaped)
+    marked = _ITALIC_MARKUP.sub(lambda match: f"<i>{match.group(1)}</i>", marked)
+    return _linkify_research_pdf_urls(marked)
 
 
 def _is_research_pdf_heading(text: str) -> bool:
+    level = len(text) - len(text.lstrip("#"))
     heading = text.lstrip("#").strip()
     if not heading:
         return False
     if "\n" in heading:
         return False
-    if re.match(r"^\d+\.\s+", heading):
+    if level >= 2 and re.match(r"^\d+\.\s+", heading):
         return False
     if len(heading) > 85:
         return False
@@ -2733,6 +2739,38 @@ def _is_research_pdf_heading(text: str) -> bool:
 
 def _strip_markdown_heading_prefix(text: str) -> str:
     return re.sub(r"^#{1,6}\s*", "", text, count=1).strip()
+
+
+_LIST_ITEM = re.compile(r"^(\s*)[-*]\s+(\S.*)$")
+
+
+def _parse_markdown_list(text: str) -> tuple[str, list[tuple[int, str]]] | None:
+    """Trennt einen Block in Einleitungstext und (Einrueckungstiefe, Text)-Items.
+
+    Gibt ``None`` zurueck, wenn der Block keine Aufzaehlung enthaelt. Die
+    Aufzaehlung darf direkt an einen Absatz anschliessen, weil das Modell die
+    Leerzeile davor nicht zuverlaessig setzt. Zeilen nach einem Item gelten als
+    dessen Fortsetzung, damit umgebrochene Eintraege nicht zu eigenen Bullets
+    werden.
+    """
+    lead_lines: list[str] = []
+    items: list[tuple[int, str]] = []
+    for line in text.split("\n"):
+        if not line.strip():
+            continue
+        match = _LIST_ITEM.match(line)
+        if match:
+            depth = 1 if len(match.group(1)) >= 2 else 0
+            items.append((depth, match.group(2).strip()))
+            continue
+        if not items:
+            lead_lines.append(line.strip())
+            continue
+        depth, current = items[-1]
+        items[-1] = (depth, f"{current} {line.strip()}")
+    if not items:
+        return None
+    return "\n".join(lead_lines), items
 
 
 def _linkify_research_pdf_urls(escaped_text: str) -> str:
@@ -2795,9 +2833,8 @@ def _format_compliance_export_metadata_lines(metadata: dict[str, object]) -> lis
         "<b>Analyseumfang:</b> Die Darstellung umfasst ausschliesslich jaehrlichen "
         "Erfuellungsaufwand. Einmaliger Erfuellungsaufwand ist nicht Gegenstand "
         "dieser Analyse.",
-        "<b>Verwaltung:</b> Fuer die Verwaltung werden ausschliesslich Effekte auf "
-        "die Bundesverwaltung dargestellt; Laender und Kommunen sind nicht "
-        "Gegenstand dieser Analyse.",
+        "<b>Verwaltung:</b> Der Erfuellungsaufwand der Verwaltung wird getrennt nach "
+        "Bundesebene und Landesebene (einschliesslich Kommunen) ausgewiesen.",
     ]
     for label, value in (
         ("Session", metadata.get("app_session_id")),
@@ -2869,6 +2906,22 @@ def _render_research_report_pdf(
         fontSize=8,
         leading=10,
     )
+    sub_heading_style = ParagraphStyle(
+        "ResearchSubHeading",
+        parent=styles["Heading2"],
+        fontSize=12,
+        leading=15,
+    )
+    list_item_styles = [
+        ParagraphStyle(
+            f"ResearchListItem{depth}",
+            parent=styles["BodyText"],
+            leftIndent=16 + depth * 14,
+            bulletIndent=4 + depth * 14,
+            spaceAfter=2,
+        )
+        for depth in (0, 1)
+    ]
     available_width = A4[0] - doc.leftMargin - doc.rightMargin
     story = [Paragraph(html.escape(title), styles["Title"]), Spacer(1, 12)]
     if metadata or metadata_lines:
@@ -2899,8 +2952,10 @@ def _render_research_report_pdf(
         if not text:
             continue
         if text.startswith("#") and _is_research_pdf_heading(text):
+            level = len(text) - len(text.lstrip("#"))
             heading = text.lstrip("#").strip()
-            story.append(Paragraph(html.escape(heading), styles["Heading2"]))
+            heading_style = sub_heading_style if level >= 3 else styles["Heading2"]
+            story.append(Paragraph(html.escape(heading), heading_style))
         elif table_rows := _parse_pipe_table(text):
             column_count = len(table_rows[0])
             table_data = [
@@ -2929,6 +2984,23 @@ def _render_research_report_pdf(
                 )
             )
             story.append(table)
+        elif parsed_list := _parse_markdown_list(text):
+            lead, list_items = parsed_list
+            if lead:
+                story.append(
+                    Paragraph(
+                        _research_pdf_inline_markup(_strip_markdown_heading_prefix(lead)),
+                        styles["BodyText"],
+                    )
+                )
+            for depth, item in list_items:
+                story.append(
+                    Paragraph(
+                        _research_pdf_inline_markup(item),
+                        list_item_styles[depth],
+                        bulletText="•" if depth == 0 else "–",
+                    )
+                )
         else:
             story.append(
                 Paragraph(

--- a/backend/routers/sessions.py
+++ b/backend/routers/sessions.py
@@ -1127,6 +1127,100 @@ def _promote_pending_retry(answer_ids: list[int]) -> None:
         )
 
 
+class _EffortPairParseError(Exception):
+    def __init__(
+        self,
+        *,
+        norm_addressee: str,
+        prompt_id: str,
+        primary_exc: Exception,
+        handled_answer_ids: set[int],
+    ) -> None:
+        self.norm_addressee = norm_addressee
+        self.prompt_id = prompt_id
+        self.primary_exc = primary_exc
+        self.handled_answer_ids = handled_answer_ids
+        super().__init__(str(primary_exc))
+
+
+def _parse_effort_pair_for_addressee(
+    *,
+    session_id: int,
+    norm_addressee: str,
+    context: dict,
+    use_deep_research: bool,
+    query_results: dict[str, LlmResult],
+    pending_answer_ids: dict[str, int],
+) -> tuple[list[dict], list[dict]]:
+    effort_key = _result_key(PromptId.EFFORT_CALCULATION, norm_addressee)
+    cases_key = _result_key(PromptId.CASES_CALCULATION, norm_addressee)
+    effort_answer_id = pending_answer_ids[effort_key]
+    handled_answer_ids: set[int] = set()
+    parsed_cases: list[dict] = []
+    parsed_effort: list[dict] | None = None
+    cases_exc: Exception | None = None
+    effort_exc: Exception | None = None
+
+    if not use_deep_research:
+        cases_answer_id = pending_answer_ids[cases_key]
+        try:
+            parsed_cases = effort_router.parse_cases_calculation_output(
+                session_id=session_id,
+                norm_addressee=norm_addressee,
+                context=context,
+                cases_text=query_results[cases_key].text,
+                cases_answer_id=cases_answer_id,
+            )
+        except Exception as exc:
+            cases_exc = exc
+        else:
+            handled_answer_ids.add(cases_answer_id)
+
+    try:
+        parsed_effort = effort_router.parse_effort_calculation_output(
+            session_id=session_id,
+            norm_addressee=norm_addressee,
+            context=context,
+            effort_text=query_results[effort_key].text,
+            effort_answer_id=effort_answer_id,
+        )
+    except Exception as exc:
+        effort_exc = exc
+    else:
+        handled_answer_ids.add(effort_answer_id)
+
+    if cases_exc is None and effort_exc is None:
+        assert parsed_effort is not None
+        return parsed_cases, parsed_effort
+
+    if not use_deep_research:
+        cases_answer_id = pending_answer_ids[cases_key]
+        if cases_exc is not None:
+            mark_llm_answer_apply_failed(answer_id=cases_answer_id, exc=cases_exc)
+            handled_answer_ids.add(cases_answer_id)
+        else:
+            _promote_pending_retry([cases_answer_id])
+    if effort_exc is not None:
+        mark_llm_answer_apply_failed(answer_id=effort_answer_id, exc=effort_exc)
+        handled_answer_ids.add(effort_answer_id)
+    else:
+        _promote_pending_retry([effort_answer_id])
+
+    primary_prompt = (
+        PromptId.CASES_CALCULATION
+        if cases_exc is not None
+        else PromptId.EFFORT_CALCULATION
+    )
+    primary_exc = cases_exc or effort_exc
+    assert primary_exc is not None
+    raise _EffortPairParseError(
+        norm_addressee=norm_addressee,
+        prompt_id=primary_prompt,
+        primary_exc=primary_exc,
+        handled_answer_ids=handled_answer_ids,
+    )
+
+
 async def _run_atomic_single_prompt_step(
     *,
     step: _AtomicSinglePromptStep,
@@ -1473,49 +1567,37 @@ async def _run_atomic_effort_step(
         for norm_addressee, context in contexts.items():
             if context["status"] != "ready":
                 continue
-            effort_key = _result_key(PromptId.EFFORT_CALCULATION, norm_addressee)
-            cases_key = _result_key(PromptId.CASES_CALCULATION, norm_addressee)
-            parsed_by_addressee[norm_addressee] = effort_router.parse_effort_calculation_outputs(
+            parsed_by_addressee[norm_addressee] = _parse_effort_pair_for_addressee(
                 session_id=session_id,
                 norm_addressee=norm_addressee,
                 context=context,
-                cases_text=(
-                    None
-                    if use_deep_research
-                    else query_results[cases_key].text
-                ),
-                effort_text=query_results[effort_key].text,
-                cases_answer_id=(
-                    None
-                    if use_deep_research
-                    else pending_answer_ids[cases_key]
-                ),
-                effort_answer_id=pending_answer_ids[effort_key],
+                use_deep_research=use_deep_research,
+                query_results=query_results,
+                pending_answer_ids=pending_answer_ids,
             )
     except Exception as exc:
-        failed_addressee = norm_addressee
-        failed_ids = [
-            pending_answer_ids[key]
-            for key in (
-                _result_key(PromptId.CASES_CALCULATION, failed_addressee),
-                _result_key(PromptId.EFFORT_CALCULATION, failed_addressee),
-            )
-            if key in pending_answer_ids
-        ]
-        for answer_id in failed_ids:
-            mark_llm_answer_apply_failed(answer_id=answer_id, exc=exc)
+        if isinstance(exc, _EffortPairParseError):
+            failed_addressee = exc.norm_addressee
+            prompt_label = exc.prompt_id
+            detail_exc = exc.primary_exc
+            handled_answer_ids = exc.handled_answer_ids
+        else:
+            failed_addressee = norm_addressee
+            prompt_label = PromptId.EFFORT_CALCULATION
+            detail_exc = exc
+            handled_answer_ids = set()
         sibling_ids = [
             answer_id
             for answer_id in pending_answer_ids.values()
-            if answer_id not in set(failed_ids)
+            if answer_id not in handled_answer_ids
         ]
         _promote_pending_retry(sibling_ids)
         detail = _format_atomic_step_error(
             step_label=RUN_ALL_STEP_BY_KEY["effort"][0],
             step_key="effort",
             norm_addressee=failed_addressee,
-            prompt_label=PromptId.EFFORT_CALCULATION,
-            detail=_step_error_message(exc),
+            prompt_label=prompt_label,
+            detail=_step_error_message(detail_exc),
         )
         await _emit_event(
             event_hook,
@@ -1523,12 +1605,12 @@ async def _run_atomic_effort_step(
             {
                 "key": "effort",
                 "norm_addressee": failed_addressee,
-                "prompt_id": PromptId.EFFORT_CALCULATION,
+                "prompt_id": prompt_label,
                 "message": detail,
             },
         )
         raise HTTPException(
-            status_code=getattr(exc, "status_code", 422),
+            status_code=getattr(detail_exc, "status_code", 422),
             detail=detail,
         ) from exc
 
@@ -2848,24 +2930,6 @@ def _format_compliance_export_metadata_lines(metadata: dict[str, object]) -> lis
     ):
         if value:
             lines.append(f"<b>{label}:</b> {html.escape(str(value))}")
-    token_parts = [
-        f"in {metadata.get('input_tokens')}" if metadata.get("input_tokens") is not None else None,
-        f"out {metadata.get('output_tokens')}" if metadata.get("output_tokens") is not None else None,
-        (
-            f"thinking {metadata.get('hidden_thinking_tokens')}"
-            if metadata.get("hidden_thinking_tokens") is not None
-            else None
-        ),
-    ]
-    tokens = " / ".join(part for part in token_parts if part)
-    if tokens:
-        lines.append(f"<b>Token:</b> {html.escape(tokens)}")
-    cost = metadata.get("estimated_cost_usd")
-    if cost is not None:
-        try:
-            lines.append(f"<b>Geschaetzte API-Kosten:</b> ${float(cost):.4f}")
-        except (TypeError, ValueError):
-            lines.append(f"<b>Geschaetzte API-Kosten:</b> {html.escape(str(cost))}")
     return lines
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,52 @@
+# Production deployment stack for the Compliance-Cost Computer (CCC).
+#
+# Topology: only Caddy is exposed to the public (ports 80/443). It terminates
+# TLS and reverse-proxies same-origin to the backend (/api/*) and frontend.
+#
+# Usage:
+#   cp .env.example .env   # then fill in DOMAIN, secrets, API keys
+#   docker compose up -d --build
+
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
+    env_file: .env
+    environment:
+      # Persisted on the ccc-data volume; override anything in .env.
+      DB_PATH: /data/ccc.db
+      REGULATIONS_PATH: /data/regulations
+    volumes:
+      - ccc-data:/data
+    restart: unless-stopped
+    # Single instance by design (in-process workflow state).
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+      args:
+        # Same-origin API path; Caddy strips the /api prefix.
+        NEXT_PUBLIC_API_BASE_URL: /api
+    restart: unless-stopped
+
+  caddy:
+    image: caddy:2
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    env_file: .env
+    depends_on:
+      - frontend
+      - backend
+    restart: unless-stopped
+
+volumes:
+  ccc-data:
+  caddy_data:
+  caddy_config:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,12 @@
+# Build-context exclusions for the frontend image (context = ./frontend).
+
+node_modules
+.next
+out
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+.turbo
+coverage
+.DS_Store

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,49 @@
+# syntax=docker/dockerfile:1
+#
+# Frontend image for the Compliance-Cost Computer (CCC).
+# Build context = ./frontend
+#   docker build -f frontend/Dockerfile -t ccc-frontend ./frontend
+#
+# Relies on Next.js standalone output (`output: "standalone"` in next.config.ts).
+
+# --- Stage 1: build -----------------------------------------------------------
+FROM node:20-slim AS builder
+
+WORKDIR /app
+
+# NEXT_PUBLIC_* values are inlined at build time, so they must be set BEFORE
+# `npm run build`. Defaults to same-origin "/api" (Caddy strips the prefix).
+ARG NEXT_PUBLIC_API_BASE_URL=/api
+ENV NEXT_PUBLIC_API_BASE_URL=$NEXT_PUBLIC_API_BASE_URL
+
+# Install dependencies first for better layer caching.
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# Copy the rest of the source and build.
+COPY . .
+RUN npm run build
+
+# --- Stage 2: runtime ---------------------------------------------------------
+FROM node:20-slim AS runner
+
+WORKDIR /app
+
+ENV NODE_ENV=production \
+    PORT=3000 \
+    HOSTNAME=0.0.0.0 \
+    NEXT_TELEMETRY_DISABLED=1
+
+# Copy only what the standalone server needs.
+# The standalone output already contains a minimal node_modules and server.js.
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/.next/static ./.next/static
+
+# Run as the built-in non-root "node" user and give it ownership.
+RUN chown -R node:node /app
+USER node
+
+EXPOSE 3000
+
+CMD ["node", "server.js"]

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,6 +1,8 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  // Emit a self-contained server bundle (.next/standalone) for a slim Docker image.
+  output: "standalone",
   eslint: {
     ignoreDuringBuilds: true,
   },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,8 @@
       "name": "ccc-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@fontsource/jetbrains-mono": "^5.2.8",
+        "@fontsource/space-grotesk": "^5.2.10",
         "@xyflow/react": "^12.4.4",
         "next": "15.5.12",
         "react": "^19.0.0",
@@ -82,7 +84,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -766,6 +767,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@fontsource/jetbrains-mono": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/jetbrains-mono/-/jetbrains-mono-5.2.8.tgz",
+      "integrity": "sha512-6w8/SG4kqvIMu7xd7wt6x3idn1Qux3p9N62s6G3rfldOUYHpWcc2FKrqf+Vo44jRvqWj2oAtTHrZXEP23oSKwQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/space-grotesk": {
+      "version": "5.2.10",
+      "resolved": "https://registry.npmjs.org/@fontsource/space-grotesk/-/space-grotesk-5.2.10.tgz",
+      "integrity": "sha512-XNXEbT74OIITPqw2H6HXwPDp85fy43uxfBwFR5PU+9sLnjuLj12KlhVM9nZVN6q6dlKjkuN8JisW/OBxwxgUew==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@humanfs/core": {
@@ -2379,6 +2398,7 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -2478,7 +2498,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2706,7 +2727,6 @@
       "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2717,7 +2737,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2798,7 +2817,6 @@
       "integrity": "sha512-npiaib8XzbjtzS2N4HlqPvlpxpmZ14FjSJrteZpPxGUaYPlvhzlzUZ4mZyABo0EFrOWnvyd0Xxroq//hKhtAWg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.0",
         "@typescript-eslint/types": "8.53.0",
@@ -3325,7 +3343,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3877,7 +3894,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4357,7 +4373,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4591,6 +4606,7 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4643,7 +4659,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/domexception": {
       "version": "4.0.0",
@@ -4966,7 +4983,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5140,7 +5156,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -8175,6 +8190,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -8956,6 +8972,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -8971,6 +8988,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -8983,7 +9001,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prompts": {
       "version": "2.4.2",
@@ -9084,7 +9103,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9094,7 +9112,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10026,7 +10043,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10235,7 +10251,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,10 +10,12 @@
     "test": "jest"
   },
   "dependencies": {
+    "@fontsource/jetbrains-mono": "^5.2.8",
+    "@fontsource/space-grotesk": "^5.2.10",
+    "@xyflow/react": "^12.4.4",
     "next": "15.5.12",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "@xyflow/react": "^12.4.4"
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
@@ -21,10 +23,10 @@
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
+    "@types/jest": "^29.5.14",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@types/jest": "^29.5.14",
     "eslint": "^9",
     "eslint-config-next": "15.5.12",
     "jest": "^29.7.0",

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -2,6 +2,8 @@
 @import "@xyflow/react/dist/style.css";
 
 :root {
+  --font-space: "Space Grotesk", system-ui, sans-serif;
+  --font-jet: "JetBrains Mono", ui-monospace, monospace;
   --bg-base: #f6f1ea;
   --bg-veil: #fbfaf7;
   --bg-ink: #0b1220;

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,20 +1,19 @@
 import type { Metadata } from "next";
-import { JetBrains_Mono, Space_Grotesk } from "next/font/google";
 
+import "@fontsource/space-grotesk/300.css";
+import "@fontsource/space-grotesk/400.css";
+import "@fontsource/space-grotesk/500.css";
+import "@fontsource/space-grotesk/600.css";
+import "@fontsource/space-grotesk/700.css";
+import "@fontsource/jetbrains-mono/400.css";
+import "@fontsource/jetbrains-mono/500.css";
+import "@fontsource/jetbrains-mono/700.css";
 import "./globals.css";
+import AuthGate from "@/components/AuthGate";
 import Header from "@/components/Header";
 import TabBar from "@/components/TabBar";
 import { AppProvider } from "@/contexts/AppContext";
-
-const spaceGrotesk = Space_Grotesk({
-  subsets: ["latin"],
-  variable: "--font-space",
-});
-
-const jetBrainsMono = JetBrains_Mono({
-  subsets: ["latin"],
-  variable: "--font-jet",
-});
+import { AuthProvider } from "@/contexts/AuthContext";
 
 export const metadata: Metadata = {
   title: "CCC App",
@@ -30,19 +29,23 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="de" className={`${spaceGrotesk.variable} ${jetBrainsMono.variable}`}>
+    <html lang="de">
       <body>
-        <AppProvider>
-          <div className="min-h-screen flex flex-col">
-            <div className="sticky top-0 z-40">
-              <Header />
-              <TabBar />
-            </div>
-            <main className="flex-1">
-              {children}
-            </main>
-          </div>
-        </AppProvider>
+        <AuthProvider>
+          <AuthGate>
+            <AppProvider>
+              <div className="min-h-screen flex flex-col">
+                <div className="sticky top-0 z-40">
+                  <Header />
+                  <TabBar />
+                </div>
+                <main className="flex-1">
+                  {children}
+                </main>
+              </div>
+            </AppProvider>
+          </AuthGate>
+        </AuthProvider>
       </body>
     </html>
   );

--- a/frontend/src/components/AccountMenu.tsx
+++ b/frontend/src/components/AccountMenu.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+import { useAnchoredPopoverPosition } from "@/lib/useAnchoredPopoverPosition";
+import { useMounted } from "@/lib/useMounted";
+import type { AuthUser } from "@/types";
+
+type AccountMenuProps = {
+  user: AuthUser;
+  logout: () => Promise<void>;
+};
+
+export default function AccountMenu({ user, logout }: AccountMenuProps) {
+  const [open, setOpen] = useState(false);
+  const [isLoggingOut, setIsLoggingOut] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const popoverRef = useRef<HTMLDivElement | null>(null);
+  const isMounted = useMounted();
+  const { position } = useAnchoredPopoverPosition({
+    open,
+    triggerRef,
+    width: 300,
+    align: "right",
+    offset: 12,
+    padding: 12,
+  });
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target as Node;
+      if (
+        popoverRef.current?.contains(target) ||
+        triggerRef.current?.contains(target)
+      ) {
+        return;
+      }
+      setOpen(false);
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open]);
+
+  const handleLogout = async () => {
+    if (isLoggingOut) {
+      return;
+    }
+    setIsLoggingOut(true);
+    try {
+      await logout();
+      setOpen(false);
+    } finally {
+      setIsLoggingOut(false);
+    }
+  };
+
+  const popover = (
+    <div
+      ref={popoverRef}
+      data-testid="account-menu-popover"
+      className="fixed z-[70] w-[300px] rounded-2xl border border-slate-200 bg-white p-4 text-slate-800 shadow-2xl"
+      style={{ top: position.top, left: position.left }}
+    >
+      <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+        Angemeldet als
+      </div>
+      <div className="mt-2 truncate text-sm font-semibold text-slate-950" title={user.email}>
+        {user.email}
+      </div>
+      <div className="mt-2 inline-flex rounded-full bg-slate-100 px-2 py-0.5 text-[11px] font-semibold text-slate-600">
+        {user.is_admin ? "Admin" : "Benutzer"}
+      </div>
+      <button
+        type="button"
+        onClick={handleLogout}
+        disabled={isLoggingOut}
+        className="mt-4 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm font-semibold text-slate-800 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        {isLoggingOut ? "Abmelden..." : "Abmelden"}
+      </button>
+    </div>
+  );
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={() => setOpen((prev) => !prev)}
+        className="flex h-8 w-8 items-center justify-center rounded-xl border border-white/30 bg-white/10 text-white shadow-sm transition hover:bg-white/20"
+        aria-label="Benutzerkonto öffnen"
+        title="Benutzerkonto"
+        aria-expanded={open}
+      >
+        <svg
+          aria-hidden="true"
+          viewBox="0 0 24 24"
+          className="h-[18px] w-[18px]"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2.4"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M20 21a8 8 0 0 0-16 0" />
+          <circle cx="12" cy="7" r="4" />
+        </svg>
+      </button>
+      {open && isMounted ? createPortal(popover, document.body) : null}
+    </>
+  );
+}

--- a/frontend/src/components/AdminUsersPanel.tsx
+++ b/frontend/src/components/AdminUsersPanel.tsx
@@ -1,0 +1,246 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+
+import { apiClient, type ApiClientError } from "@/lib/api";
+import { useMounted } from "@/lib/useMounted";
+import type { AdminUser } from "@/types";
+
+type AdminUsersPanelProps = {
+  open: boolean;
+  onClose: () => void;
+};
+
+function getErrorMessage(error: unknown, fallback: string): string {
+  const message = (error as ApiClientError)?.message;
+  return typeof message === "string" && message.trim() ? message : fallback;
+}
+
+export default function AdminUsersPanel({ open, onClose }: AdminUsersPanelProps) {
+  const isMounted = useMounted();
+  const [users, setUsers] = useState<AdminUser[]>([]);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [actionStatus, setActionStatus] = useState<string | null>(null);
+  const [newEmail, setNewEmail] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [newIsAdmin, setNewIsAdmin] = useState(false);
+  const [isCreating, setIsCreating] = useState(false);
+  const [pendingUserId, setPendingUserId] = useState<number | null>(null);
+
+  const loadUsers = useCallback(async () => {
+    setLoadError(null);
+    try {
+      const list = await apiClient.listUsers();
+      setUsers(list);
+    } catch (error) {
+      setUsers([]);
+      setLoadError(getErrorMessage(error, "Benutzer konnten nicht geladen werden."));
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    setActionError(null);
+    setActionStatus(null);
+    void loadUsers();
+  }, [open, loadUsers]);
+
+  const handleCreate = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (isCreating) {
+      return;
+    }
+    setActionError(null);
+    setActionStatus(null);
+    setIsCreating(true);
+    try {
+      await apiClient.createUser(newEmail.trim(), newPassword, newIsAdmin);
+      setNewEmail("");
+      setNewPassword("");
+      setNewIsAdmin(false);
+      setActionStatus("Benutzer angelegt.");
+      await loadUsers();
+    } catch (error) {
+      setActionError(getErrorMessage(error, "Benutzer konnte nicht angelegt werden."));
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  const handleToggleActive = async (user: AdminUser) => {
+    if (pendingUserId !== null) {
+      return;
+    }
+    setActionError(null);
+    setActionStatus(null);
+    setPendingUserId(user.user_id);
+    try {
+      await apiClient.updateUser(user.user_id, { is_active: !user.is_active });
+      setActionStatus(
+        user.is_active ? "Benutzer deaktiviert." : "Benutzer reaktiviert."
+      );
+      await loadUsers();
+    } catch (error) {
+      setActionError(
+        getErrorMessage(error, "Benutzer konnte nicht aktualisiert werden.")
+      );
+    } finally {
+      setPendingUserId(null);
+    }
+  };
+
+  if (!isMounted || !open) {
+    return null;
+  }
+
+  const body = (
+    <div className="pointer-events-none fixed inset-0 z-[85]">
+      <div className="absolute inset-0 bg-slate-900/25" onClick={onClose} />
+      <div className="flex h-full items-stretch justify-end">
+        <section className="pointer-events-auto relative h-full w-full max-w-[640px] border-l border-slate-300 bg-white shadow-2xl">
+          <header className="border-b border-slate-200 bg-slate-50 px-4 py-3">
+            <div className="flex items-center justify-between">
+              <div className="text-sm font-semibold text-slate-900">
+                Benutzerverwaltung
+              </div>
+              <button
+                onClick={onClose}
+                className="rounded-full border border-slate-300 px-3 py-1 text-xs font-semibold text-slate-700"
+              >
+                Schließen
+              </button>
+            </div>
+          </header>
+          <div className="h-[calc(100%-52px)] overflow-auto px-4 py-4">
+            <form
+              onSubmit={handleCreate}
+              className="rounded-2xl border border-slate-200 bg-slate-50 p-4"
+            >
+              <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                Neuen Benutzer anlegen
+              </div>
+              <div className="mt-3 grid gap-3 sm:grid-cols-2">
+                <label className="block">
+                  <span className="text-[11px] font-semibold text-slate-500">
+                    E-Mail
+                  </span>
+                  <input
+                    type="email"
+                    required
+                    value={newEmail}
+                    onChange={(event) => setNewEmail(event.target.value)}
+                    className="mt-1 w-full rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none"
+                  />
+                </label>
+                <label className="block">
+                  <span className="text-[11px] font-semibold text-slate-500">
+                    Passwort (min. 8 Zeichen)
+                  </span>
+                  <input
+                    type="password"
+                    required
+                    value={newPassword}
+                    onChange={(event) => setNewPassword(event.target.value)}
+                    className="mt-1 w-full rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none"
+                  />
+                </label>
+              </div>
+              <label className="mt-3 flex items-center gap-2 text-xs font-semibold text-slate-700">
+                <input
+                  type="checkbox"
+                  checked={newIsAdmin}
+                  onChange={(event) => setNewIsAdmin(event.target.checked)}
+                  className="h-4 w-4"
+                />
+                Administrator
+              </label>
+              <button
+                type="submit"
+                disabled={isCreating}
+                className="mt-3 rounded-xl bg-slate-900 px-4 py-2 text-xs font-semibold text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400"
+              >
+                {isCreating ? "Wird angelegt..." : "Benutzer anlegen"}
+              </button>
+            </form>
+
+            {actionError && (
+              <div className="mt-3 rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-xs font-semibold text-rose-700">
+                {actionError}
+              </div>
+            )}
+            {actionStatus && (
+              <div className="mt-3 rounded-xl border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs font-semibold text-emerald-700">
+                {actionStatus}
+              </div>
+            )}
+
+            <div className="mt-5">
+              <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                Benutzer
+              </div>
+              {loadError ? (
+                <div className="mt-3 rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-xs font-semibold text-rose-700">
+                  {loadError}
+                </div>
+              ) : (
+                <ul className="mt-3 space-y-2">
+                  {users.map((user) => (
+                    <li
+                      key={user.user_id}
+                      className="flex items-center justify-between gap-3 rounded-xl border border-slate-200 bg-white px-3 py-2"
+                    >
+                      <div className="min-w-0">
+                        <div className="truncate text-sm font-semibold text-slate-900">
+                          {user.email}
+                        </div>
+                        <div className="mt-0.5 flex flex-wrap gap-1 text-[10px] font-semibold uppercase tracking-wide">
+                          {user.is_admin && (
+                            <span className="rounded-full bg-slate-900 px-2 py-0.5 text-white">
+                              Admin
+                            </span>
+                          )}
+                          <span
+                            className={`rounded-full px-2 py-0.5 ${
+                              user.is_active
+                                ? "bg-emerald-100 text-emerald-700"
+                                : "bg-slate-200 text-slate-600"
+                            }`}
+                          >
+                            {user.is_active ? "Aktiv" : "Inaktiv"}
+                          </span>
+                        </div>
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => handleToggleActive(user)}
+                        disabled={pendingUserId === user.user_id}
+                        className={`shrink-0 rounded-full border px-3 py-1.5 text-xs font-semibold transition disabled:cursor-not-allowed disabled:opacity-50 ${
+                          user.is_active
+                            ? "border-rose-200 text-rose-700 hover:bg-rose-50"
+                            : "border-emerald-200 text-emerald-700 hover:bg-emerald-50"
+                        }`}
+                      >
+                        {user.is_active ? "Deaktivieren" : "Reaktivieren"}
+                      </button>
+                    </li>
+                  ))}
+                  {users.length === 0 && (
+                    <li className="rounded-xl border border-slate-200 bg-white px-3 py-2 text-xs text-slate-500">
+                      Keine Benutzer vorhanden.
+                    </li>
+                  )}
+                </ul>
+              )}
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+
+  return createPortal(body, document.body);
+}

--- a/frontend/src/components/AdminUsersPanel.tsx
+++ b/frontend/src/components/AdminUsersPanel.tsx
@@ -12,6 +12,64 @@ type AdminUsersPanelProps = {
   onClose: () => void;
 };
 
+function PasswordVisibilityIcon({ visible }: { visible: boolean }) {
+  if (visible) {
+    return (
+      <svg
+        aria-hidden="true"
+        viewBox="0 0 24 24"
+        className="h-4 w-4"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M2 2l20 20" />
+        <path d="M10.6 10.6a2 2 0 0 0 2.8 2.8" />
+        <path d="M7.1 7.1C4.9 8.3 3.2 10 2 12c2.1 3.5 5.5 6 10 6 1.6 0 3-.3 4.2-.9" />
+        <path d="M14.1 5.3A10.5 10.5 0 0 0 12 5C7.5 5 4.1 7.5 2 12" />
+        <path d="M18.8 8.8A13.3 13.3 0 0 1 22 12c-.7 1.2-1.5 2.3-2.5 3.2" />
+      </svg>
+    );
+  }
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 24 24"
+      className="h-4 w-4"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7S2 12 2 12Z" />
+      <circle cx="12" cy="12" r="3" />
+    </svg>
+  );
+}
+
+function PasswordVisibilityButton({
+  visible,
+  onClick,
+}: {
+  visible: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={visible ? "Passwort verbergen" : "Passwort anzeigen"}
+      title={visible ? "Passwort verbergen" : "Passwort anzeigen"}
+      className="flex h-9 w-10 shrink-0 items-center justify-center rounded-r-xl border-l border-slate-200 text-slate-500 transition hover:bg-slate-50 hover:text-slate-800"
+    >
+      <PasswordVisibilityIcon visible={visible} />
+    </button>
+  );
+}
+
 function getErrorMessage(error: unknown, fallback: string): string {
   const message = (error as ApiClientError)?.message;
   return typeof message === "string" && message.trim() ? message : fallback;
@@ -25,9 +83,13 @@ export default function AdminUsersPanel({ open, onClose }: AdminUsersPanelProps)
   const [actionStatus, setActionStatus] = useState<string | null>(null);
   const [newEmail, setNewEmail] = useState("");
   const [newPassword, setNewPassword] = useState("");
+  const [showNewPassword, setShowNewPassword] = useState(false);
   const [newIsAdmin, setNewIsAdmin] = useState(false);
   const [isCreating, setIsCreating] = useState(false);
   const [pendingUserId, setPendingUserId] = useState<number | null>(null);
+  const [resetUserId, setResetUserId] = useState<number | null>(null);
+  const [resetPassword, setResetPassword] = useState("");
+  const [showResetPassword, setShowResetPassword] = useState(false);
 
   const loadUsers = useCallback(async () => {
     setLoadError(null);
@@ -61,6 +123,7 @@ export default function AdminUsersPanel({ open, onClose }: AdminUsersPanelProps)
       await apiClient.createUser(newEmail.trim(), newPassword, newIsAdmin);
       setNewEmail("");
       setNewPassword("");
+      setShowNewPassword(false);
       setNewIsAdmin(false);
       setActionStatus("Benutzer angelegt.");
       await loadUsers();
@@ -93,6 +156,42 @@ export default function AdminUsersPanel({ open, onClose }: AdminUsersPanelProps)
     }
   };
 
+  const beginPasswordReset = (user: AdminUser) => {
+    setActionError(null);
+    setActionStatus(null);
+    setResetUserId(user.user_id);
+    setResetPassword("");
+    setShowResetPassword(false);
+  };
+
+  const cancelPasswordReset = () => {
+    setResetUserId(null);
+    setResetPassword("");
+    setShowResetPassword(false);
+  };
+
+  const handlePasswordReset = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (resetUserId === null || pendingUserId !== null) {
+      return;
+    }
+    setActionError(null);
+    setActionStatus(null);
+    setPendingUserId(resetUserId);
+    try {
+      await apiClient.updateUser(resetUserId, { password: resetPassword });
+      setActionStatus("Passwort zurückgesetzt.");
+      cancelPasswordReset();
+      await loadUsers();
+    } catch (error) {
+      setActionError(
+        getErrorMessage(error, "Passwort konnte nicht zurückgesetzt werden.")
+      );
+    } finally {
+      setPendingUserId(null);
+    }
+  };
+
   if (!isMounted || !open) {
     return null;
   }
@@ -104,12 +203,17 @@ export default function AdminUsersPanel({ open, onClose }: AdminUsersPanelProps)
         <section className="pointer-events-auto relative h-full w-full max-w-[640px] border-l border-slate-300 bg-white shadow-2xl">
           <header className="border-b border-slate-200 bg-slate-50 px-4 py-3">
             <div className="flex items-center justify-between">
-              <div className="text-sm font-semibold text-slate-900">
-                Benutzerverwaltung
+              <div>
+                <div className="text-sm font-semibold text-slate-900">
+                  Benutzerverwaltung
+                </div>
+                <div className="mt-0.5 text-[11px] font-medium text-slate-500">
+                  Konten anlegen, sperren und Passwörter neu setzen.
+                </div>
               </div>
               <button
                 onClick={onClose}
-                className="rounded-full border border-slate-300 px-3 py-1 text-xs font-semibold text-slate-700"
+                className="rounded-xl border border-slate-300 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 transition hover:bg-slate-50"
               >
                 Schließen
               </button>
@@ -118,7 +222,7 @@ export default function AdminUsersPanel({ open, onClose }: AdminUsersPanelProps)
           <div className="h-[calc(100%-52px)] overflow-auto px-4 py-4">
             <form
               onSubmit={handleCreate}
-              className="rounded-2xl border border-slate-200 bg-slate-50 p-4"
+              className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm"
             >
               <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">
                 Neuen Benutzer anlegen
@@ -133,20 +237,27 @@ export default function AdminUsersPanel({ open, onClose }: AdminUsersPanelProps)
                     required
                     value={newEmail}
                     onChange={(event) => setNewEmail(event.target.value)}
-                    className="mt-1 w-full rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none"
+                    className="mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-500 focus:outline-none"
                   />
                 </label>
                 <label className="block">
                   <span className="text-[11px] font-semibold text-slate-500">
                     Passwort (min. 8 Zeichen)
                   </span>
-                  <input
-                    type="password"
-                    required
-                    value={newPassword}
-                    onChange={(event) => setNewPassword(event.target.value)}
-                    className="mt-1 w-full rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none"
-                  />
+                  <div className="mt-1 flex rounded-xl border border-slate-200 bg-white focus-within:border-slate-500">
+                    <input
+                      type={showNewPassword ? "text" : "password"}
+                      required
+                      minLength={8}
+                      value={newPassword}
+                      onChange={(event) => setNewPassword(event.target.value)}
+                      className="min-w-0 flex-1 rounded-l-xl px-3 py-2 text-sm text-slate-900 focus:outline-none"
+                    />
+                    <PasswordVisibilityButton
+                      visible={showNewPassword}
+                      onClick={() => setShowNewPassword((prev) => !prev)}
+                    />
+                  </div>
                 </label>
               </div>
               <label className="mt-3 flex items-center gap-2 text-xs font-semibold text-slate-700">
@@ -168,12 +279,12 @@ export default function AdminUsersPanel({ open, onClose }: AdminUsersPanelProps)
             </form>
 
             {actionError && (
-              <div className="mt-3 rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-xs font-semibold text-rose-700">
+              <div className="ccc-status-error mt-3 rounded-xl border px-3 py-2 text-xs font-semibold">
                 {actionError}
               </div>
             )}
             {actionStatus && (
-              <div className="mt-3 rounded-xl border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs font-semibold text-emerald-700">
+              <div className="ccc-status-success mt-3 rounded-xl border px-3 py-2 text-xs font-semibold">
                 {actionStatus}
               </div>
             )}
@@ -183,7 +294,7 @@ export default function AdminUsersPanel({ open, onClose }: AdminUsersPanelProps)
                 Benutzer
               </div>
               {loadError ? (
-                <div className="mt-3 rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-xs font-semibold text-rose-700">
+                <div className="ccc-status-error mt-3 rounded-xl border px-3 py-2 text-xs font-semibold">
                   {loadError}
                 </div>
               ) : (
@@ -191,41 +302,95 @@ export default function AdminUsersPanel({ open, onClose }: AdminUsersPanelProps)
                   {users.map((user) => (
                     <li
                       key={user.user_id}
-                      className="flex items-center justify-between gap-3 rounded-xl border border-slate-200 bg-white px-3 py-2"
+                      className="rounded-xl border border-slate-200 bg-white px-3 py-2"
                     >
-                      <div className="min-w-0">
-                        <div className="truncate text-sm font-semibold text-slate-900">
-                          {user.email}
-                        </div>
-                        <div className="mt-0.5 flex flex-wrap gap-1 text-[10px] font-semibold uppercase tracking-wide">
-                          {user.is_admin && (
-                            <span className="rounded-full bg-slate-900 px-2 py-0.5 text-white">
-                              Admin
+                      <div className="flex items-center justify-between gap-3">
+                        <div className="min-w-0">
+                          <div className="truncate text-sm font-semibold text-slate-900">
+                            {user.email}
+                          </div>
+                          <div className="mt-0.5 flex flex-wrap gap-1 text-[10px] font-semibold uppercase tracking-wide">
+                            {user.is_admin && (
+                              <span className="ccc-status-warning rounded-full border px-2 py-0.5">
+                                Admin
+                              </span>
+                            )}
+                            <span
+                              className={`rounded-full border px-2 py-0.5 ${
+                                user.is_active
+                                  ? "ccc-status-success"
+                                  : "border-slate-200 bg-slate-100 text-slate-600"
+                              }`}
+                            >
+                              {user.is_active ? "Aktiv" : "Inaktiv"}
                             </span>
-                          )}
-                          <span
-                            className={`rounded-full px-2 py-0.5 ${
+                          </div>
+                        </div>
+                        <div className="flex shrink-0 items-center gap-2">
+                          <button
+                            type="button"
+                            onClick={() => beginPasswordReset(user)}
+                            disabled={pendingUserId === user.user_id}
+                            className="rounded-xl border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
+                          >
+                            Passwort zurücksetzen
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => handleToggleActive(user)}
+                            disabled={pendingUserId === user.user_id}
+                            className={`rounded-xl border bg-white px-3 py-1.5 text-xs font-semibold transition disabled:cursor-not-allowed disabled:opacity-50 ${
                               user.is_active
-                                ? "bg-emerald-100 text-emerald-700"
-                                : "bg-slate-200 text-slate-600"
+                                ? "ccc-danger-outline hover:bg-[var(--ccc-status-alert-bg)]"
+                                : "border-slate-200 text-slate-700 hover:bg-slate-50"
                             }`}
                           >
-                            {user.is_active ? "Aktiv" : "Inaktiv"}
-                          </span>
+                            {user.is_active ? "Deaktivieren" : "Reaktivieren"}
+                          </button>
                         </div>
                       </div>
-                      <button
-                        type="button"
-                        onClick={() => handleToggleActive(user)}
-                        disabled={pendingUserId === user.user_id}
-                        className={`shrink-0 rounded-full border px-3 py-1.5 text-xs font-semibold transition disabled:cursor-not-allowed disabled:opacity-50 ${
-                          user.is_active
-                            ? "border-rose-200 text-rose-700 hover:bg-rose-50"
-                            : "border-emerald-200 text-emerald-700 hover:bg-emerald-50"
-                        }`}
-                      >
-                        {user.is_active ? "Deaktivieren" : "Reaktivieren"}
-                      </button>
+                      {resetUserId === user.user_id && (
+                        <form
+                          onSubmit={handlePasswordReset}
+                          className="mt-3 flex flex-col gap-2 rounded-xl border border-slate-200 bg-slate-50 p-3 sm:flex-row sm:items-center"
+                        >
+                          <label className="min-w-0 flex-1">
+                            <span className="text-[11px] font-semibold text-slate-500">
+                              Neues Passwort
+                            </span>
+                            <div className="mt-1 flex rounded-xl border border-slate-200 bg-white focus-within:border-slate-500">
+                              <input
+                                type={showResetPassword ? "text" : "password"}
+                                required
+                                minLength={8}
+                                value={resetPassword}
+                                onChange={(event) => setResetPassword(event.target.value)}
+                                className="min-w-0 flex-1 rounded-l-xl px-3 py-2 text-sm text-slate-900 focus:outline-none"
+                              />
+                              <PasswordVisibilityButton
+                                visible={showResetPassword}
+                                onClick={() => setShowResetPassword((prev) => !prev)}
+                              />
+                            </div>
+                          </label>
+                          <div className="flex gap-2 sm:pt-5">
+                            <button
+                              type="submit"
+                              disabled={pendingUserId === user.user_id}
+                              className="rounded-xl bg-slate-900 px-3 py-2 text-xs font-semibold text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400"
+                            >
+                              Speichern
+                            </button>
+                            <button
+                              type="button"
+                              onClick={cancelPasswordReset}
+                              className="rounded-xl border border-slate-300 px-3 py-2 text-xs font-semibold text-slate-700 transition hover:bg-white"
+                            >
+                              Abbrechen
+                            </button>
+                          </div>
+                        </form>
+                      )}
                     </li>
                   ))}
                   {users.length === 0 && (

--- a/frontend/src/components/AuthGate.tsx
+++ b/frontend/src/components/AuthGate.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useAuth } from "@/contexts/AuthContext";
+import LoginForm from "@/components/LoginForm";
+
+export default function AuthGate({ children }: { children: React.ReactNode }) {
+  const { user, loading } = useAuth();
+
+  if (loading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center px-4">
+        <div className="rounded-2xl border border-slate-200 bg-white px-6 py-4 text-sm font-semibold text-slate-600 shadow-xl">
+          Wird geladen...
+        </div>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return <LoginForm />;
+  }
+
+  return <>{children}</>;
+}

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,8 +1,18 @@
+"use client";
+
+import { useState } from "react";
+
+import AccountMenu from "@/components/AccountMenu";
+import AdminUsersPanel from "@/components/AdminUsersPanel";
 import HeaderHelpPopover from "@/components/HeaderHelpPopover";
 import ModelSelector from "@/components/ModelSelector";
 import SessionMenu from "@/components/SessionMenu";
+import { useAuth } from "@/contexts/AuthContext";
 
 export default function Header() {
+  const { user, logout } = useAuth();
+  const [adminOpen, setAdminOpen] = useState(false);
+
   return (
     <header className="border-b border-white/20 bg-gradient-to-r from-slate-900 via-slate-800 to-slate-700 text-white shadow-xl">
       <div className="mx-auto flex min-h-20 max-w-7xl items-center justify-between gap-6 px-4 py-3 sm:px-6 lg:px-8">
@@ -22,9 +32,20 @@ export default function Header() {
         <div className="flex items-center gap-3">
           <SessionMenu variant="header" />
           <ModelSelector />
+          {user?.is_admin && (
+            <button
+              type="button"
+              onClick={() => setAdminOpen(true)}
+              className="rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-xs font-semibold text-amber-900 shadow-sm transition hover:bg-amber-100"
+            >
+              Benutzerverwaltung
+            </button>
+          )}
           <HeaderHelpPopover />
+          {user && <AccountMenu user={user} logout={logout} />}
         </div>
       </div>
+      <AdminUsersPanel open={adminOpen} onClose={() => setAdminOpen(false)} />
     </header>
   );
 }

--- a/frontend/src/components/LoginForm.tsx
+++ b/frontend/src/components/LoginForm.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useState } from "react";
+
+import { useAuth } from "@/contexts/AuthContext";
+import { type ApiClientError } from "@/lib/api";
+
+export default function LoginForm() {
+  const { login } = useAuth();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (isSubmitting) {
+      return;
+    }
+    setError(null);
+    setIsSubmitting(true);
+    try {
+      await login(email.trim(), password);
+    } catch (err) {
+      const status = (err as ApiClientError)?.status;
+      if (status === 401) {
+        setError("E-Mail oder Passwort ist ungültig.");
+      } else {
+        setError("Anmeldung fehlgeschlagen. Bitte erneut versuchen.");
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center px-4">
+      <form
+        onSubmit={handleSubmit}
+        className="w-full max-w-sm rounded-2xl border border-slate-200 bg-white p-6 shadow-2xl"
+      >
+        <div className="flex items-center gap-3">
+          <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-slate-900 text-lg font-bold text-white shadow-inner">
+            CCC
+          </div>
+          <div>
+            <h1 className="text-base font-semibold text-slate-900">
+              Compliance-Cost Computer
+            </h1>
+            <p className="text-xs text-slate-500">Bitte anmelden, um fortzufahren.</p>
+          </div>
+        </div>
+        <div className="mt-6 space-y-3">
+          <label className="block">
+            <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+              E-Mail
+            </span>
+            <input
+              type="email"
+              autoComplete="username"
+              required
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              className="mt-1 w-full rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none"
+            />
+          </label>
+          <label className="block">
+            <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+              Passwort
+            </span>
+            <input
+              type="password"
+              autoComplete="current-password"
+              required
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              className="mt-1 w-full rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-900 focus:border-slate-400 focus:outline-none"
+            />
+          </label>
+        </div>
+        {error && (
+          <div className="mt-3 rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-xs font-semibold text-rose-700">
+            {error}
+          </div>
+        )}
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="mt-5 w-full rounded-xl bg-slate-900 px-3 py-2 text-sm font-semibold text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-400"
+        >
+          {isSubmitting ? "Wird angemeldet..." : "Anmelden"}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/AdminUsersPanel.test.tsx
+++ b/frontend/src/components/__tests__/AdminUsersPanel.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import AdminUsersPanel from "@/components/AdminUsersPanel";
+import { apiClient } from "@/lib/api";
+
+jest.mock("@/lib/api", () => ({
+  apiClient: {
+    listUsers: jest.fn(),
+    createUser: jest.fn(),
+    updateUser: jest.fn(),
+  },
+}));
+
+const mockListUsers = apiClient.listUsers as jest.Mock;
+const mockCreateUser = apiClient.createUser as jest.Mock;
+const mockUpdateUser = apiClient.updateUser as jest.Mock;
+
+describe("AdminUsersPanel", () => {
+  beforeEach(() => {
+    mockListUsers.mockReset();
+    mockCreateUser.mockReset();
+    mockUpdateUser.mockReset();
+    mockListUsers.mockResolvedValue([
+      {
+        user_id: 1,
+        email: "admin@example.com",
+        is_admin: true,
+        is_active: true,
+        created_at: "2026-07-17",
+      },
+      {
+        user_id: 2,
+        email: "member@example.com",
+        is_admin: false,
+        is_active: true,
+        created_at: "2026-07-17",
+      },
+    ]);
+    mockCreateUser.mockResolvedValue({
+      user_id: 3,
+      email: "new@example.com",
+      is_admin: false,
+      is_active: true,
+    });
+    mockUpdateUser.mockResolvedValue({
+      user_id: 2,
+      email: "member@example.com",
+      is_admin: false,
+      is_active: true,
+    });
+  });
+
+  it("reveals and hides the new-user password field", async () => {
+    const user = userEvent.setup();
+    render(<AdminUsersPanel open onClose={jest.fn()} />);
+
+    const input = await screen.findByLabelText("Passwort (min. 8 Zeichen)", {
+      selector: "input",
+    });
+    expect(input).toHaveAttribute("type", "password");
+
+    await user.click(screen.getByRole("button", { name: "Passwort anzeigen" }));
+    expect(input).toHaveAttribute("type", "text");
+
+    await user.click(screen.getByRole("button", { name: "Passwort verbergen" }));
+    expect(input).toHaveAttribute("type", "password");
+  });
+
+  it("resets an existing user's password", async () => {
+    const user = userEvent.setup();
+    render(<AdminUsersPanel open onClose={jest.fn()} />);
+
+    const member = await screen.findByText("member@example.com");
+    const row = member.closest("li");
+    expect(row).not.toBeNull();
+
+    await user.click(
+      within(row as HTMLElement).getByRole("button", {
+        name: "Passwort zurücksetzen",
+      })
+    );
+    await user.type(
+      within(row as HTMLElement).getByLabelText("Neues Passwort"),
+      "new-password-123"
+    );
+    await user.click(within(row as HTMLElement).getByRole("button", { name: "Speichern" }));
+
+    await waitFor(() =>
+      expect(mockUpdateUser).toHaveBeenCalledWith(2, {
+        password: "new-password-123",
+      })
+    );
+    expect(await screen.findByText("Passwort zurückgesetzt.")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/__tests__/AuthGate.test.tsx
+++ b/frontend/src/components/__tests__/AuthGate.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from "@testing-library/react";
+
+import AuthGate from "@/components/AuthGate";
+import { useAuth } from "@/contexts/AuthContext";
+
+jest.mock("@/contexts/AuthContext", () => ({
+  useAuth: jest.fn(),
+}));
+
+jest.mock("@/components/LoginForm", () => ({
+  __esModule: true,
+  default: () => <div data-testid="login-form" />,
+}));
+
+const mockUseAuth = useAuth as jest.Mock;
+
+describe("AuthGate", () => {
+  it("shows a loading state while auth is resolving", () => {
+    mockUseAuth.mockReturnValue({ user: null, loading: true });
+
+    render(
+      <AuthGate>
+        <div data-testid="app" />
+      </AuthGate>
+    );
+
+    expect(screen.getByText(/wird geladen/i)).toBeInTheDocument();
+    expect(screen.queryByTestId("app")).not.toBeInTheDocument();
+  });
+
+  it("renders the login form when unauthenticated", () => {
+    mockUseAuth.mockReturnValue({ user: null, loading: false });
+
+    render(
+      <AuthGate>
+        <div data-testid="app" />
+      </AuthGate>
+    );
+
+    expect(screen.getByTestId("login-form")).toBeInTheDocument();
+    expect(screen.queryByTestId("app")).not.toBeInTheDocument();
+  });
+
+  it("renders children when authenticated", () => {
+    mockUseAuth.mockReturnValue({
+      user: { user_id: 1, email: "ada@example.com", is_admin: false },
+      loading: false,
+    });
+
+    render(
+      <AuthGate>
+        <div data-testid="app" />
+      </AuthGate>
+    );
+
+    expect(screen.getByTestId("app")).toBeInTheDocument();
+    expect(screen.queryByTestId("login-form")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/__tests__/Header.test.tsx
+++ b/frontend/src/components/__tests__/Header.test.tsx
@@ -1,10 +1,23 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import Header from "@/components/Header";
+import { useAuth } from "@/contexts/AuthContext";
+
+jest.mock("@/contexts/AuthContext", () => ({
+  useAuth: jest.fn(),
+}));
 
 jest.mock("@/components/SessionMenu", () => ({
   __esModule: true,
   default: () => <div data-testid="session-menu" />,
+}));
+
+jest.mock("@/components/AdminUsersPanel", () => ({
+  __esModule: true,
+  default: ({ open }: { open: boolean }) => (
+    <div data-testid="admin-panel" data-open={open ? "true" : "false"} />
+  ),
 }));
 
 jest.mock("@/components/ModelSelector", () => ({
@@ -17,7 +30,16 @@ jest.mock("@/components/HeaderHelpPopover", () => ({
   default: () => <button type="button">Hilfe und Demo</button>,
 }));
 
+const mockUseAuth = useAuth as jest.Mock;
+
 describe("Header", () => {
+  beforeEach(() => {
+    mockUseAuth.mockReturnValue({
+      user: { user_id: 1, email: "user@example.com", is_admin: false },
+      logout: jest.fn().mockResolvedValue(undefined),
+    });
+  });
+
   it("renders app context and global session tools", () => {
     render(<Header />);
 
@@ -33,6 +55,40 @@ describe("Header", () => {
     expect(screen.getByTestId("model-selector")).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Hilfe und Demo" })
+    ).toBeInTheDocument();
+  });
+
+  it("shows the user email in the account menu and calls logout there", async () => {
+    const logout = jest.fn().mockResolvedValue(undefined);
+    mockUseAuth.mockReturnValue({
+      user: { user_id: 7, email: "ada@example.com", is_admin: false },
+      logout,
+    });
+
+    render(<Header />);
+    const user = userEvent.setup();
+
+    expect(screen.queryByText("ada@example.com")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Benutzerverwaltung" })
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Benutzerkonto öffnen" }));
+    expect(screen.getByText("ada@example.com")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /abmelden/i }));
+    expect(logout).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the admin users button only for admins", () => {
+    mockUseAuth.mockReturnValue({
+      user: { user_id: 1, email: "root@example.com", is_admin: true },
+      logout: jest.fn().mockResolvedValue(undefined),
+    });
+
+    render(<Header />);
+
+    expect(
+      screen.getByRole("button", { name: "Benutzerverwaltung" })
     ).toBeInTheDocument();
   });
 });

--- a/frontend/src/contexts/AppContext.tsx
+++ b/frontend/src/contexts/AppContext.tsx
@@ -5,7 +5,6 @@ import React, {
   useCallback,
   useContext,
   useEffect,
-  useRef,
   useState,
 } from "react";
 import { apiClient } from "@/lib/api";
@@ -225,7 +224,6 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
 
   const [currentTab, setCurrentTab] = useState(0);
   const [appSessionId, setAppSessionIdState] = useState("");
-  const [isFreshAppSessionId, setIsFreshAppSessionId] = useState(false);
   const [selectedNormAddressee, setSelectedNormAddresseeState] =
     useState<NormAddressee>("administration");
   const [selectedModel, setSelectedModel] = useState("");
@@ -254,26 +252,9 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
   const [lastFailedLabel, setLastFailedLabel] = useState<string | null>(null);
   const [lastFailedMessage, setLastFailedMessage] = useState<string | null>(null);
   const [isComplianceExportRunning, setIsComplianceExportRunning] = useState(false);
-  const appSessionIdAttempts = useRef(0);
-
-  const generateAppSessionId = useCallback(() => {
-    const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-    return Array.from({ length: 6 }, () =>
-      chars[Math.floor(Math.random() * chars.length)]
-    ).join("");
-  }, []);
-
-  const setNewAppSessionId = useCallback(() => {
-    const generated = generateAppSessionId();
-    appSessionIdAttempts.current += 1;
-    setAppSessionIdState(generated);
-    setIsFreshAppSessionId(true);
-  }, [generateAppSessionId]);
 
   const setAppSessionId = useCallback((nextAppSessionId: string) => {
     setAppSessionIdState(nextAppSessionId);
-    setIsFreshAppSessionId(false);
-    appSessionIdAttempts.current = 0;
   }, []);
 
   const setSelectedNormAddressee = useCallback((normAddressee: NormAddressee) => {
@@ -326,15 +307,15 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     const storedAppSessionId =
       sessionStorage.getItem(APP_SESSION_STORAGE_KEY) ||
       sessionStorage.getItem(LEGACY_SESSION_STORAGE_KEY);
-    if (storedAppSessionId && /^[A-Z0-9]{6}$/.test(storedAppSessionId)) {
+    if (storedAppSessionId && /^[A-Za-z0-9_-]{1,64}$/.test(storedAppSessionId)) {
       setAppSessionIdState(storedAppSessionId);
-      setIsFreshAppSessionId(false);
       sessionStorage.setItem(APP_SESSION_STORAGE_KEY, storedAppSessionId);
       sessionStorage.removeItem(LEGACY_SESSION_STORAGE_KEY);
-      return;
     }
-    setNewAppSessionId();
-  }, [setNewAppSessionId]);
+    // When there is no stored session id, a new one is created server-side by
+    // the syncSession effect once a model is selected (the server generates and
+    // returns the app_session_id).
+  }, []);
 
   useEffect(() => {
     const stored = sessionStorage.getItem(SELECTED_NORM_ADDRESSEE_STORAGE_KEY);
@@ -417,8 +398,8 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
           typeof (error as { status?: unknown })?.status === "number"
             ? ((error as { status: number }).status as number)
             : undefined;
-        // New app session IDs are created client-side first and may not exist
-        // server-side until the first upsert completes.
+        // A stored session id may no longer exist or may not be owned by the
+        // current user (the backend returns 404 in that case).
         if (status === 404) {
           return;
         }
@@ -502,39 +483,31 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
   }, [addresseeReadiness, regulationsReady, summaryReady]);
 
   useEffect(() => {
-    if (!appSessionId || !selectedModel) {
+    // A session id is only created server-side, on demand, once a model is
+    // selected. The server generates the id and we adopt the returned value.
+    if (appSessionId || !selectedModel) {
       return;
     }
     let cancelled = false;
-    const syncSession = async () => {
+    const createSession = async () => {
       try {
-        const { created } = await apiClient.upsertSession(appSessionId, selectedModel);
+        const { app_session_id } = await apiClient.createSession(selectedModel);
         if (cancelled) {
           return;
         }
-        if (created) {
-          appSessionIdAttempts.current = 0;
-          setIsFreshAppSessionId(false);
-          return;
-        }
-        if (isFreshAppSessionId && appSessionIdAttempts.current < 5) {
-          setNewAppSessionId();
-          return;
-        }
-        setIsFreshAppSessionId(false);
+        setAppSessionIdState(app_session_id);
       } catch (error) {
-        logDebug("[AppContext] Failed to upsert session", {
-          appSessionId,
+        logDebug("[AppContext] Failed to create session", {
           selectedModel,
           error,
         });
       }
     };
-    syncSession();
+    createSession();
     return () => {
       cancelled = true;
     };
-  }, [appSessionId, selectedModel, isFreshAppSessionId, setNewAppSessionId, logDebug]);
+  }, [appSessionId, selectedModel, logDebug]);
 
   return (
     <AppContext.Provider

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+
+import { apiClient, type ApiClientError } from "@/lib/api";
+import type { AuthUser } from "@/types";
+
+interface AuthContextValue {
+  user: AuthUser | null;
+  loading: boolean;
+  login: (email: string, password: string) => Promise<void>;
+  logout: () => Promise<void>;
+  refresh: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+function isUnauthorized(error: unknown): boolean {
+  return (error as ApiClientError)?.status === 401;
+}
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const refresh = useCallback(async () => {
+    try {
+      const me = await apiClient.getMe();
+      setUser(me);
+    } catch (error) {
+      if (!isUnauthorized(error) && process.env.NODE_ENV === "development") {
+        console.debug("[AuthContext] Failed to load current user", error);
+      }
+      setUser(null);
+    }
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    const bootstrap = async () => {
+      await refresh();
+      if (!cancelled) {
+        setLoading(false);
+      }
+    };
+    void bootstrap();
+    return () => {
+      cancelled = true;
+    };
+  }, [refresh]);
+
+  const login = useCallback(
+    async (email: string, password: string) => {
+      await apiClient.login(email, password);
+      await refresh();
+    },
+    [refresh]
+  );
+
+  const logout = useCallback(async () => {
+    try {
+      await apiClient.logout();
+    } finally {
+      // Clear per-session state so a different user does not inherit the
+      // previous user's session id or workflow readiness.
+      try {
+        sessionStorage.clear();
+      } catch {
+        // sessionStorage may be unavailable (e.g. private browsing); ignore.
+      }
+      setUser(null);
+    }
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ user, loading, login, logout, refresh }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error("useAuth must be used within AuthProvider");
+  }
+  return context;
+}

--- a/frontend/src/contexts/__tests__/AppContext.test.tsx
+++ b/frontend/src/contexts/__tests__/AppContext.test.tsx
@@ -8,7 +8,7 @@ import { apiClient } from "@/lib/api";
 jest.mock("@/lib/api", () => ({
   apiClient: {
     getSessionStatus: jest.fn(),
-    upsertSession: jest.fn(),
+    createSession: jest.fn(),
   },
 }));
 
@@ -28,6 +28,10 @@ function ContextProbe() {
 describe("AppContext session status sync", () => {
   beforeEach(() => {
     sessionStorage.clear();
+    (apiClient.createSession as jest.Mock).mockResolvedValue({
+      app_session_id: "a".repeat(32),
+      created: true,
+    });
     (apiClient.getSessionStatus as jest.Mock).mockResolvedValue({
       summary_ready: true,
       regulations_ready: true,

--- a/frontend/src/contexts/__tests__/AuthContext.test.tsx
+++ b/frontend/src/contexts/__tests__/AuthContext.test.tsx
@@ -1,0 +1,132 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { AuthProvider, useAuth } from "@/contexts/AuthContext";
+import { apiClient } from "@/lib/api";
+
+jest.mock("@/lib/api", () => ({
+  apiClient: {
+    getMe: jest.fn(),
+    login: jest.fn(),
+    logout: jest.fn(),
+  },
+}));
+
+function AuthProbe() {
+  const { user, loading, login, logout } = useAuth();
+  return (
+    <div>
+      <div data-testid="loading">{loading ? "loading" : "ready"}</div>
+      <div data-testid="user">{user ? user.email : "anon"}</div>
+      <button onClick={() => login("ada@example.com", "secret123")}>login</button>
+      <button onClick={() => logout()}>logout</button>
+    </div>
+  );
+}
+
+describe("AuthContext", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    sessionStorage.clear();
+  });
+
+  it("loads the current user on mount", async () => {
+    (apiClient.getMe as jest.Mock).mockResolvedValue({
+      user_id: 1,
+      email: "ada@example.com",
+      is_admin: false,
+    });
+
+    render(
+      <AuthProvider>
+        <AuthProbe />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading").textContent).toBe("ready");
+    });
+    expect(screen.getByTestId("user").textContent).toBe("ada@example.com");
+  });
+
+  it("treats a 401 from getMe as logged out", async () => {
+    (apiClient.getMe as jest.Mock).mockRejectedValue(
+      Object.assign(new Error("Unauthorized"), { status: 401 })
+    );
+
+    render(
+      <AuthProvider>
+        <AuthProbe />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading").textContent).toBe("ready");
+    });
+    expect(screen.getByTestId("user").textContent).toBe("anon");
+  });
+
+  it("logs in and refreshes the user", async () => {
+    (apiClient.getMe as jest.Mock)
+      .mockRejectedValueOnce(
+        Object.assign(new Error("Unauthorized"), { status: 401 })
+      )
+      .mockResolvedValueOnce({
+        user_id: 2,
+        email: "grace@example.com",
+        is_admin: true,
+      });
+    (apiClient.login as jest.Mock).mockResolvedValue({
+      user_id: 2,
+      email: "grace@example.com",
+      is_admin: true,
+    });
+
+    render(
+      <AuthProvider>
+        <AuthProbe />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("user").textContent).toBe("anon");
+    });
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "login" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("user").textContent).toBe("grace@example.com");
+    });
+    expect(apiClient.login).toHaveBeenCalledWith("ada@example.com", "secret123");
+  });
+
+  it("clears the user and session storage on logout", async () => {
+    (apiClient.getMe as jest.Mock).mockResolvedValue({
+      user_id: 1,
+      email: "ada@example.com",
+      is_admin: false,
+    });
+    (apiClient.logout as jest.Mock).mockResolvedValue(undefined);
+    sessionStorage.setItem("app_session_id", "a".repeat(32));
+
+    render(
+      <AuthProvider>
+        <AuthProbe />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("user").textContent).toBe("ada@example.com");
+    });
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "logout" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("user").textContent).toBe("anon");
+    });
+    expect(sessionStorage.getItem("app_session_id")).toBeNull();
+    expect(apiClient.logout).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -21,6 +21,8 @@ import {
   EditableProcessStepsResponse,
   NormAddressee,
   CaseGroupResearchSettingsResponse,
+  AuthUser,
+  AdminUser,
 } from "@/types";
 
 const API_BASE_URL =
@@ -176,27 +178,110 @@ async function throwApiClientErrorFromResponse(
 }
 
 export const apiClient = {
-  async upsertSession(
-    appSessionId: string,
-    llmModel: string
-  ): Promise<{ app_session_id: string; created: boolean }> {
-    const response = await fetch(`${API_BASE_URL}/sessions`, {
+  async login(email: string, password: string): Promise<AuthUser> {
+    const response = await fetch(`${API_BASE_URL}/auth/login`, {
+      credentials: "include",
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ email, password }),
+    });
+    if (!response.ok) {
+      await throwApiClientErrorFromResponse(response, "Anmeldung fehlgeschlagen");
+    }
+    return response.json();
+  },
+  async logout(): Promise<void> {
+    const response = await fetch(`${API_BASE_URL}/auth/logout`, {
+      credentials: "include",
+      method: "POST",
+    });
+    if (!response.ok) {
+      await throwApiClientErrorFromResponse(response, "Abmeldung fehlgeschlagen");
+    }
+  },
+  async getMe(): Promise<AuthUser> {
+    const response = await fetch(`${API_BASE_URL}/auth/me`, {
+      credentials: "include",
+    });
+    if (!response.ok) {
+      await throwApiClientErrorFromResponse(response, "Failed to load current user");
+    }
+    return response.json();
+  },
+  async listUsers(): Promise<AdminUser[]> {
+    const response = await fetch(`${API_BASE_URL}/auth/users`, {
+      credentials: "include",
+    });
+    if (!response.ok) {
+      await throwApiClientErrorFromResponse(response, "Failed to load users");
+    }
+    return response.json();
+  },
+  async createUser(
+    email: string,
+    password: string,
+    isAdmin?: boolean
+  ): Promise<AdminUser> {
+    const response = await fetch(`${API_BASE_URL}/auth/users`, {
+      credentials: "include",
       method: "POST",
       headers: {
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
-        app_session_id: appSessionId,
+        email,
+        password,
+        is_admin: isAdmin ?? false,
+      }),
+    });
+    if (!response.ok) {
+      await throwApiClientErrorFromResponse(response, "Failed to create user");
+    }
+    return response.json();
+  },
+  async updateUser(
+    userId: number,
+    patch: { is_active?: boolean; is_admin?: boolean; password?: string }
+  ): Promise<AdminUser> {
+    const response = await fetch(
+      `${API_BASE_URL}/auth/users/${encodeURIComponent(String(userId))}`,
+      {
+        credentials: "include",
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(patch),
+      }
+    );
+    if (!response.ok) {
+      await throwApiClientErrorFromResponse(response, "Failed to update user");
+    }
+    return response.json();
+  },
+  async createSession(
+    llmModel: string
+  ): Promise<{ app_session_id: string; created: boolean }> {
+    const response = await fetch(`${API_BASE_URL}/sessions`, {
+      credentials: "include",
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
         llm_model: llmModel,
       }),
     });
     if (!response.ok) {
-      await throwApiClientErrorFromResponse(response, "Failed to upsert session");
+      await throwApiClientErrorFromResponse(response, "Failed to create session");
     }
     return response.json();
   },
   async fetchOrganizedModels(keys: ApiKeys): Promise<OrganizedModelsResponse> {
     const response = await fetch(`${API_BASE_URL}/models/organized`, {
+      credentials: "include",
       headers: buildKeyHeaders(keys),
     });
     if (!response.ok) {
@@ -219,7 +304,9 @@ export const apiClient = {
       params.set("norm_addressee", normAddressee);
     }
     const query = `?${params.toString()}`;
-    const response = await fetch(`${API_BASE_URL}/tiles${query}`);
+    const response = await fetch(`${API_BASE_URL}/tiles${query}`, {
+      credentials: "include",
+    });
     if (!response.ok) {
       await throwApiClientErrorFromResponse(response, "Failed to load tiles");
     }
@@ -239,6 +326,7 @@ export const apiClient = {
     }
     const query = `?${params.toString()}`;
     const response = await fetch(`${API_BASE_URL}/tiles${query}`, {
+      credentials: "include",
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -256,6 +344,7 @@ export const apiClient = {
     normAddressee?: NormAddressee
   ): Promise<{ ok: boolean }> {
     const response = await fetch(`${API_BASE_URL}/tiles/rebuild`, {
+      credentials: "include",
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -275,7 +364,9 @@ export const apiClient = {
   },
 
   async fetchRegulations(): Promise<RegulationsResponse> {
-    const response = await fetch(`${API_BASE_URL}/regulations`);
+    const response = await fetch(`${API_BASE_URL}/regulations`, {
+      credentials: "include",
+    });
     if (!response.ok) {
       await throwApiClientErrorFromResponse(response, "Failed to load regulations");
     }
@@ -283,7 +374,9 @@ export const apiClient = {
   },
 
   async listSessions(limit = 50): Promise<SessionsResponse> {
-    const response = await fetch(`${API_BASE_URL}/sessions?limit=${limit}`);
+    const response = await fetch(`${API_BASE_URL}/sessions?limit=${limit}`, {
+      credentials: "include",
+    });
     if (!response.ok) {
       await throwApiClientErrorFromResponse(response, "Failed to load sessions");
     }
@@ -294,7 +387,10 @@ export const apiClient = {
     const response = await fetch(
       `${API_BASE_URL}/sessions/status?app_session_id=${encodeURIComponent(
         appSessionId
-      )}`
+      )}`,
+      {
+        credentials: "include",
+      }
     );
     if (!response.ok) {
       await throwApiClientErrorFromResponse(response, "Failed to load session status");
@@ -306,6 +402,7 @@ export const apiClient = {
     appSessionId: string
   ): Promise<UndoStepResponse> {
     const response = await fetch(`${API_BASE_URL}/sessions/undo`, {
+      credentials: "include",
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -325,7 +422,10 @@ export const apiClient = {
     const response = await fetch(
       `${API_BASE_URL}/sessions/case-group-research?app_session_id=${encodeURIComponent(
         appSessionId
-      )}`
+      )}`,
+      {
+        credentials: "include",
+      }
     );
     if (!response.ok) {
       await throwApiClientErrorFromResponse(
@@ -340,6 +440,7 @@ export const apiClient = {
     enabled: boolean
   ): Promise<CaseGroupResearchSettingsResponse> {
     const response = await fetch(`${API_BASE_URL}/sessions/case-group-research`, {
+      credentials: "include",
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -361,7 +462,10 @@ export const apiClient = {
     const response = await fetch(
       `${API_BASE_URL}/sessions/deep-research-report?app_session_id=${encodeURIComponent(
         appSessionId
-      )}&format=pdf`
+      )}&format=pdf`,
+      {
+        credentials: "include",
+      }
     );
     if (!response.ok) {
       await throwApiClientErrorFromResponse(
@@ -379,6 +483,7 @@ export const apiClient = {
     userEditPolicy?: ComplianceTextUserEditPolicy;
   }): Promise<Blob> {
     const response = await fetch(`${API_BASE_URL}/sessions/compliance-text-export`, {
+      credentials: "include",
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -410,6 +515,7 @@ export const apiClient = {
     }
   ): Promise<RunAllStartResponse> {
     const response = await fetch(`${API_BASE_URL}/sessions/run-all/start`, {
+      credentials: "include",
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -440,6 +546,7 @@ export const apiClient = {
     }
   ): Promise<RunAllStartResponse> {
     const response = await fetch(`${API_BASE_URL}/sessions/step-runs/start`, {
+      credentials: "include",
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -461,7 +568,10 @@ export const apiClient = {
   },
   async getStepRunStatus(runId: string): Promise<RunAllStatusResponse> {
     const response = await fetch(
-      `${API_BASE_URL}/sessions/step-runs/${encodeURIComponent(runId)}`
+      `${API_BASE_URL}/sessions/step-runs/${encodeURIComponent(runId)}`,
+      {
+        credentials: "include",
+      }
     );
     if (!response.ok) {
       await throwApiClientErrorFromResponse(response, "Failed to load step status");
@@ -476,6 +586,7 @@ export const apiClient = {
       `${API_BASE_URL}/sessions/step-runs/${encodeURIComponent(runId)}/cancel`,
       {
         method: "POST",
+        credentials: "include",
       }
     );
     if (!response.ok) {
@@ -485,7 +596,10 @@ export const apiClient = {
   },
   async getRunAllStatus(runId: string): Promise<RunAllStatusResponse> {
     const response = await fetch(
-      `${API_BASE_URL}/sessions/run-all/${encodeURIComponent(runId)}`
+      `${API_BASE_URL}/sessions/run-all/${encodeURIComponent(runId)}`,
+      {
+        credentials: "include",
+      }
     );
     if (!response.ok) {
       await throwApiClientErrorFromResponse(response, "Failed to load run-all status");
@@ -500,6 +614,7 @@ export const apiClient = {
       `${API_BASE_URL}/sessions/run-all/${encodeURIComponent(runId)}/cancel`,
       {
         method: "POST",
+        credentials: "include",
       }
     );
     if (!response.ok) {
@@ -515,7 +630,10 @@ export const apiClient = {
     const response = await fetch(
       `${API_BASE_URL}/sessions/llm-monitor?app_session_id=${encodeURIComponent(
         options.appSessionId
-      )}&limit=${limit}`
+      )}&limit=${limit}`,
+      {
+        credentials: "include",
+      }
     );
     if (!response.ok) {
       await throwApiClientErrorFromResponse(
@@ -541,7 +659,10 @@ export const apiClient = {
     const response = await fetch(
       `${API_BASE_URL}/sessions/llm-monitor/stream/${encodeURIComponent(
         options.attemptId
-      )}?app_session_id=${encodeURIComponent(options.appSessionId)}`
+      )}?app_session_id=${encodeURIComponent(options.appSessionId)}`,
+      {
+        credentials: "include",
+      }
     );
     if (!response.ok) {
       await throwApiClientErrorFromResponse(
@@ -561,6 +682,7 @@ export const apiClient = {
       formData.append("filename", filenameOverride);
     }
     const response = await fetch(`${API_BASE_URL}/regulations/upload`, {
+      credentials: "include",
       method: "POST",
       body: formData,
     });
@@ -583,6 +705,7 @@ export const apiClient = {
     } = {}
   ): Promise<{ title: string; summary: string; blurb?: string; filename: string }> {
     const response = await fetch(`${API_BASE_URL}/regulations/summary`, {
+      credentials: "include",
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -614,6 +737,7 @@ export const apiClient = {
     }
   ): Promise<VorgabenResponse> {
     const response = await fetch(`${API_BASE_URL}/regulations/identify`, {
+      credentials: "include",
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -634,6 +758,7 @@ export const apiClient = {
     appSessionId: string;
   }): Promise<{ app_session_id: string; activity_id: string; lease_seconds: number; expires_at?: number | null }> {
     const response = await fetch(`${API_BASE_URL}/sessions/ea-edit-activity/acquire`, {
+      credentials: "include",
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -652,6 +777,7 @@ export const apiClient = {
     activityId: string;
   }): Promise<{ app_session_id: string; activity_id: string; lease_seconds: number; expires_at?: number | null }> {
     const response = await fetch(`${API_BASE_URL}/sessions/ea-edit-activity/heartbeat`, {
+      credentials: "include",
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -671,6 +797,7 @@ export const apiClient = {
     activityId: string;
   }): Promise<{ ok: boolean }> {
     const response = await fetch(`${API_BASE_URL}/sessions/ea-edit-activity/release`, {
+      credentials: "include",
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -691,6 +818,7 @@ export const apiClient = {
     eaActivityId?: string;
   }): Promise<TotalCostResponse> {
     const response = await fetch(`${API_BASE_URL}/costs/compute`, {
+      credentials: "include",
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -712,7 +840,9 @@ export const apiClient = {
   ): Promise<TotalCostSummaryResponse> {
     const params = new URLSearchParams();
     params.set("app_session_id", appSessionId);
-    const response = await fetch(`${API_BASE_URL}/costs/totals?${params.toString()}`);
+    const response = await fetch(`${API_BASE_URL}/costs/totals?${params.toString()}`, {
+      credentials: "include",
+    });
     if (!response.ok) {
       await throwApiClientErrorFromResponse(response, "Failed to load total costs");
     }
@@ -728,6 +858,7 @@ export const apiClient = {
     recomputed_norm_addressees: string[];
   }> {
     const response = await fetch(`${API_BASE_URL}/sessions/ea-edits/reset`, {
+      credentials: "include",
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -752,7 +883,9 @@ export const apiClient = {
     if (options.normAddressee) {
       params.set("norm_addressee", options.normAddressee);
     }
-    const response = await fetch(`${API_BASE_URL}/sessions/wage-rates?${params.toString()}`);
+    const response = await fetch(`${API_BASE_URL}/sessions/wage-rates?${params.toString()}`, {
+      credentials: "include",
+    });
     if (!response.ok) {
       await throwApiClientErrorFromResponse(response, "Failed to load session wage rates");
     }
@@ -769,6 +902,7 @@ export const apiClient = {
     hourlyRateEdited: number | null;
   }): Promise<SessionWageRatesResponse> {
     const response = await fetch(`${API_BASE_URL}/sessions/wage-rates`, {
+      credentials: "include",
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -798,7 +932,9 @@ export const apiClient = {
     if (typeof options.limit === "number") {
       params.set("limit", String(options.limit));
     }
-    const response = await fetch(`${API_BASE_URL}/sessions/edit-audit?${params.toString()}`);
+    const response = await fetch(`${API_BASE_URL}/sessions/edit-audit?${params.toString()}`, {
+      credentials: "include",
+    });
     if (!response.ok) {
       await throwApiClientErrorFromResponse(response, "Failed to load session edit audit");
     }
@@ -811,7 +947,10 @@ export const apiClient = {
     const response = await fetch(
       `${API_BASE_URL}/case-groups/editable?app_session_id=${encodeURIComponent(
         options.appSessionId
-      )}`
+      )}`,
+      {
+        credentials: "include",
+      }
     );
     if (!response.ok) {
       await throwApiClientErrorFromResponse(response, "Failed to load editable case groups");
@@ -831,6 +970,7 @@ export const apiClient = {
     }>;
   }): Promise<{ updated: number }> {
     const response = await fetch(`${API_BASE_URL}/case-groups/bulk-update`, {
+      credentials: "include",
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -856,7 +996,9 @@ export const apiClient = {
     if (typeof options.caseGroupId === "number") {
       params.set("case_group_id", String(options.caseGroupId));
     }
-    const response = await fetch(`${API_BASE_URL}/process-steps/editable?${params.toString()}`);
+    const response = await fetch(`${API_BASE_URL}/process-steps/editable?${params.toString()}`, {
+      credentials: "include",
+    });
     if (!response.ok) {
       await throwApiClientErrorFromResponse(response, "Failed to load editable process steps");
     }
@@ -881,6 +1023,7 @@ export const apiClient = {
     }>;
   }): Promise<{ updated: number }> {
     const response = await fetch(`${API_BASE_URL}/process-steps/bulk-update`, {
+      credentials: "include",
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -909,6 +1052,7 @@ export const apiClient = {
     timeRequiredInMinEdited: number | null;
   }): Promise<{ updated: number }> {
     const response = await fetch(`${API_BASE_URL}/process-steps/personnel-effort-edit`, {
+      credentials: "include",
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,5 +1,20 @@
 export type Provider = "OpenAI" | "DeepInfra" | "Gemini";
 export type NormAddressee = "administration" | "business" | "citizens";
+
+export interface AuthUser {
+  user_id: number;
+  email: string;
+  is_admin: boolean;
+}
+
+export interface AdminUser {
+  user_id: number;
+  email: string;
+  is_admin: boolean;
+  is_active: boolean;
+  created_at: string;
+}
+
 export const AUTOMATED_NORM_ADDRESSEES: NormAddressee[] = [
   "administration",
   "business",

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ google-genai>=0.6.0
 pytest>=8.0.0
 python-multipart>=0.0.9
 reportlab>=4.2.0
+bcrypt>=4.1.0
+pyjwt>=2.8.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,59 @@
 import pytest
 from fastapi.testclient import TestClient
 
+from backend.core import auth as auth_core
 from backend.core import config, db
 from backend.main import app
+
+
+# Identity that the auth dependency is overridden to represent in tests. Sessions
+# created during tests are owned by this user so ownership checks line up without
+# every test having to perform a real login.
+TEST_USER_ID = 1
+TEST_USER_EMAIL = "tester@example.com"
+TEST_USER_PASSWORD = "password123"
+
+
+def override_current_user() -> auth_core.AuthUser:
+    return auth_core.AuthUser(
+        user_id=TEST_USER_ID,
+        email=TEST_USER_EMAIL,
+        is_admin=True,
+    )
 
 
 @pytest.fixture(autouse=True)
 def isolated_db(tmp_path, monkeypatch):
     monkeypatch.setattr(config.settings, "db_path", tmp_path / "test.db")
+    monkeypatch.setattr(config.settings, "auth_secret_key", "test-secret-key")
     db.init_db()
+    # Seed the user the overridden auth dependency represents.
+    if db.get_user_by_email(TEST_USER_EMAIL) is None:
+        db.create_user(
+            TEST_USER_EMAIL,
+            auth_core.hash_password(TEST_USER_PASSWORD),
+            is_admin=True,
+        )
+
+    # Default the owner of any test-created session (the ~140 direct
+    # upsert_session/ensure_session calls) to the test user so ownership-gated
+    # endpoints resolve. Explicit owners (e.g. create_owned_session) are honored.
+    real_upsert_session = db.upsert_session
+
+    def _upsert_session_with_owner(app_session_id, llm_model, owner_user_id=None):
+        # Only default the owner when the seeded test user exists in the active DB.
+        # Some pure-DB tests repoint db_path to a fresh database without the user;
+        # stamping a non-existent owner there would violate the FK.
+        if owner_user_id is None and db.get_user_by_id(TEST_USER_ID) is not None:
+            owner_user_id = TEST_USER_ID
+        return real_upsert_session(app_session_id, llm_model, owner_user_id=owner_user_id)
+
+    monkeypatch.setattr(db, "upsert_session", _upsert_session_with_owner)
+
+    # Authenticate every request as the seeded test user by default.
+    app.dependency_overrides[auth_core.get_current_user] = override_current_user
     yield
+    app.dependency_overrides.pop(auth_core.get_current_user, None)
 
 
 @pytest.fixture

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -5,12 +5,15 @@ rest of the suite runs authenticated. These tests pop that override to drive the
 genuine cookie-based login and ownership checks.
 """
 
+import re
+
 import pytest
 from fastapi.testclient import TestClient
 
 from backend.core import auth as auth_core
 from backend.core import config, db
 from backend.main import app
+from backend.routers import regulations as regulations_router
 
 from tests.conftest import TEST_USER_EMAIL, TEST_USER_PASSWORD
 
@@ -100,6 +103,7 @@ def test_sessions_are_private_per_user(client):
     created = client.post("/sessions", json={"llm_model": "gpt-5"})
     assert created.status_code == 200
     app_session_id = created.json()["app_session_id"]
+    assert re.fullmatch(r"[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{6}", app_session_id)
 
     # Provision and switch to user B.
     client.post(
@@ -120,3 +124,123 @@ def test_cannot_remove_last_admin(client):
     admin = db.get_user_by_email(TEST_USER_EMAIL)
     resp = client.patch(f"/auth/users/{admin['user_id']}", json={"is_active": False})
     assert resp.status_code == 400
+
+
+def test_bootstrap_admin_does_not_add_second_admin_when_admin_exists(client, monkeypatch):
+    monkeypatch.setattr(config.settings, "admin_bootstrap_email", "bootstrap@example.com")
+    monkeypatch.setattr(config.settings, "admin_bootstrap_password", "bootstrappass")
+
+    auth_core.ensure_bootstrap_admin()
+
+    assert db.get_user_by_email("bootstrap@example.com") is None
+    assert db.count_admins() == 1
+
+
+def test_regulation_summary_requires_owned_session(client):
+    _login(client, TEST_USER_EMAIL, TEST_USER_PASSWORD)
+    db.insert_law("summary-proposed.txt", "neuer entwurf")
+
+    missing_session = client.post(
+        "/regulations/summary",
+        json={
+            "filename": "summary-proposed.txt",
+            "model": "test-model",
+        },
+    )
+    assert missing_session.status_code == 400
+
+    created = client.post("/sessions", json={"llm_model": "test-model"})
+    assert created.status_code == 200
+    app_session_id = created.json()["app_session_id"]
+    client.post(
+        "/auth/users",
+        json={"email": "summary-other@example.com", "password": "otherpass"},
+    )
+    client.post("/auth/logout")
+    _login(client, "summary-other@example.com", "otherpass")
+
+    cross_user = client.post(
+        "/regulations/summary",
+        json={
+            "filename": "summary-proposed.txt",
+            "app_session_id": app_session_id,
+            "model": "test-model",
+        },
+    )
+    assert cross_user.status_code == 404
+
+
+def test_regulation_summary_succeeds_for_owned_session(client, monkeypatch):
+    _login(client, TEST_USER_EMAIL, TEST_USER_PASSWORD)
+    db.insert_law("owned-summary-current.txt", "aktuelles gesetz")
+    db.insert_law("owned-summary-proposed.txt", "neuer entwurf")
+    created = client.post("/sessions", json={"llm_model": "test-model"})
+    assert created.status_code == 200
+    app_session_id = created.json()["app_session_id"]
+
+    async def fake_query_llm(*_args, **_kwargs):
+        return '{"title": "Kurz", "blurb": "Ein Satz.", "summary": "Zusammenfassung."}'
+
+    monkeypatch.setattr(regulations_router, "query_llm", fake_query_llm)
+
+    response = client.post(
+        "/regulations/summary",
+        json={
+            "filename": "owned-summary-proposed.txt",
+            "current_filename": "owned-summary-current.txt",
+            "app_session_id": app_session_id,
+            "model": "test-model",
+        },
+    )
+
+    assert response.status_code == 200
+    session = db.get_session_by_app_id(app_session_id)
+    assert session["proposed_law_id"] is not None
+
+
+def test_uploaded_laws_are_private_but_builtin_laws_are_shared(client):
+    _login(client, TEST_USER_EMAIL, TEST_USER_PASSWORD)
+    db.insert_law("builtin-law.txt", "shared fixture")
+
+    upload = client.post(
+        "/regulations/upload",
+        files={"file": ("private-law.txt", b"user a law", "text/plain")},
+    )
+    assert upload.status_code == 200
+    assert set(client.get("/regulations").json()["files"]) == {
+        "builtin-law.txt",
+        "private-law.txt",
+    }
+
+    client.post(
+        "/auth/users",
+        json={"email": "law-other@example.com", "password": "otherpass"},
+    )
+    client.post("/auth/logout")
+    _login(client, "law-other@example.com", "otherpass")
+
+    assert client.get("/regulations").json()["files"] == ["builtin-law.txt"]
+
+    own_session = client.post("/sessions", json={"llm_model": "test-model"})
+    assert own_session.status_code == 200
+    hidden_private_law = client.post(
+        "/regulations/summary",
+        json={
+            "filename": "private-law.txt",
+            "app_session_id": own_session.json()["app_session_id"],
+            "model": "test-model",
+        },
+    )
+    assert hidden_private_law.status_code == 404
+
+    same_private_name = client.post(
+        "/regulations/upload",
+        files={"file": ("private-law.txt", b"user b law", "text/plain")},
+    )
+    assert same_private_name.status_code == 200
+
+    builtin_conflict = client.post(
+        "/regulations/upload",
+        files={"file": ("builtin-law.txt", b"shadow builtin", "text/plain")},
+    )
+    assert builtin_conflict.status_code == 409

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,122 @@
+"""Auth + per-user ownership tests exercising the real login flow.
+
+The autouse ``isolated_db`` fixture normally overrides ``get_current_user`` so the
+rest of the suite runs authenticated. These tests pop that override to drive the
+genuine cookie-based login and ownership checks.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.core import auth as auth_core
+from backend.core import config, db
+from backend.main import app
+
+from tests.conftest import TEST_USER_EMAIL, TEST_USER_PASSWORD
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    # Use real authentication (no dependency override) on the seeded DB.
+    app.dependency_overrides.pop(auth_core.get_current_user, None)
+    monkeypatch.setattr(config.settings, "db_path", tmp_path / "test.db")
+    monkeypatch.setattr(config.settings, "auth_secret_key", "test-secret-key")
+    db.init_db()
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+def _login(client: TestClient, email: str, password: str):
+    return client.post("/auth/login", json={"email": email, "password": password})
+
+
+def test_login_sets_cookie_and_me_returns_user(client):
+    resp = _login(client, TEST_USER_EMAIL, TEST_USER_PASSWORD)
+    assert resp.status_code == 200
+    assert resp.json()["email"] == TEST_USER_EMAIL
+
+    me = client.get("/auth/me")
+    assert me.status_code == 200
+    assert me.json()["email"] == TEST_USER_EMAIL
+    assert me.json()["is_admin"] is True
+
+
+def test_login_with_wrong_password_is_rejected(client):
+    assert _login(client, TEST_USER_EMAIL, "wrong-password").status_code == 401
+
+
+def test_unauthenticated_request_is_rejected(client):
+    assert client.get("/sessions").status_code == 401
+    assert client.get("/auth/me").status_code == 401
+
+
+def test_logout_clears_session(client):
+    _login(client, TEST_USER_EMAIL, TEST_USER_PASSWORD)
+    assert client.get("/auth/me").status_code == 200
+    assert client.post("/auth/logout").status_code == 204
+    assert client.get("/auth/me").status_code == 401
+
+
+def test_admin_can_provision_user_who_can_then_login(client):
+    _login(client, TEST_USER_EMAIL, TEST_USER_PASSWORD)
+    created = client.post(
+        "/auth/users",
+        json={"email": "member@example.com", "password": "memberpass"},
+    )
+    assert created.status_code == 201
+    assert created.json()["is_admin"] is False
+
+    client.post("/auth/logout")
+    assert _login(client, "member@example.com", "memberpass").status_code == 200
+
+
+def test_duplicate_email_is_rejected(client):
+    _login(client, TEST_USER_EMAIL, TEST_USER_PASSWORD)
+    assert client.post(
+        "/auth/users",
+        json={"email": TEST_USER_EMAIL, "password": "anotherpass"},
+    ).status_code == 409
+
+
+def test_non_admin_cannot_provision_users(client):
+    _login(client, TEST_USER_EMAIL, TEST_USER_PASSWORD)
+    client.post(
+        "/auth/users",
+        json={"email": "plain@example.com", "password": "plainpass"},
+    )
+    client.post("/auth/logout")
+    _login(client, "plain@example.com", "plainpass")
+
+    resp = client.post(
+        "/auth/users",
+        json={"email": "blocked@example.com", "password": "blockedpass"},
+    )
+    assert resp.status_code == 403
+
+
+def test_sessions_are_private_per_user(client):
+    # User A creates a session.
+    _login(client, TEST_USER_EMAIL, TEST_USER_PASSWORD)
+    created = client.post("/sessions", json={"llm_model": "gpt-5"})
+    assert created.status_code == 200
+    app_session_id = created.json()["app_session_id"]
+
+    # Provision and switch to user B.
+    client.post(
+        "/auth/users",
+        json={"email": "userb@example.com", "password": "userbpass"},
+    )
+    client.post("/auth/logout")
+    _login(client, "userb@example.com", "userbpass")
+
+    # B cannot see A's session, and B's own list is empty.
+    status = client.get("/sessions/status", params={"app_session_id": app_session_id})
+    assert status.status_code == 404
+    assert client.get("/sessions").json()["sessions"] == []
+
+
+def test_cannot_remove_last_admin(client):
+    _login(client, TEST_USER_EMAIL, TEST_USER_PASSWORD)
+    admin = db.get_user_by_email(TEST_USER_EMAIL)
+    resp = client.patch(f"/auth/users/{admin['user_id']}", json={"is_active": False})
+    assert resp.status_code == 400

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,22 @@
+from backend.core.config import Settings
+
+
+def test_settings_accept_shared_deployment_env_keys(tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "\n".join(
+            [
+                "DOMAIN=http://localhost",
+                "NEXT_PUBLIC_API_BASE_URL=/api",
+                "AUTH_SECRET_KEY=test-secret",
+                "ADMIN_BOOTSTRAP_EMAIL=admin@example.com",
+                "ADMIN_BOOTSTRAP_PASSWORD=choose-a-password",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    settings = Settings(_env_file=env_file)
+
+    assert settings.auth_secret_key == "test-secret"
+    assert settings.admin_bootstrap_email == "admin@example.com"

--- a/tests/test_edit_metrics_endpoints.py
+++ b/tests/test_edit_metrics_endpoints.py
@@ -355,7 +355,7 @@ def test_case_groups_editable_rejects_invalid_app_session_id(test_client):
         "/case-groups/editable",
         params={"app_session_id": "bad id"},
     )
-    assert response.status_code == 422
+    assert response.status_code in (404, 422)
 
 
 def test_case_groups_bulk_update_rejects_unknown_case_group_ids(test_client):
@@ -563,7 +563,7 @@ def test_process_steps_editable_rejects_invalid_app_session_id(test_client):
         "/process-steps/editable",
         params={"app_session_id": "bad id"},
     )
-    assert response.status_code == 422
+    assert response.status_code in (404, 422)
 
 
 def test_process_steps_bulk_update_rejects_unknown_step_ids(test_client):

--- a/tests/test_session_activity.py
+++ b/tests/test_session_activity.py
@@ -11,6 +11,7 @@ from backend.core.norm_addressees import ADMINISTRATION, BUSINESS, CITIZENS
 from backend.core.session_activity import WORKFLOW_LEASE_SECONDS, begin_session_activity
 from backend.main import startup
 from backend.routers import sessions as sessions_router
+from tests.conftest import override_current_user
 
 
 def _seed_total_cost_ready(app_session_id: str) -> int:
@@ -281,6 +282,7 @@ def test_other_session_workflow_allowed_while_ea_activity_active(test_client, mo
         api_keys,
         model,
         workflow_activity_id,
+        user,
     ):
         session_id = db.get_session_id_by_app_id(payload.app_session_id)
         if session_id is not None:
@@ -397,6 +399,7 @@ def test_single_step_workflow_activity_released_when_final_publish_fails(monkeyp
                     ApiKeys(),
                     "test-model",
                     activity.activity_id,
+                    override_current_user(),
                 )
             )
 

--- a/tests/test_sessions_contract.py
+++ b/tests/test_sessions_contract.py
@@ -16,27 +16,28 @@ def _parse_contract(model_cls, payload):
 def test_sessions_upsert_and_list_contract(test_client):
     upsert_resp = test_client.post(
         "/sessions",
-        json={"app_session_id": "CONTRACT-UPSERT", "llm_model": "gpt-5"},
+        json={"llm_model": "gpt-5"},
     )
     assert upsert_resp.status_code == 200
     upsert_payload = upsert_resp.json()
     upsert = _parse_contract(sessions_router.SessionUpsertResponse, upsert_payload)
-    assert upsert.app_session_id == "CONTRACT-UPSERT"
+    assert upsert.app_session_id
+    assert upsert.created is True
 
     list_resp = test_client.get("/sessions", params={"limit": 1})
     assert list_resp.status_code == 200
     listed = _parse_contract(sessions_router.SessionListResponse, list_resp.json())
     assert len(listed.sessions) == 1
-    assert listed.sessions[0].app_session_id == "CONTRACT-UPSERT"
+    assert listed.sessions[0].app_session_id == upsert.app_session_id
 
 
 def test_sessions_list_includes_used_llm_models(test_client):
-    app_session_id = "CONTRACT-USED-MODELS"
     upsert_resp = test_client.post(
         "/sessions",
-        json={"app_session_id": app_session_id, "llm_model": "gpt-5"},
+        json={"llm_model": "gpt-5"},
     )
     assert upsert_resp.status_code == 200
+    app_session_id = upsert_resp.json()["app_session_id"]
 
     session_id = db.get_session_id_by_app_id(app_session_id)
     assert session_id is not None
@@ -62,12 +63,12 @@ def test_sessions_list_includes_used_llm_models(test_client):
 
 
 def test_sessions_used_llm_models_triggers_update_and_delete(test_client):
-    app_session_id = "CONTRACT-USED-MODELS-TRIGGERS"
     upsert_resp = test_client.post(
         "/sessions",
-        json={"app_session_id": app_session_id, "llm_model": "gpt-5"},
+        json={"llm_model": "gpt-5"},
     )
     assert upsert_resp.status_code == 200
+    app_session_id = upsert_resp.json()["app_session_id"]
 
     session_id = db.get_session_id_by_app_id(app_session_id)
     assert session_id is not None
@@ -104,13 +105,14 @@ def test_sessions_used_llm_models_triggers_update_and_delete(test_client):
 
 
 def test_sessions_status_contract(test_client):
-    test_client.post(
+    created = test_client.post(
         "/sessions",
-        json={"app_session_id": "CONTRACT-STATUS", "llm_model": "gpt-5"},
+        json={"llm_model": "gpt-5"},
     )
+    app_session_id = created.json()["app_session_id"]
 
     resp = test_client.get(
-        "/sessions/status", params={"app_session_id": "CONTRACT-STATUS"}
+        "/sessions/status", params={"app_session_id": app_session_id}
     )
     assert resp.status_code == 200
     status_payload = resp.json()
@@ -120,11 +122,11 @@ def test_sessions_status_contract(test_client):
 
 
 def test_sessions_edit_audit_contract(test_client):
-    app_session_id = "CONTRACT-EDIT-AUDIT"
-    test_client.post(
+    created = test_client.post(
         "/sessions",
-        json={"app_session_id": app_session_id, "llm_model": "gpt-5"},
+        json={"llm_model": "gpt-5"},
     )
+    app_session_id = created.json()["app_session_id"]
 
     update_resp = test_client.post(
         "/sessions/pay-rates",
@@ -288,22 +290,23 @@ def test_pay_rates_save_and_reset_for_laender_session_no_422(test_client):
 
 
 def test_sessions_undo_contract(test_client):
-    test_client.post(
+    created = test_client.post(
         "/sessions",
-        json={"app_session_id": "CONTRACT-UNDO", "llm_model": "gpt-5"},
+        json={"llm_model": "gpt-5"},
     )
+    app_session_id = created.json()["app_session_id"]
 
     noop_resp = test_client.post(
-        "/sessions/undo", json={"app_session_id": "CONTRACT-UNDO"}
+        "/sessions/undo", json={"app_session_id": app_session_id}
     )
     assert noop_resp.status_code == 200
     noop = _parse_contract(sessions_router.SessionUndoResponse, noop_resp.json())
     assert noop.status == "no-op"
     assert noop.message == "No completed steps"
 
-    db.update_session_summary("CONTRACT-UNDO", "Titel", "Zusammenfassung")
+    db.update_session_summary(app_session_id, "Titel", "Zusammenfassung")
     ok_resp = test_client.post(
-        "/sessions/undo", json={"app_session_id": "CONTRACT-UNDO"}
+        "/sessions/undo", json={"app_session_id": app_session_id}
     )
     assert ok_resp.status_code == 200
     undone = _parse_contract(sessions_router.SessionUndoResponse, ok_resp.json())

--- a/tests/test_sessions_deep_research.py
+++ b/tests/test_sessions_deep_research.py
@@ -309,6 +309,10 @@ def test_format_compliance_export_metadata_lines_includes_scope_disclaimer():
             "deep_research_status": "Nicht verwendet",
             "user_edit_status": "Keine bearbeiteten EA-Werte im Quellstand.",
             "source_snapshot_sha256": "abcdef123456",
+            "input_tokens": 100,
+            "output_tokens": 200,
+            "hidden_thinking_tokens": 30,
+            "estimated_cost_usd": 0.0042,
         }
     )
 
@@ -316,6 +320,8 @@ def test_format_compliance_export_metadata_lines_includes_scope_disclaimer():
     assert "jaehrlichen Erfuellungsaufwand" in joined
     assert "Einmaliger Erfuellungsaufwand ist nicht Gegenstand" in joined
     assert "Bundesebene und Landesebene" in joined
+    assert "Token:" not in joined
+    assert "Geschaetzte API-Kosten" not in joined
 
 
 def test_case_group_research_toggle_locks_after_run_started(test_client):

--- a/tests/test_sessions_deep_research.py
+++ b/tests/test_sessions_deep_research.py
@@ -154,6 +154,27 @@ def test_render_research_report_pdf_builds_document_with_lists_and_markup():
     assert pdf.startswith(b"%PDF")
 
 
+def test_research_pdf_async_helper_runs_renderer(monkeypatch):
+    calls = []
+
+    def fake_render(*args, **kwargs):
+        calls.append((args, kwargs))
+        return b"PDF"
+
+    monkeypatch.setattr(sessions_router, "_render_research_report_pdf", fake_render)
+
+    result = asyncio.run(
+        sessions_router._render_research_report_pdf_async(
+            "markdown",
+            "Titel",
+            metadata={"session": "ABC"},
+        )
+    )
+
+    assert result == b"PDF"
+    assert calls == [(("markdown", "Titel"), {"metadata": {"session": "ABC"}})]
+
+
 def test_research_pdf_heading_detection_rejects_long_heading_like_paragraphs():
     assert sessions_router._is_research_pdf_heading("# E. Erfüllungsaufwand") is True
     assert sessions_router._is_research_pdf_heading("# 4. Erfüllungsaufwand") is True

--- a/tests/test_sessions_run_all.py
+++ b/tests/test_sessions_run_all.py
@@ -2099,9 +2099,16 @@ def test_effort_step_parse_failure_applies_no_sibling_metrics_and_keeps_valid_pe
 ):
     app_session_id = "STEP-EFFORT-ATOMIC-FAIL"
     session_id = _seed_step6_prerequisites(app_session_id)
+    calls: dict[tuple[str, str], int] = {}
 
     async def fake_effort_llm(prompt, *_args, **_kwargs):
         addressee = _detect_addressee_from_prompt(prompt)
+        prompt_id = (
+            PromptId.EFFORT_CALCULATION
+            if _is_effort_prompt(prompt)
+            else PromptId.CASES_CALCULATION
+        )
+        calls[(prompt_id, addressee)] = calls.get((prompt_id, addressee), 0) + 1
         processes = db.list_processes_for_session_and_addressee(session_id, addressee)
         case_groups = db.list_case_groups_for_session_and_addressee(session_id, addressee)
         steps = db.list_process_steps_for_session_and_addressee(session_id, addressee)
@@ -2190,8 +2197,221 @@ def test_effort_step_parse_failure_applies_no_sibling_metrics_and_keeps_valid_pe
     for addressee in (ADMINISTRATION, CITIZENS):
         assert by_key[(PromptId.CASES_CALCULATION, addressee)]["answer_state"] == "pending"
         assert by_key[(PromptId.EFFORT_CALCULATION, addressee)]["answer_state"] == "pending"
-    assert by_key[(PromptId.CASES_CALCULATION, BUSINESS)]["answer_state"] == "invalid"
+        assert (
+            by_key[(PromptId.CASES_CALCULATION, addressee)]["state_reason"]
+            == "waiting_for_paired_retry"
+        )
+        assert (
+            by_key[(PromptId.EFFORT_CALCULATION, addressee)]["state_reason"]
+            == "waiting_for_paired_retry"
+        )
+    assert by_key[(PromptId.CASES_CALCULATION, BUSINESS)]["answer_state"] == "pending"
+    assert (
+        by_key[(PromptId.CASES_CALCULATION, BUSINESS)]["state_reason"]
+        == "waiting_for_paired_retry"
+    )
     assert by_key[(PromptId.EFFORT_CALCULATION, BUSINESS)]["answer_state"] == "invalid"
+    assert by_key[(PromptId.EFFORT_CALCULATION, BUSINESS)]["state_reason"].startswith(
+        "session_update_failed"
+    )
+
+    async def retry_business_effort_only(prompt, *_args, **_kwargs):
+        addressee = _detect_addressee_from_prompt(prompt)
+        assert addressee == BUSINESS
+        assert _is_effort_prompt(prompt)
+        calls[(PromptId.EFFORT_CALCULATION, addressee)] = (
+            calls.get((PromptId.EFFORT_CALCULATION, addressee), 0) + 1
+        )
+        processes = db.list_processes_for_session_and_addressee(session_id, addressee)
+        case_groups = db.list_case_groups_for_session_and_addressee(session_id, addressee)
+        steps = db.list_process_steps_for_session_and_addressee(session_id, addressee)
+        return json.dumps(
+            {
+                "prozesse": [
+                    {
+                        "prozess_id": str(processes[0]["process_id"]),
+                        "fallgruppen": [
+                            {
+                                "fallgruppen_id": str(case_groups[0]["case_group_id"]),
+                                "taetigkeiten": [
+                                    {
+                                        "taetigkeiten_id": str(steps[0]["step_id"]),
+                                        "personalaufwand_vorschlag": [
+                                            _personalaufwand_row(addressee, "30")
+                                        ],
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
+
+    monkeypatch.setattr(effort_router, "query_llm", retry_business_effort_only)
+    retry_response = test_client.post(
+        "/sessions/step-runs/start",
+        json={
+            "app_session_id": app_session_id,
+            "step_key": "effort",
+            "model": "test-model",
+            "provider": "openai",
+        },
+    )
+    assert retry_response.status_code == 200
+    retry_payload = _wait_for_run_completion(test_client, retry_response.json()["run_id"])
+    assert retry_payload["status"] == "completed"
+    assert db.has_effort_metrics(session_id, ADMINISTRATION)
+    assert db.has_effort_metrics(session_id, BUSINESS)
+    assert db.has_effort_metrics(session_id, CITIZENS)
+    assert calls == {
+        (PromptId.CASES_CALCULATION, ADMINISTRATION): 1,
+        (PromptId.EFFORT_CALCULATION, ADMINISTRATION): 1,
+        (PromptId.CASES_CALCULATION, BUSINESS): 1,
+        (PromptId.EFFORT_CALCULATION, BUSINESS): 2,
+        (PromptId.CASES_CALCULATION, CITIZENS): 1,
+        (PromptId.EFFORT_CALCULATION, CITIZENS): 1,
+    }
+
+
+def test_effort_step_cases_failure_keeps_valid_effort_pending_and_reuses_it(
+    test_client,
+    monkeypatch,
+):
+    app_session_id = "STEP-EFFORT-CASES-FAIL"
+    session_id = _seed_step6_prerequisites(app_session_id)
+    calls: dict[tuple[str, str], int] = {}
+
+    def cases_payload(addressee: str) -> str:
+        processes = db.list_processes_for_session_and_addressee(session_id, addressee)
+        case_groups = db.list_case_groups_for_session_and_addressee(session_id, addressee)
+        return json.dumps(
+            {
+                "prozesse": [
+                    {
+                        "prozess_id": str(processes[0]["process_id"]),
+                        "fallgruppen": [
+                            {
+                                "fallgruppen_id": str(case_groups[0]["case_group_id"]),
+                                "anzahl_betroffene_vorschlag": "10",
+                                "haeufigkeit_pro_jahr_vorschlag": "2",
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
+
+    def effort_payload(addressee: str) -> str:
+        processes = db.list_processes_for_session_and_addressee(session_id, addressee)
+        case_groups = db.list_case_groups_for_session_and_addressee(session_id, addressee)
+        steps = db.list_process_steps_for_session_and_addressee(session_id, addressee)
+        if addressee == CITIZENS:
+            effort_entry = {
+                "taetigkeiten_id": str(steps[0]["step_id"]),
+                "zeitaufwand_in_min_vorschlag": "30",
+                "sachaufwand_vorschlag": "10",
+            }
+        else:
+            effort_entry = {
+                "taetigkeiten_id": str(steps[0]["step_id"]),
+                "personalaufwand_vorschlag": [_personalaufwand_row(addressee, "30")],
+            }
+        return json.dumps(
+            {
+                "prozesse": [
+                    {
+                        "prozess_id": str(processes[0]["process_id"]),
+                        "fallgruppen": [
+                            {
+                                "fallgruppen_id": str(case_groups[0]["case_group_id"]),
+                                "taetigkeiten": [effort_entry],
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
+
+    async def first_effort_llm(prompt, *_args, **_kwargs):
+        addressee = _detect_addressee_from_prompt(prompt)
+        prompt_id = (
+            PromptId.EFFORT_CALCULATION
+            if _is_effort_prompt(prompt)
+            else PromptId.CASES_CALCULATION
+        )
+        calls[(prompt_id, addressee)] = calls.get((prompt_id, addressee), 0) + 1
+        if prompt_id == PromptId.CASES_CALCULATION and addressee == BUSINESS:
+            return '{"prozesse": ['
+        if prompt_id == PromptId.CASES_CALCULATION:
+            return cases_payload(addressee)
+        return effort_payload(addressee)
+
+    monkeypatch.setattr(effort_router, "query_llm", first_effort_llm)
+    start_response = test_client.post(
+        "/sessions/step-runs/start",
+        json={
+            "app_session_id": app_session_id,
+            "step_key": "effort",
+            "model": "test-model",
+            "provider": "openai",
+        },
+    )
+    assert start_response.status_code == 200
+    payload = _wait_for_run_completion(test_client, start_response.json()["run_id"])
+    assert payload["status"] == "failed"
+    assert "Die Antwort für Wirtschaft konnte nicht verarbeitet werden" in payload["last_error"]
+    assert not db.has_effort_metrics(session_id, BUSINESS)
+
+    rows = [
+        row
+        for row in db.list_recent_llm_answers_for_session(session_id)
+        if row["prompt_id"] in {PromptId.CASES_CALCULATION, PromptId.EFFORT_CALCULATION}
+    ]
+    by_key = {(row["prompt_id"], row["norm_addressee"]): row for row in rows}
+    assert by_key[(PromptId.CASES_CALCULATION, BUSINESS)]["answer_state"] == "invalid"
+    assert by_key[(PromptId.CASES_CALCULATION, BUSINESS)]["state_reason"].startswith(
+        "session_update_failed"
+    )
+    assert by_key[(PromptId.EFFORT_CALCULATION, BUSINESS)]["answer_state"] == "pending"
+    assert (
+        by_key[(PromptId.EFFORT_CALCULATION, BUSINESS)]["state_reason"]
+        == "waiting_for_paired_retry"
+    )
+
+    async def retry_business_cases_only(prompt, *_args, **_kwargs):
+        addressee = _detect_addressee_from_prompt(prompt)
+        assert addressee == BUSINESS
+        assert not _is_effort_prompt(prompt)
+        calls[(PromptId.CASES_CALCULATION, addressee)] = (
+            calls.get((PromptId.CASES_CALCULATION, addressee), 0) + 1
+        )
+        return cases_payload(addressee)
+
+    monkeypatch.setattr(effort_router, "query_llm", retry_business_cases_only)
+    retry_response = test_client.post(
+        "/sessions/step-runs/start",
+        json={
+            "app_session_id": app_session_id,
+            "step_key": "effort",
+            "model": "test-model",
+            "provider": "openai",
+        },
+    )
+    assert retry_response.status_code == 200
+    retry_payload = _wait_for_run_completion(test_client, retry_response.json()["run_id"])
+    assert retry_payload["status"] == "completed"
+    assert db.has_effort_metrics(session_id, ADMINISTRATION)
+    assert db.has_effort_metrics(session_id, BUSINESS)
+    assert db.has_effort_metrics(session_id, CITIZENS)
+    assert calls == {
+        (PromptId.CASES_CALCULATION, ADMINISTRATION): 1,
+        (PromptId.EFFORT_CALCULATION, ADMINISTRATION): 1,
+        (PromptId.CASES_CALCULATION, BUSINESS): 2,
+        (PromptId.EFFORT_CALCULATION, BUSINESS): 1,
+        (PromptId.CASES_CALCULATION, CITIZENS): 1,
+        (PromptId.EFFORT_CALCULATION, CITIZENS): 1,
+    }
 
 
 def test_effort_step_tile_refresh_failure_rolls_back_metrics_and_answers(

--- a/tests/test_sessions_validation.py
+++ b/tests/test_sessions_validation.py
@@ -1,9 +1,13 @@
-def test_upsert_session_rejects_invalid_app_session_id(test_client):
+def test_upsert_session_ignores_client_app_session_id(test_client):
+    # app_session_id is now server-generated; any client-supplied value is ignored.
     resp = test_client.post(
         "/sessions",
         json={"app_session_id": "bad id", "llm_model": "gpt-5"},
     )
-    assert resp.status_code == 422
+    assert resp.status_code == 200
+    app_session_id = resp.json()["app_session_id"]
+    assert app_session_id != "bad id"
+    assert app_session_id.isalnum()
 
 
 def test_upsert_session_rejects_blank_model_name(test_client):
@@ -15,19 +19,20 @@ def test_upsert_session_rejects_blank_model_name(test_client):
 
 
 def test_status_rejects_invalid_app_session_id_query(test_client):
+    # Malformed/unknown id is rejected by the ownership gate (404) or pattern (422).
     resp = test_client.get("/sessions/status", params={"app_session_id": "bad id"})
-    assert resp.status_code == 422
+    assert resp.status_code in (404, 422)
 
 
 def test_upsert_session_response_shape(test_client):
     resp = test_client.post(
         "/sessions",
-        json={"app_session_id": "ABC123", "llm_model": "gpt-5"},
+        json={"llm_model": "gpt-5"},
     )
     assert resp.status_code == 200
     payload = resp.json()
     assert set(payload.keys()) == {"app_session_id", "created"}
-    assert payload["app_session_id"] == "ABC123"
+    assert isinstance(payload["app_session_id"], str) and payload["app_session_id"]
     assert isinstance(payload["created"], bool)
 
 
@@ -46,8 +51,9 @@ def test_list_sessions_response_shape(test_client):
 
 
 def test_undo_noop_response_shape(test_client):
-    test_client.post("/sessions", json={"app_session_id": "UNDO00", "llm_model": "gpt-5"})
-    resp = test_client.post("/sessions/undo", json={"app_session_id": "UNDO00"})
+    created = test_client.post("/sessions", json={"llm_model": "gpt-5"})
+    app_session_id = created.json()["app_session_id"]
+    resp = test_client.post("/sessions/undo", json={"app_session_id": app_session_id})
     assert resp.status_code == 200
     payload = resp.json()
     assert payload["status"] == "no-op"

--- a/tests/test_tiles_session_scope.py
+++ b/tests/test_tiles_session_scope.py
@@ -20,19 +20,18 @@ def _tile_payload(tile_id: str, title: str) -> dict:
 
 
 def test_tiles_are_scoped_by_app_session_id(test_client):
-    session_a = "SCOPE-A"
-    session_b = "SCOPE-B"
-
     resp_a = test_client.post(
         "/sessions",
-        json={"app_session_id": session_a, "llm_model": "test-model"},
+        json={"llm_model": "test-model"},
     )
     assert resp_a.status_code == 200
+    session_a = resp_a.json()["app_session_id"]
     resp_b = test_client.post(
         "/sessions",
-        json={"app_session_id": session_b, "llm_model": "test-model"},
+        json={"llm_model": "test-model"},
     )
     assert resp_b.status_code == 200
+    session_b = resp_b.json()["app_session_id"]
 
     create_a = test_client.post(
         f"/tiles?app_session_id={session_a}",
@@ -57,16 +56,14 @@ def test_tiles_are_scoped_by_app_session_id(test_client):
 
 
 def test_tile_delete_is_scoped_by_session(test_client):
-    session_a = "DEL-A"
-    session_b = "DEL-B"
-    test_client.post(
+    session_a = test_client.post(
         "/sessions",
-        json={"app_session_id": session_a, "llm_model": "test-model"},
-    )
-    test_client.post(
+        json={"llm_model": "test-model"},
+    ).json()["app_session_id"]
+    session_b = test_client.post(
         "/sessions",
-        json={"app_session_id": session_b, "llm_model": "test-model"},
-    )
+        json={"llm_model": "test-model"},
+    ).json()["app_session_id"]
 
     test_client.post(
         f"/tiles?app_session_id={session_a}",


### PR DESCRIPTION
## Summary
Containerizes CCC for production and adds an authentication + per-user
ownership layer, merged up to the latest `develop`.

### Deployment
- Caddy reverse proxy (TLS, same-origin `/api`, SSE-safe), backend/frontend
  Dockerfiles (Next standalone), single-replica `docker-compose.yml` with a
  persistent DB volume. Guides: `DEPLOY.md`, `DEPLOY_LOCAL.md`.
- SQLite WAL + busy_timeout; PDF rendering moved off the event loop; fonts
  vendored via `@fontsource` (offline builds).

### Authentication (built-in email + password, admin-provisioned)
- `users` table, bcrypt hashing, JWT in an httpOnly cookie; `/auth` login/
  logout/me + admin-only user CRUD; bootstrap admin from env; email allowlist.
- Frontend: AuthContext + login gate, logout + user email in header, admin panel.

### Per-user ownership (private sessions)
- `owner_user_id` on `sessions`; auth required on every app router; ownership
  gate on read/edit endpoints; server-generated session ids; `GET /sessions`
  scoped to the caller; cross-user access → 404. User threaded through the
  run-all chain.

### Merge with develop
- Reconciled with develop's wage-model refactor, session-activity locking, and
  atomic per-addressee step runs (re-applied auth onto develop's atomic runners).

## Validation
- Backend: 562 passed · Frontend: 192 passed · eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)