### PR TITLE
IP-Anzeige der Wirtschaft (#24) und beispielkonformer Vorblatt-/Begründungs-Export (#66)

### DIFF
--- a/backend/core/compliance_text_export.py
+++ b/backend/core/compliance_text_export.py
@@ -224,16 +224,25 @@ def _build_addressee_payload(
         for group in process_groups:
             group["taetigkeiten"] = steps_by_group.get(int(group["fallgruppen_id"]), [])
 
+    serialized_vorgaben = [_serialize_regulation(row) for row in regulations]
+    vorgaben_by_process: dict[int, list[dict[str, Any]]] = {}
+    for row, serialized in zip(regulations, serialized_vorgaben):
+        process_id = row.get("process_id")
+        if process_id is None:
+            continue
+        vorgaben_by_process.setdefault(int(process_id), []).append(serialized)
+
     return {
         "normadressat": norm_addressee,
         "lohnsaetze": serialized_pay_rates,
-        "vorgaben": [_serialize_regulation(row) for row in regulations],
+        "vorgaben": serialized_vorgaben,
         "prozesse": [
             {
                 "prozess_id": int(process["process_id"]),
                 "prozess_bezeichnung": process.get("process"),
                 "prozess_beschreibung": process.get("description"),
                 "aenderungsstatus": process.get("change_status"),
+                "vorgaben": vorgaben_by_process.get(int(process["process_id"]), []),
                 "kosten": process_costs.get(
                     int(process["process_id"]), process.get("cost")
                 ),

--- a/backend/core/compliance_text_export.py
+++ b/backend/core/compliance_text_export.py
@@ -179,6 +179,8 @@ def _build_addressee_payload(
             "norm_addressee": norm_addressee,
             "total_cost": cost["total_cost"],
             "bureaucracy_cost": cost["bureaucracy_cost"],
+            "verwaltung_bundesebene": cost["verwaltung_bundesebene"],
+            "verwaltung_landesebene": cost["verwaltung_landesebene"],
             "total_time_minutes": cost["total_time_minutes"],
             "total_expenses": cost["total_expenses"],
         }

--- a/backend/core/cost_aggregation.py
+++ b/backend/core/cost_aggregation.py
@@ -79,6 +79,45 @@ def _compute_step_personnel_cost_from_rows(
     return total
 
 
+_ADMIN_LEVEL_BUCKET: dict[str, str] = {
+    "bund": "bund",
+    "laender": "land",
+    "kommunen": "land",
+}
+
+
+def _personnel_cost_by_level(
+    period_rows: list[dict], wage_overrides: dict
+) -> dict[str, float]:
+    by_level: dict[str, float] = {}
+    for row in period_rows:
+        bucket = _ADMIN_LEVEL_BUCKET.get(row["wage_source_value"])
+        if bucket is None:
+            continue
+        edited = row.get("time_required_in_min_edited")
+        minutes = edited if edited is not None else row.get("time_required_in_min")
+        cost = _resolve_personnel_rate(row, wage_overrides) * (_safe_number(minutes) / 60.0)
+        by_level[bucket] = by_level.get(bucket, 0.0) + cost
+    return by_level
+
+
+def _step_cost_by_level(
+    period_rows: list[dict], wage_overrides: dict, expenses: float
+) -> dict[str, float]:
+    by_level = _personnel_cost_by_level(period_rows, wage_overrides)
+    if not expenses or not by_level:
+        return by_level
+    personnel_total = sum(by_level.values())
+    if personnel_total > 0:
+        for bucket in by_level:
+            by_level[bucket] += expenses * (by_level[bucket] / personnel_total)
+    else:
+        share = expenses / len(by_level)
+        for bucket in by_level:
+            by_level[bucket] += share
+    return by_level
+
+
 def _compute_step_time_minutes(step: dict, suffix: str) -> float:
     total = 0.0
     for key in ["a", "b", "c", "d"]:
@@ -269,6 +308,8 @@ def _compute_step_metrics(
 
     for step in steps:
         step_id = int(step["step_id"])
+        level_current: dict[str, float] | None = None
+        level_proposed: dict[str, float] | None = None
         if norm_addressee == CITIZENS:
             cost_current = _safe_number(step.get("expenses_current_effective"))
             cost_proposed = _safe_number(step.get("expenses_proposed_effective"))
@@ -284,6 +325,15 @@ def _compute_step_metrics(
                 cost_proposed = _compute_step_personnel_cost_from_rows(
                     proposed_rows, wage_overrides
                 ) + _safe_number(step.get("expenses_proposed_effective"))
+                if norm_addressee == ADMINISTRATION:
+                    level_current = _step_cost_by_level(
+                        current_rows, wage_overrides,
+                        _safe_number(step.get("expenses_current_effective")),
+                    )
+                    level_proposed = _step_cost_by_level(
+                        proposed_rows, wage_overrides,
+                        _safe_number(step.get("expenses_proposed_effective")),
+                    )
             else:
                 # Legacy fallback (old sessions without child rows / migration).
                 cost_current = _compute_step_cost(
@@ -308,6 +358,8 @@ def _compute_step_metrics(
         per_case_flags[step_id] = bool(step.get("execution_per_case")) if step.get("execution_per_case") is not None else True
         step["cost_current"] = cost_current
         step["cost_proposed"] = cost_proposed
+        step["level_cost_current"] = level_current
+        step["level_cost_proposed"] = level_proposed
 
     return (
         step_costs_current,
@@ -360,6 +412,8 @@ def _aggregate_case_group_costs(
         time_total_proposed = 0.0
         expenses_total_current = 0.0
         expenses_total_proposed = 0.0
+        level_current_totals: dict[str, float] = {}
+        level_proposed_totals: dict[str, float] = {}
         for step_id in case_steps:
             step_effective = effective_steps_by_id.get(step_id, {})
             step_multiplier_current = cases_current if per_case_flags.get(step_id, True) else 1.0
@@ -380,7 +434,27 @@ def _aggregate_case_group_costs(
             expenses_total_proposed += _safe_number(
                 step_effective.get("expenses_proposed_effective")
             ) * step_multiplier_proposed
+            step_level_current = step_effective.get("level_cost_current")
+            if step_level_current:
+                for bucket, value in step_level_current.items():
+                    level_current_totals[bucket] = (
+                        level_current_totals.get(bucket, 0.0)
+                        + value * step_multiplier_current
+                    )
+            step_level_proposed = step_effective.get("level_cost_proposed")
+            if step_level_proposed:
+                for bucket, value in step_level_proposed.items():
+                    level_proposed_totals[bucket] = (
+                        level_proposed_totals.get(bucket, 0.0)
+                        + value * step_multiplier_proposed
+                    )
         cost_delta = cost_proposed - cost_current
+        level_buckets = set(level_current_totals) | set(level_proposed_totals)
+        group["level_cost_delta"] = {
+            bucket: level_proposed_totals.get(bucket, 0.0)
+            - level_current_totals.get(bucket, 0.0)
+            for bucket in level_buckets
+        }
         group["cases_current"] = cases_current
         group["cases_proposed"] = cases_proposed
         group["cost"] = cost_delta
@@ -589,6 +663,17 @@ def aggregate_addressee_costs(
     bureaucracy_cost = (
         sum(process_bureaucracy_costs.values()) if norm_addressee == BUSINESS else None
     )
+    verwaltung_bundesebene: float | None = None
+    verwaltung_landesebene: float | None = None
+    if norm_addressee == ADMINISTRATION and any(
+        step.get("level_cost_current") is not None for step in effective_steps
+    ):
+        level_totals: dict[str, float] = {}
+        for group in effective_case_groups:
+            for bucket, value in (group.get("level_cost_delta") or {}).items():
+                level_totals[bucket] = level_totals.get(bucket, 0.0) + value
+        verwaltung_bundesebene = level_totals.get("bund", 0.0)
+        verwaltung_landesebene = level_totals.get("land", 0.0)
     total_time_minutes = (
         sum(process_time_deltas.values()) if norm_addressee == CITIZENS else None
     )
@@ -610,6 +695,8 @@ def aggregate_addressee_costs(
         "process_costs": process_costs,
         "total_cost": total_cost,
         "bureaucracy_cost": bureaucracy_cost,
+        "verwaltung_bundesebene": verwaltung_bundesebene,
+        "verwaltung_landesebene": verwaltung_landesebene,
         "total_time_minutes": total_time_minutes,
         "total_expenses": total_expenses,
     }

--- a/backend/core/payload_builders.py
+++ b/backend/core/payload_builders.py
@@ -102,6 +102,21 @@ def _project_normadressaten(
     return projected or all_addressees
 
 
+def _project_information_obligation(
+    row: dict,
+    norm_addressee: str | None,
+) -> bool:
+    """Das IP-Flag ist ausschliesslich fuer die Wirtschaft definiert.
+
+    In Laeufen anderer Normadressaten wuerde ein `true` im Widerspruch zu den
+    auf den Run projizierten `normadressaten` stehen (siehe
+    `_project_normadressaten`), weshalb es dort unterdrueckt wird.
+    """
+    if norm_addressee is not None and norm_addressee != BUSINESS:
+        return False
+    return bool(row.get("is_business_information_obligation"))
+
+
 def build_vorgaben_payload(
     regulations: list[dict],
     *,
@@ -116,8 +131,8 @@ def build_vorgaben_payload(
                 beschreibung=str(row.get("description") or ""),
                 aenderungsstatus=row.get("change_status"),
                 normadressaten=_project_normadressaten(row, norm_addressee),
-                ist_informationspflicht_wirtschaft=bool(
-                    row.get("is_business_information_obligation")
+                ist_informationspflicht_wirtschaft=_project_information_obligation(
+                    row, norm_addressee
                 ),
             ).model_dump()
         )
@@ -136,8 +151,8 @@ def _serialize_process_regulations(
             beschreibung=str(row.get("description") or ""),
             aenderungsstatus=row.get("change_status"),
             normadressaten=_project_normadressaten(row, norm_addressee),
-            ist_informationspflicht_wirtschaft=bool(
-                row.get("is_business_information_obligation")
+            ist_informationspflicht_wirtschaft=_project_information_obligation(
+                row, norm_addressee
             ),
         )
         for row in regs_by_process.get(process_id, [])

--- a/backend/core/prompts.py
+++ b/backend/core/prompts.py
@@ -1545,6 +1545,7 @@ PROMPT_TEMPLATES: Dict[str, str] = {
         - Wirtschaft und Verwaltung: Aufwand grundsätzlich in Euro beziehungsweise Tsd. Euro darstellen.
         - Werte in Tabellen grundsätzlich in Tsd. Euro ausweisen, sofern die JSON-Struktur nichts anderes vorgibt.
         - Im Fließtext können gerundete Werte in Euro, Tsd. Euro oder Mio. Euro verwendet werden; die Rundung muss konsistent sein.
+        - Euro-Beträge werden auf ganze Euro gerundet; Cent werden nicht ausgewiesen, also `14 017 747 Euro` statt `14 017 746,67 Euro`.
         - Bürgerzeit wird nicht monetarisiert, es sei denn, die JSON-Struktur enthält ausdrücklich eine solche Monetarisierung.
         - Verwende deutsche Zahlenformatierung, soweit dies für Gesetzesbegründungen üblich ist, zum Beispiel `1 000 Euro`, `1,5 Mio. Euro`, `100 000 Euro`.
 

--- a/backend/core/prompts.py
+++ b/backend/core/prompts.py
@@ -1410,12 +1410,14 @@ PROMPT_TEMPLATES: Dict[str, str] = {
 
         `Für die Wirtschaft entsteht kein jährlicher Erfüllungsaufwand.`
 
-        `Keine` ist nur zulässig, wenn keine Wirtschafts-Vorgabe das Feld `ist_informationspflicht_wirtschaft = true` trägt:
+        `Keine` ist nur zulässig, wenn keine Wirtschafts-Vorgabe das Feld `ist_informationspflicht_wirtschaft = true` trägt. Gib dann
+        unter der Überschrift ausschließlich aus:
 
-        `Davon Bürokratiekosten aus Informationspflichten: Keine.`
+        `Keine.`
 
         Trägt mindestens eine Wirtschafts-Vorgabe dieses Flag, sind diese Vorgaben als Informationspflicht auszuweisen und der Saldo
-        `summen.bureaucracy_cost` ist zu nennen, auch wenn er 0 Euro beträgt (dann als geringfügig bzw. 0 Euro).
+        `summen.bureaucracy_cost` ist zu nennen, auch wenn er 0 Euro beträgt (dann als geringfügig bzw. 0 Euro). Formuliere dann einen
+        Satz, ohne die Überschrift zu wiederholen, zum Beispiel `Davon entfallen [Wert] auf Bürokratiekosten aus Informationspflichten.`
 
         Wenn Angaben fehlen:
 
@@ -1463,23 +1465,55 @@ PROMPT_TEMPLATES: Dict[str, str] = {
         Greife die Aufteilung des Verwaltungsaufwands auf Bundesebene (`summen.verwaltung_bundesebene`) und Landesebene einschließlich
         Kommunen (`summen.verwaltung_landesebene`) aus dem Vorblatt auf.
 
-        Für jede Vorgabe ist, soweit einschlägig, eine kurze Überschrift zu verwenden:
+        Stelle je Normadressat genau eine konsolidierte Berechnungstabelle dar. Verwende keine eigene Zwischenüberschrift je Vorgabe. Die
+        Spalte `Norm (§§); Bezeichnung der Vorgabe` nennt Fundstelle und Bezeichnung aus der je Prozess mitgelieferten Liste `vorgaben`
+        (Feld `normzitat`). Nummeriere die Zeilen in der Spalte `lfd. Nr.` fortlaufend je Abschnitt (4.1.1, 4.1.2, …; 4.2.1, …; 4.3.1, …).
 
-        ### Vorgabe [Nummer]: [kurzes Stichwort]; [Norm]
+        Grundsätzlich steht eine Vorgabe in einer eigenen Zeile. Werden mehrere Vorgaben innerhalb eines Prozesses gemeinsam berechnet,
+        teilen sie sich eine Zeile; nenne in der Vorgaben-Spalte alle betroffenen Vorgaben und teile den gemeinsam ermittelten Aufwand
+        nicht künstlich auf einzelne Vorgaben auf.
 
-        Die Überschrift darf nicht länger als eine kurze Zeile sein. Ausführliche Bezeichnungen, Fallgruppentitel und fachliche
-        Differenzierungen sind im anschließenden Absatz oder in einer Tabelle darzustellen.
+        Alle Werte sind die jährliche Änderung des Erfüllungsaufwands; Entlastungen werden mit negativem Vorzeichen geführt (zum Beispiel
+        `-52.496` oder `-1.088.000 Stunden`). Es wird kein einmaliger Erfüllungsaufwand berechnet oder ausgewiesen; entsprechende Spalten
+        entfallen. Die Spalte `Jährlicher Aufwand pro Fall` enthält die Änderung pro Fall mit Formel und Herleitung inline, zum Beispiel
+        `-0,6 Euro = (-1 / 60 * 38,60 Euro/h (WZ: A-S ohne O))` oder `737.000 Euro = (4 hD-Stellen * 108.160 Euro/Stelle) + 175.000 Euro`.
+
+        Für Bürgerinnen und Bürger (4.1) verwende die Struktur:
+
+        | lfd. Nr. | Norm (§§); Bezeichnung der Vorgabe | Jährliche Fallzahl und Einheit | Jährlicher Aufwand pro Fall (in Minuten bzw. Euro) | Jährlicher Erfüllungsaufwand (in Stunden bzw. Tsd. Euro) oder „geringfügig“ (Begründung) |
+        |---|---|---:|---|---:|
+
+        Ergänze unter der Tabelle die Summenzeilen `Summe Zeitaufwand (in Stunden)` und `Summe Sachaufwand (in Tsd. Euro)` über alle
+        Vorgaben.
+
+        Für die Wirtschaft (4.2) verwende die Struktur:
+
+        | lfd. Nr. | Norm (§§); Bezeichnung der Vorgabe | IP | Jährliche Fallzahl und Einheit | Jährlicher Aufwand pro Fall (Minuten * Lohnkosten pro Stunde + Sachkosten in Euro) | Jährlicher Erfüllungsaufwand (in Tsd. Euro) oder „geringfügig“ (Begründung) |
+        |---|---|---|---:|---|---:|
+
+        In der Spalte `IP` steht `Ja`, wenn die Vorgabe das Feld `ist_informationspflicht_wirtschaft` mit dem Wert `true` trägt, sonst
+        bleibt die Zelle leer. Schätze den Informationspflicht-Status nicht selbst ein. Ergänze unter der Tabelle die Summenzeilen
+        `Summe (in Tsd. Euro)` (Saldo über alle Vorgaben) und `…davon aus Informationspflichten (IP)` (übernimm den Wert
+        `summen.bureaucracy_cost` des Wirtschaftsblocks, Entlastung negativ, und rechne ihn nicht aus den Einzelzeilen zusammen).
+
+        Für die Verwaltung (4.3) verwende die Struktur:
+
+        | lfd. Nr. | Norm (§§); Bezeichnung der Vorgabe | Jährliche Fallzahl und Einheit | Jährlicher Aufwand pro Fall (Minuten * Lohnkosten pro Stunde + Sachkosten in Euro) | Jährlicher Erfüllungsaufwand (in Tsd. Euro) oder „geringfügig“ (Begründung) |
+        |---|---|---:|---|---:|
+
+        Ergänze unter der Tabelle die Summenzeilen `Summe (in Tsd. Euro)`, `davon auf Bundesebene` (Wert
+        `summen.verwaltung_bundesebene`) und `davon auf Landesebene (inklusive Kommunen)` (Wert `summen.verwaltung_landesebene`). Führe
+        die Aufteilung auf Bund und Land nur in diesen Summenzeilen, nicht als eigene Spalte je Tabellenzeile.
+
+        Vorgaben mit einer jährlichen Be- oder Entlastung von betragsmäßig höchstens 100 000 Euro werden als eigene Zeile mit
+        `geringfügig` in der Ergebnisspalte geführt; die Begründung steht in der Fußnote.
+
+        Unter jeder Tabelle folgen knappe Fußnoten je Zeile im Format `**Zu lfd. Nr. X:** [Bezeichnung]; [Norm]` mit der Herleitung von
+        Fallzahl, Zeitaufwand, Lohnsatz und Sachkosten. Überfrachte die Tabellenzellen nicht; die Herleitung gehört in die Fußnote. Gib
+        je Vorgabe an, dass es sich um jährlichen Erfüllungsaufwand handelt, sowie den EU-Bezug, sofern die JSON-Struktur hierzu Angaben
+        enthält.
+
         Fallgruppen dürfen nicht als eigene Markdown-Überschriften und nicht als fett gesetzte Abschnittstitel ausgegeben werden.
-        Wenn mehrere Fallgruppen dargestellt werden, verwende normale Listenpunkte oder Tabellenzeilen, zum Beispiel
-        `- Erstanerkennungsverfahren (Fallgruppe 1): ...`.
-
-        Gib je Vorgabe an:
-
-        - dass es sich um jährlichen Erfüllungsaufwand handelt,
-        - den Normadressaten,
-        - bei Wirtschaft: ob es sich um eine Informationspflicht handelt, und zwar genau dann, wenn das Feld
-          `ist_informationspflicht_wirtschaft` den Wert `true` hat,
-        - den EU-Bezug nur dann, wenn die JSON-Struktur hierzu Angaben enthält.
 
         ---
 
@@ -1487,47 +1521,16 @@ PROMPT_TEMPLATES: Dict[str, str] = {
 
         Diese Darstellungsregeln sind Arbeitsanweisungen. Sie sind nicht als eigene Überschriften in den finalen Entwurf zu übernehmen.
 
-        ### Vorgaben bis einschließlich 100 000 Euro jährlich
+        Vorgaben mit einer jährlichen Be- oder Entlastung von betragsmäßig höchstens 100 000 Euro werden nicht gesondert berechnet. Sie
+        erscheinen als eigene Zeile der Abschnittstabelle mit `geringfügig` in der Ergebnisspalte; die Fußnote unter der Tabelle nennt
+        kurz die Begründung, insbesondere die geringe Fallzahl und/oder den geringen Zeit- oder Sachaufwand.
 
-        Wenn der Betrag der jährlichen Be- oder Entlastung höchstens 100 000 Euro beträgt, genügt eine kurze Listendarstellung mit:
+        Vorgaben mit einer jährlichen Be- oder Entlastung über 100 000 Euro werden in der Abschnittstabelle nach der jeweiligen Struktur
+        aus Abschnitt 4 mit ihren Berechnungswerten dargestellt.
 
-        - Bezeichnung der Vorgabe,
-        - Fundstelle im Regelungstext,
-        - Normadressat,
-        - jährlicher Erfüllungsaufwand oder jährliche Entlastung,
-        - kurze Begründung, insbesondere geringe Fallzahl und/oder geringer Zeit- oder Sachaufwand.
-
-        Eine Berechnungstabelle ist nur erforderlich, wenn die JSON-Struktur sie enthält oder die Nachvollziehbarkeit dies verlangt.
-
-        ### Vorgaben über 100 000 Euro jährlich
-
-        Wenn der Betrag der jährlichen Be- oder Entlastung über 100 000 Euro liegt, ist eine Markdown-Tabelle zu erstellen.
-
-        Für Bürgerinnen und Bürger soll die Tabelle grundsätzlich folgende Struktur verwenden:
-
-        | Fallzahl | Zeitaufwand pro Fall in Minuten | Sachkosten pro Fall in Euro | Zeitaufwand in Stunden | Sachkosten in Tsd. Euro |
-        |---:|---:|---:|---:|---:|
-
-        Für Wirtschaft und Verwaltung soll die Tabelle grundsätzlich folgende Struktur verwenden:
-
-        | Fallzahl | Zeitaufwand pro Fall in Minuten | Lohnsatz pro Stunde in Euro | Sachkosten pro Fall in Euro | Personalkosten in Tsd. Euro | Sachkosten in Tsd. Euro |
-        |---:|---:|---:|---:|---:|---:|
-
-        Wenn die JSON-Struktur eine andere oder zusätzliche sinnvolle Differenzierung enthält, etwa Laufbahngruppe, Tätigkeitskategorie,
-        Stelle, Vorgabenart oder Sachkostenart, darf die Tabelle entsprechend angepasst werden. Die Tabelle muss aber weiterhin die
-        Berechnung nachvollziehbar machen.
-
-        Danach ist die Gesamtsumme als fett gesetzter Satz aufzunehmen:
-
-        **Änderung des jährlichen Erfüllungsaufwands in Tsd. Euro: [Wert]**
-
-        Nach der Tabelle sind die zentralen Annahmen knapp zu erläutern:
-
-        - Herleitung der Fallzahl,
-        - Herleitung des Zeitaufwands,
-        - verwendeter Lohnsatz,
-        - Sachkostenannahmen,
-        - Rechenweg für den Gesamtwert.
+        Wenn die JSON-Struktur eine zusätzliche sinnvolle Differenzierung enthält, etwa Laufbahngruppe, Tätigkeitskategorie, Stelle,
+        Vorgabenart oder Sachkostenart, darf die Tabelle um weitere Spalten ergänzt werden. Sie muss die Berechnung weiterhin
+        nachvollziehbar machen.
 
         ---
 

--- a/backend/core/prompts.py
+++ b/backend/core/prompts.py
@@ -1506,7 +1506,8 @@ PROMPT_TEMPLATES: Dict[str, str] = {
         die Aufteilung auf Bund und Land nur in diesen Summenzeilen, nicht als eigene Spalte je Tabellenzeile.
 
         Vorgaben mit einer jährlichen Be- oder Entlastung von betragsmäßig höchstens 100 000 Euro werden als eigene Zeile mit
-        `geringfügig` in der Ergebnisspalte geführt; die Begründung steht in der Fußnote.
+        `geringfügig` in der Ergebnisspalte geführt; die Begründung steht in der Fußnote. Schreibe dabei ausschließlich
+        `geringfügig` ohne Verweiszeichen; verwende in den Tabellenzellen keine hochgestellten Fußnotenziffern.
 
         Unter jeder Tabelle folgen knappe Fußnoten je Zeile im Format `**Zu lfd. Nr. X:** [Bezeichnung]; [Norm]` mit der Herleitung von
         Fallzahl, Zeitaufwand, Lohnsatz und Sachkosten. Überfrachte die Tabellenzellen nicht; die Herleitung gehört in die Fußnote. Gib

--- a/backend/core/prompts.py
+++ b/backend/core/prompts.py
@@ -1318,7 +1318,9 @@ PROMPT_TEMPLATES: Dict[str, str] = {
         - Verwende keine Aussagen zur One-in-one-out-Regel oder Bürokratiebremse.
         - Vermische Erfüllungsaufwand nicht mit Haushaltsausgaben ohne Erfüllungsaufwand.
         - Vermische Erfüllungsaufwand nicht mit weiteren Kosten, Nutzen, Digitalcheck oder Evaluierung.
-        - Informationspflichten der Wirtschaft sind gesondert auszuweisen, soweit sie in der JSON-Struktur enthalten sind.
+        - Eine Vorgabe der Wirtschaft ist genau dann eine Informationspflicht, wenn ihr Feld `ist_informationspflicht_wirtschaft` den
+          Wert `true` hat. Schätze den Informationspflicht-Status nicht selbst ein, sondern übernimm ausschließlich dieses Flag. Diese
+          Informationspflichten sind gesondert auszuweisen.
         - Entlastungen sind im Text als Entlastung, Verringerung oder Reduktion zu formulieren; in Tabellen können sie mit negativem
           Vorzeichen dargestellt werden.
         - Die Summen im Vorblatt müssen mit den Summen in der Begründung übereinstimmen.
@@ -1402,16 +1404,21 @@ PROMPT_TEMPLATES: Dict[str, str] = {
         Weise gesondert aus:
 
         - Zahl der neu eingeführten, geänderten oder aufgehobenen Informationspflichten, soweit angegeben,
-        - jährlichen Mehr- oder Minderaufwand aus Informationspflichten im Saldo,
+        - den jährlichen Mehr- oder Minderaufwand aus Informationspflichten im Saldo; dieser entspricht dem Wert
+          `summen.bureaucracy_cost` des Wirtschaftsblocks (Entlastung negativ). Übernimm diesen Wert und rechne ihn nicht selbst aus
+          den Einzelvorgaben zusammen,
         - ob der gesamte jährliche Aufwand oder nur ein Teil davon aus Informationspflichten stammt.
 
         Wenn die JSON-Struktur ausdrücklich keinen jährlichen Erfüllungsaufwand ausweist:
 
         `Für die Wirtschaft entsteht kein jährlicher Erfüllungsaufwand.`
 
-        Wenn ausdrücklich keine Bürokratiekosten aus Informationspflichten entstehen:
+        `Keine` ist nur zulässig, wenn keine Wirtschafts-Vorgabe das Feld `ist_informationspflicht_wirtschaft = true` trägt:
 
         `Davon Bürokratiekosten aus Informationspflichten: Keine.`
+
+        Trägt mindestens eine Wirtschafts-Vorgabe dieses Flag, sind diese Vorgaben als Informationspflicht auszuweisen und der Saldo
+        `summen.bureaucracy_cost` ist zu nennen, auch wenn er 0 Euro beträgt (dann als geringfügig bzw. 0 Euro).
 
         Wenn Angaben fehlen:
 
@@ -1465,7 +1472,8 @@ PROMPT_TEMPLATES: Dict[str, str] = {
 
         - dass es sich um jährlichen Erfüllungsaufwand handelt,
         - den Normadressaten,
-        - bei Wirtschaft: ob es sich um eine Informationspflicht handelt,
+        - bei Wirtschaft: ob es sich um eine Informationspflicht handelt, und zwar genau dann, wenn das Feld
+          `ist_informationspflicht_wirtschaft` den Wert `true` hat,
         - bei Verwaltung: dass die Vorgabe der Bundesverwaltung zugeordnet ist,
         - den EU-Bezug nur dann, wenn die JSON-Struktur hierzu Angaben enthält.
 

--- a/backend/core/prompts.py
+++ b/backend/core/prompts.py
@@ -124,9 +124,10 @@ PROCESS_STEP_ANALYSIS_ADDRESSEE_RULES: Dict[str, str] = {
     BUSINESS: (
         "Jede Taetigkeit beschreibt eine Handlung des Unternehmens zur "
         "Erfuellung der Vorgabe (z.B. Daten beschaffen, Meldung erstellen, "
-        "Betriebspruefung begleiten, interne Prozesse anpassen). Orientieren "
-        "Sie sich bei Informationspflichten an Teil A der Checkliste, bei "
-        "anderen Vorgaben zusaetzlich an Teil B. IT- oder "
+        "Betriebspruefung begleiten, interne Prozesse anpassen). Fuer Vorgaben, "
+        "die im Input als `ist_informationspflicht_wirtschaft` markiert sind, "
+        "orientieren Sie sich an Teil A der Checkliste; fuer die uebrigen "
+        "Vorgaben zusaetzlich an Teil B. IT- oder "
         "Automatisierungsbezug darf in der Beschreibung genannt werden, wenn "
         "er den Handlungskern praegt. Uebernehmen Sie keine "
         "Verwaltungshandlungen (z.B. Bescheiderstellung, behoerdliche "
@@ -651,6 +652,12 @@ PROMPT_TEMPLATES: Dict[str, str] = {
 
         Hinweis zu `ist_informationspflicht_wirtschaft`: Dieses Flag ist ausschliesslich fuer den Normadressaten
         Wirtschaft (`business`) vorgesehen und kennzeichnet eine Informationspflicht im Sinne des Leitfadens.
+        Eine Informationspflicht liegt vor, wenn aufgrund der Vorgabe Daten oder sonstige Informationen fuer
+        Behoerden oder Dritte zu beschaffen, verfuegbar zu halten oder zu uebermitteln sind (§ 2 Absatz 2 Satz 2 NKRG).
+        Typische Beispiele sind das Ausfuellen von Antraegen und Formularen, die Mitwirkung an amtlichen Erhebungen,
+        Nachweis- und Dokumentationspflichten (Auskunfts-, Melde-, Berichts-, Veroeffentlichungs-, Registrierungs- und
+        Genehmigungspflichten), das Aufbewahren von Unterlagen (z. B. Rechnungen) sowie die Mitwirkung bei
+        behoerdlichen Pruefungen (z. B. Aussenpruefung).
         Setzen Sie das Flag nur dann auf "1", wenn (a) `business` im `normadressaten`-Array enthalten ist UND
         (b) die Vorgabe fuer die Wirtschaft eine Informationspflicht darstellt. In allen anderen Faellen - also
         bei reinen Verwaltungs- oder Buerger-Vorgaben, oder bei Wirtschaftsvorgaben ohne Informationspflicht-Charakter -

--- a/backend/core/prompts.py
+++ b/backend/core/prompts.py
@@ -1241,10 +1241,8 @@ PROMPT_TEMPLATES: Dict[str, str] = {
         - Nicht formulieren, dass kein einmaliger Erfüllungsaufwand entsteht, es sei denn, die JSON-Struktur enthält diese Aussage ausdrücklich.
         - Die Information, dass einmaliger Erfüllungsaufwand nicht Gegenstand der Analyse ist, steht bereits in der PDF-Infobox. Wiederhole
           diese Information im finalen Entwurf nicht als allgemeinen Prüfbedarfshinweis.
-        - Bei der Verwaltung werden ausschließlich Effekte auf die Bundesverwaltung dargestellt.
-        - Länder und Kommunen sind nicht Gegenstand der Analyse.
-        - Die Information, dass Länder und Kommunen nicht Gegenstand der Analyse sind, steht bereits in der PDF-Infobox. Wiederhole diese
-          Information im finalen Entwurf nicht als allgemeinen Prüfbedarfshinweis.
+        - Bei der Verwaltung wird der Aufwand getrennt für Bundesebene und Landesebene (einschließlich Kommunen) dargestellt; der
+          Länderanteil schließt die Kommunen ein.
         - Die One-in-one-out-Regel / Bürokratiebremse wird nicht behandelt.
         - Bürgerinnen und Bürger sowie Wirtschaft werden dargestellt, soweit die JSON-Struktur hierzu Angaben enthält.
         - Der EU-Bezug wird nur dargestellt, wenn die JSON-Struktur hierzu Angaben enthält.
@@ -1307,11 +1305,9 @@ PROMPT_TEMPLATES: Dict[str, str] = {
         - Trenne immer die Normadressaten:
         - Bürgerinnen und Bürger,
         - Wirtschaft,
-        - Bundesverwaltung.
-        - Stelle für die Verwaltung ausschließlich den Bund dar.
-        - Stelle keine Beträge für Länder oder Kommunen dar.
-        - Wenn die JSON-Struktur Angaben zu Ländern oder Kommunen enthält, lasse diese Angaben im finalen Entwurf weg. Setze nur dann einen
-          spezifischen Prüfbedarfshinweis, wenn dadurch eine konkrete Berechnung oder Summe unklar oder widersprüchlich wird.
+        - Verwaltung.
+        - Weise bei der Verwaltung den Aufwand getrennt für Bundesebene und Landesebene (einschließlich Kommunen) aus. Der Länderanteil
+          schließt die Kommunen ein.
         - Stelle ausschließlich jährlichen Erfüllungsaufwand dar.
         - Berechne und erwähne keinen einmaligen Erfüllungsaufwand. Setze nur dann einen spezifischen Prüfbedarfshinweis, wenn dadurch eine
           konkrete Berechnung oder Summe unklar oder widersprüchlich wird.
@@ -1342,10 +1338,11 @@ PROMPT_TEMPLATES: Dict[str, str] = {
 
         1. Bürgerinnen und Bürger,
         2. Wirtschaft,
-        3. Bundesverwaltung.
+        3. Verwaltung.
 
         Es genügt jeweils die Angabe des Saldos über alle Vorgaben, ergänzt um die notwendigen Differenzierungen, insbesondere Zeitaufwand
-        und Sachkosten bei Bürgerinnen und Bürgern sowie Bürokratiekosten aus Informationspflichten bei der Wirtschaft.
+        und Sachkosten bei Bürgerinnen und Bürgern, Bürokratiekosten aus Informationspflichten bei der Wirtschaft sowie die Aufteilung auf
+        Bundes- und Landesebene (einschließlich Kommunen) bei der Verwaltung.
 
         ### Begründung
 
@@ -1424,26 +1421,31 @@ PROMPT_TEMPLATES: Dict[str, str] = {
 
         `[Prüfbedarf: Angaben zum jährlichen Erfüllungsaufwand der Wirtschaft fehlen.]`
 
-        ## E.3 Erfüllungsaufwand der Bundesverwaltung
+        ## E.3 Erfüllungsaufwand der Verwaltung
 
-        Stelle knapp den jährlichen Erfüllungsaufwand oder die jährliche Entlastung der Bundesverwaltung dar.
+        Stelle knapp den jährlichen Erfüllungsaufwand oder die jährliche Entlastung der Verwaltung dar.
 
         Soweit einschlägig, nenne:
 
-        - jährlichen Erfüllungsaufwand des Bundes in Euro,
-        - jährliche Entlastung des Bundes in Euro,
-        - davon Personalkosten und Sachkosten, soweit angegeben,
+        - jährlichen Erfüllungsaufwand der Verwaltung in Euro,
+        - jährliche Entlastung in Euro,
+        - davon auf Bundesebene in Euro; dieser Wert entspricht `summen.verwaltung_bundesebene` des Verwaltungsblocks. Übernimm ihn und
+          rechne ihn nicht selbst aus den Einzelvorgaben zusammen,
+        - davon auf Landesebene (einschließlich Kommunen) in Euro; dieser Wert entspricht `summen.verwaltung_landesebene` des
+          Verwaltungsblocks. Übernimm ihn und rechne ihn nicht selbst zusammen,
         - Saldo über alle Vorgaben.
 
-        Länder und Kommunen werden nicht dargestellt.
+        Der Länderanteil schließt die Kommunen ein. Die beiden Ebenen-Werte sind Teilbeträge des Gesamtaufwands der Verwaltung und müssen
+        nicht zusammen den Gesamtaufwand ergeben. Ist eines der Felder `summen.verwaltung_bundesebene` oder `summen.verwaltung_landesebene`
+        nicht enthalten, lasse die entsprechende Zeile weg statt eine Null zu erfinden.
 
-        Wenn die JSON-Struktur ausdrücklich keinen jährlichen Erfüllungsaufwand des Bundes ausweist:
+        Wenn die JSON-Struktur ausdrücklich keinen jährlichen Erfüllungsaufwand der Verwaltung ausweist:
 
-        `Für die Bundesverwaltung entsteht kein jährlicher Erfüllungsaufwand.`
+        `Für die Verwaltung entsteht kein jährlicher Erfüllungsaufwand.`
 
         Wenn Angaben fehlen:
 
-        `[Prüfbedarf: Angaben zum jährlichen Erfüllungsaufwand der Bundesverwaltung fehlen.]`
+        `[Prüfbedarf: Angaben zum jährlichen Erfüllungsaufwand der Verwaltung fehlen.]`
 
         # 4. Erfüllungsaufwand
 
@@ -1456,7 +1458,10 @@ PROMPT_TEMPLATES: Dict[str, str] = {
 
         ## 4.2 Erfüllungsaufwand für die Wirtschaft
 
-        ## 4.3 Erfüllungsaufwand der Bundesverwaltung
+        ## 4.3 Erfüllungsaufwand der Verwaltung
+
+        Greife die Aufteilung des Verwaltungsaufwands auf Bundesebene (`summen.verwaltung_bundesebene`) und Landesebene einschließlich
+        Kommunen (`summen.verwaltung_landesebene`) aus dem Vorblatt auf.
 
         Für jede Vorgabe ist, soweit einschlägig, eine kurze Überschrift zu verwenden:
 
@@ -1474,7 +1479,6 @@ PROMPT_TEMPLATES: Dict[str, str] = {
         - den Normadressaten,
         - bei Wirtschaft: ob es sich um eine Informationspflicht handelt, und zwar genau dann, wenn das Feld
           `ist_informationspflicht_wirtschaft` den Wert `true` hat,
-        - bei Verwaltung: dass die Vorgabe der Bundesverwaltung zugeordnet ist,
         - den EU-Bezug nur dann, wenn die JSON-Struktur hierzu Angaben enthält.
 
         ---
@@ -1504,7 +1508,7 @@ PROMPT_TEMPLATES: Dict[str, str] = {
         | Fallzahl | Zeitaufwand pro Fall in Minuten | Sachkosten pro Fall in Euro | Zeitaufwand in Stunden | Sachkosten in Tsd. Euro |
         |---:|---:|---:|---:|---:|
 
-        Für Wirtschaft und Bundesverwaltung soll die Tabelle grundsätzlich folgende Struktur verwenden:
+        Für Wirtschaft und Verwaltung soll die Tabelle grundsätzlich folgende Struktur verwenden:
 
         | Fallzahl | Zeitaufwand pro Fall in Minuten | Lohnsatz pro Stunde in Euro | Sachkosten pro Fall in Euro | Personalkosten in Tsd. Euro | Sachkosten in Tsd. Euro |
         |---:|---:|---:|---:|---:|---:|
@@ -1535,7 +1539,7 @@ PROMPT_TEMPLATES: Dict[str, str] = {
         - Gesamtaufwand = Personalkosten + Sachkosten.
         - Entlastungen sind mit negativem Vorzeichen zu rechnen, aber im Text als Entlastung zu formulieren.
         - Bürgerinnen und Bürger: Zeitaufwand grundsätzlich in Stunden darstellen.
-        - Wirtschaft und Bundesverwaltung: Aufwand grundsätzlich in Euro beziehungsweise Tsd. Euro darstellen.
+        - Wirtschaft und Verwaltung: Aufwand grundsätzlich in Euro beziehungsweise Tsd. Euro darstellen.
         - Werte in Tabellen grundsätzlich in Tsd. Euro ausweisen, sofern die JSON-Struktur nichts anderes vorgibt.
         - Im Fließtext können gerundete Werte in Euro, Tsd. Euro oder Mio. Euro verwendet werden; die Rundung muss konsistent sein.
         - Bürgerzeit wird nicht monetarisiert, es sei denn, die JSON-Struktur enthält ausdrücklich eine solche Monetarisierung.
@@ -1550,8 +1554,8 @@ PROMPT_TEMPLATES: Dict[str, str] = {
         1. Stimmen alle Summen im Vorblatt mit den Tabellen und Erläuterungen in der Begründung überein?
         2. Wird ausschließlich jährlicher Erfüllungsaufwand dargestellt?
         3. Wurde kein einmaliger Erfüllungsaufwand berechnet oder ausgewiesen?
-        4. Sind Bürgerinnen und Bürger, Wirtschaft und Bundesverwaltung getrennt dargestellt?
-        5. Wurden Länder und Kommunen nicht dargestellt?
+        4. Sind Bürgerinnen und Bürger, Wirtschaft und Verwaltung getrennt dargestellt?
+        5. Ist bei der Verwaltung die Aufteilung auf Bundesebene und Landesebene (einschließlich Kommunen) ausgewiesen, soweit die Werte vorliegen?
         6. Wurde die One-in-one-out-Regel nicht erwähnt?
         7. Sind Informationspflichten der Wirtschaft gesondert ausgewiesen, soweit sie in der JSON-Struktur enthalten sind?
         8. Wurden keine Angaben erfunden?

--- a/backend/core/session_graph.py
+++ b/backend/core/session_graph.py
@@ -182,6 +182,13 @@ def build_session_tiles_snapshot(
                         )
                         if enabled
                     ],
+                    # Flag adressat-unabhaengig mitschreiben (wie der Identify-Pfad),
+                    # damit es beim Snapshot-Rebuild nicht verloren geht. Die Anzeige
+                    # als "IP"-Pill wird rein im Frontend auf die Wirtschaft-Sicht
+                    # gegated.
+                    "is_business_information_obligation": bool(
+                        regulation.get("is_business_information_obligation")
+                    ),
                 },
                 column=1,
                 row=idx,

--- a/backend/core/session_graph.py
+++ b/backend/core/session_graph.py
@@ -182,10 +182,6 @@ def build_session_tiles_snapshot(
                         )
                         if enabled
                     ],
-                    # Flag adressat-unabhaengig mitschreiben (wie der Identify-Pfad),
-                    # damit es beim Snapshot-Rebuild nicht verloren geht. Die Anzeige
-                    # als "IP"-Pill wird rein im Frontend auf die Wirtschaft-Sicht
-                    # gegated.
                     "is_business_information_obligation": bool(
                         regulation.get("is_business_information_obligation")
                     ),

--- a/backend/core/tile_refresh.py
+++ b/backend/core/tile_refresh.py
@@ -203,6 +203,46 @@ def refresh_case_group_tiles(
             db.upsert_tile(updated, session_id=session_id, norm_addressee=addressee)
 
 
+def refresh_regulation_tiles(
+    session_id: int,
+    regulations: list[dict],
+    norm_addressee: str = ADMINISTRATION,
+) -> None:
+    """Alt-Sessions: Vorgabe-Kacheln, die vor dem IP-Flag persistiert wurden,
+    in-place um ``is_business_information_obligation`` ergaenzen.
+
+    Positionen, Text und uebrige Meta bleiben erhalten (analog
+    ``refresh_step_tiles``); es wird ausschliesslich das Flag adressat-unabhaengig
+    aus den ``regulations``-Daten ins Meta geschrieben. Der echte Flag-Wert je
+    Vorgabe wird uebernommen (kein Pauschalwert). Nach dem Refresh traegt das Meta
+    den Schluessel, sodass die Erkennung nicht erneut feuert (idempotent).
+    """
+    tiles = {
+        tile.id: tile
+        for tile in db.fetch_tiles(session_id=session_id, norm_addressee=norm_addressee)
+    }
+    for regulation in regulations:
+        tile_id = f"regulation_{regulation['regulation_id']}"
+        tile = tiles.get(tile_id)
+        if not tile:
+            continue
+        meta_information = dict(tile.meta_information or {})
+        meta_information["is_business_information_obligation"] = bool(
+            regulation.get("is_business_information_obligation")
+        )
+        updated = Tile(
+            id=tile.id,
+            title=tile.title,
+            text=tile.text,
+            meta_information=meta_information,
+            column=tile.column,
+            row=tile.row,
+            deletable=tile.deletable,
+            link_from_tile=tile.link_from_tile,
+        )
+        db.upsert_tile(updated, session_id=session_id, norm_addressee=norm_addressee)
+
+
 def refresh_step_tiles(
     session_id: int,
     steps: list[dict],

--- a/backend/core/tile_refresh.py
+++ b/backend/core/tile_refresh.py
@@ -208,15 +208,6 @@ def refresh_regulation_tiles(
     regulations: list[dict],
     norm_addressee: str = ADMINISTRATION,
 ) -> None:
-    """Alt-Sessions: Vorgabe-Kacheln, die vor dem IP-Flag persistiert wurden,
-    in-place um ``is_business_information_obligation`` ergaenzen.
-
-    Positionen, Text und uebrige Meta bleiben erhalten (analog
-    ``refresh_step_tiles``); es wird ausschliesslich das Flag adressat-unabhaengig
-    aus den ``regulations``-Daten ins Meta geschrieben. Der echte Flag-Wert je
-    Vorgabe wird uebernommen (kein Pauschalwert). Nach dem Refresh traegt das Meta
-    den Schluessel, sodass die Erkennung nicht erneut feuert (idempotent).
-    """
     tiles = {
         tile.id: tile
         for tile in db.fetch_tiles(session_id=session_id, norm_addressee=norm_addressee)

--- a/backend/routers/regulations.py
+++ b/backend/routers/regulations.py
@@ -185,15 +185,6 @@ def _parse_vorgaben(payload: str) -> list[dict]:
                 or entry.get("informationspflicht_wirtschaft")
             )
         )
-        # Per Leitfaden (StBA): Buerokratiekosten aus Informationspflichten werden
-        # ausschliesslich fuer den Normadressaten Wirtschaft gesondert ausgewiesen;
-        # fuer Verwaltung und Buergerinnen/Buerger ist die Unterscheidung entbehrlich.
-        # Eine "Verwaltungs-IP" existiert im Modell nicht (kein Feld, keine Kosten).
-        # Setzt das LLM das Flag ohne BUSINESS im Normadressaten-Set, ist es ungueltig:
-        # Wir loeschen es (statt einen Business-Adressaten zu erfinden, der Wirtschafts-
-        # und Buerokratiekosten verfaelschen wuerde). Adressaten und Vorgabe bleiben
-        # unveraendert; ein Audit-Event macht solche Faelle auswertbar
-        # (grep "event=ip_flag_cleared").
         if is_business_information_obligation and BUSINESS not in normadressaten:
             logger.warning(
                 "event=ip_flag_cleared reason=missing_business_in_addressees "

--- a/backend/routers/regulations.py
+++ b/backend/routers/regulations.py
@@ -185,21 +185,23 @@ def _parse_vorgaben(payload: str) -> list[dict]:
                 or entry.get("informationspflicht_wirtschaft")
             )
         )
-        # Per Leitfaden (StBA): Die Unterscheidung zwischen Informationspflichten
-        # und uebrigen Vorgaben ist nur fuer Wirtschaft gefordert. Setzt das LLM
-        # das Flag ohne BUSINESS im Normadressaten-Set, ergaenzen wir BUSINESS
-        # (robust gegen unvollstaendige LLM-Ausgaben) UND emittieren ein
-        # strukturiertes Audit-Event, damit solche Faelle systematisch
-        # auswertbar bleiben (grep "event=ip_flag_repair").
+        # Per Leitfaden (StBA): Buerokratiekosten aus Informationspflichten werden
+        # ausschliesslich fuer den Normadressaten Wirtschaft gesondert ausgewiesen;
+        # fuer Verwaltung und Buergerinnen/Buerger ist die Unterscheidung entbehrlich.
+        # Eine "Verwaltungs-IP" existiert im Modell nicht (kein Feld, keine Kosten).
+        # Setzt das LLM das Flag ohne BUSINESS im Normadressaten-Set, ist es ungueltig:
+        # Wir loeschen es (statt einen Business-Adressaten zu erfinden, der Wirtschafts-
+        # und Buerokratiekosten verfaelschen wuerde). Adressaten und Vorgabe bleiben
+        # unveraendert; ein Audit-Event macht solche Faelle auswertbar
+        # (grep "event=ip_flag_cleared").
         if is_business_information_obligation and BUSINESS not in normadressaten:
             logger.warning(
-                "event=ip_flag_repair reason=missing_business_in_addressees "
-                "normzitat=%r addressees_before=%r addressees_after=%r",
+                "event=ip_flag_cleared reason=missing_business_in_addressees "
+                "normzitat=%r addressees=%r",
                 normzitat[:120],
                 list(normadressaten),
-                list(normadressaten) + [BUSINESS],
             )
-            normadressaten.append(BUSINESS)
+            is_business_information_obligation = False
         if not normzitat and not beschreibung:
             continue
         parsed.append(

--- a/backend/routers/sessions.py
+++ b/backend/routers/sessions.py
@@ -2405,10 +2405,6 @@ def _compliance_metadata_for_pdf(
     used_user_edits: bool,
     reused: bool,
     created_at: str | None = None,
-    input_tokens: int | None = None,
-    output_tokens: int | None = None,
-    hidden_thinking_tokens: int | None = None,
-    estimated_cost_usd: float | None = None,
 ) -> dict[str, object]:
     if not has_user_edits:
         user_edit_status = "Keine bearbeiteten EA-Werte im Quellstand."
@@ -2433,10 +2429,6 @@ def _compliance_metadata_for_pdf(
         "deep_research_status": dr_status,
         "user_edit_status": user_edit_status,
         "source_snapshot_sha256": source_snapshot_sha256[:12],
-        "input_tokens": input_tokens,
-        "output_tokens": output_tokens,
-        "hidden_thinking_tokens": hidden_thinking_tokens,
-        "estimated_cost_usd": estimated_cost_usd,
     }
 
 
@@ -2499,10 +2491,6 @@ async def export_compliance_text(
             used_user_edits=bool(cached.get("used_user_edits")),
             reused=True,
             created_at=cached.get("created_at"),
-            input_tokens=cached.get("input_tokens"),
-            output_tokens=cached.get("output_tokens"),
-            hidden_thinking_tokens=cached.get("hidden_thinking_tokens"),
-            estimated_cost_usd=cached.get("estimated_cost_usd"),
         )
         pdf = _render_research_report_pdf(
             str(cached["generated_markdown"]),
@@ -2587,10 +2575,6 @@ async def export_compliance_text(
         has_user_edits=context.has_user_edits,
         used_user_edits=context.used_user_edits,
         reused=False,
-        input_tokens=llm_result.input_tokens,
-        output_tokens=llm_result.output_tokens,
-        hidden_thinking_tokens=llm_result.hidden_thinking_tokens,
-        estimated_cost_usd=llm_result.estimated_cost_usd,
     )
     pdf = _render_research_report_pdf(
         llm_result.text,
@@ -2786,24 +2770,6 @@ def _format_compliance_export_metadata_lines(metadata: dict[str, object]) -> lis
     ):
         if value:
             lines.append(f"<b>{label}:</b> {html.escape(str(value))}")
-    token_parts = [
-        f"in {metadata.get('input_tokens')}" if metadata.get("input_tokens") is not None else None,
-        f"out {metadata.get('output_tokens')}" if metadata.get("output_tokens") is not None else None,
-        (
-            f"thinking {metadata.get('hidden_thinking_tokens')}"
-            if metadata.get("hidden_thinking_tokens") is not None
-            else None
-        ),
-    ]
-    tokens = " / ".join(part for part in token_parts if part)
-    if tokens:
-        lines.append(f"<b>Token:</b> {html.escape(tokens)}")
-    cost = metadata.get("estimated_cost_usd")
-    if cost is not None:
-        try:
-            lines.append(f"<b>Geschaetzte API-Kosten:</b> ${float(cost):.4f}")
-        except (TypeError, ValueError):
-            lines.append(f"<b>Geschaetzte API-Kosten:</b> {html.escape(str(cost))}")
     return lines
 
 

--- a/backend/routers/sessions.py
+++ b/backend/routers/sessions.py
@@ -2754,9 +2754,8 @@ def _format_compliance_export_metadata_lines(metadata: dict[str, object]) -> lis
         "<b>Analyseumfang:</b> Die Darstellung umfasst ausschliesslich jaehrlichen "
         "Erfuellungsaufwand. Einmaliger Erfuellungsaufwand ist nicht Gegenstand "
         "dieser Analyse.",
-        "<b>Verwaltung:</b> Fuer die Verwaltung werden ausschliesslich Effekte auf "
-        "die Bundesverwaltung dargestellt; Laender und Kommunen sind nicht "
-        "Gegenstand dieser Analyse.",
+        "<b>Verwaltung:</b> Der Erfuellungsaufwand der Verwaltung wird getrennt nach "
+        "Bundesebene und Landesebene (einschliesslich Kommunen) ausgewiesen.",
     ]
     for label, value in (
         ("Session", metadata.get("app_session_id")),

--- a/backend/routers/sessions.py
+++ b/backend/routers/sessions.py
@@ -2662,10 +2662,12 @@ def _should_render_research_pdf_bold(escaped_text: str) -> bool:
 
 _BOLD_MARKUP = re.compile(r"\*\*(?=\S)(.+?)(?<=\S)\*\*", re.DOTALL)
 _ITALIC_MARKUP = re.compile(r"(?<!\*)\*(?=\S)([^*]+?)(?<=\S)\*(?!\*)", re.DOTALL)
+_ESCAPED_LINE_BREAK = re.compile(r"&lt;br\s*/?&gt;", re.IGNORECASE)
 
 
 def _research_pdf_inline_markup(text: str) -> str:
     escaped = html.escape(text).replace("\n", "<br/>")
+    escaped = _ESCAPED_LINE_BREAK.sub("<br/>", escaped)
 
     def bold(match: re.Match[str]) -> str:
         inner = match.group(1)

--- a/backend/routers/sessions.py
+++ b/backend/routers/sessions.py
@@ -2660,19 +2660,22 @@ def _should_render_research_pdf_bold(escaped_text: str) -> bool:
     return True
 
 
+_BOLD_MARKUP = re.compile(r"\*\*(?=\S)(.+?)(?<=\S)\*\*", re.DOTALL)
+_ITALIC_MARKUP = re.compile(r"(?<!\*)\*(?=\S)([^*]+?)(?<=\S)\*(?!\*)", re.DOTALL)
+
+
 def _research_pdf_inline_markup(text: str) -> str:
     escaped = html.escape(text).replace("\n", "<br/>")
-    parts = escaped.split("**")
-    if len(parts) == 1:
-        return _linkify_research_pdf_urls(escaped)
-    rendered: list[str] = []
-    for index, part in enumerate(parts):
-        linked_part = _linkify_research_pdf_urls(part)
-        if index % 2 == 1 and _should_render_research_pdf_bold(part):
-            rendered.append(f"<b>{linked_part}</b>")
-        else:
-            rendered.append(linked_part)
-    return "".join(rendered)
+
+    def bold(match: re.Match[str]) -> str:
+        inner = match.group(1)
+        if not _should_render_research_pdf_bold(inner):
+            return inner
+        return f"<b>{inner}</b>"
+
+    marked = _BOLD_MARKUP.sub(bold, escaped)
+    marked = _ITALIC_MARKUP.sub(lambda match: f"<i>{match.group(1)}</i>", marked)
+    return _linkify_research_pdf_urls(marked)
 
 
 def _is_research_pdf_heading(text: str) -> bool:
@@ -2693,6 +2696,38 @@ def _is_research_pdf_heading(text: str) -> bool:
 
 def _strip_markdown_heading_prefix(text: str) -> str:
     return re.sub(r"^#{1,6}\s*", "", text, count=1).strip()
+
+
+_LIST_ITEM = re.compile(r"^(\s*)[-*]\s+(\S.*)$")
+
+
+def _parse_markdown_list(text: str) -> tuple[str, list[tuple[int, str]]] | None:
+    """Trennt einen Block in Einleitungstext und (Einrueckungstiefe, Text)-Items.
+
+    Gibt ``None`` zurueck, wenn der Block keine Aufzaehlung enthaelt. Die
+    Aufzaehlung darf direkt an einen Absatz anschliessen, weil das Modell die
+    Leerzeile davor nicht zuverlaessig setzt. Zeilen nach einem Item gelten als
+    dessen Fortsetzung, damit umgebrochene Eintraege nicht zu eigenen Bullets
+    werden.
+    """
+    lead_lines: list[str] = []
+    items: list[tuple[int, str]] = []
+    for line in text.split("\n"):
+        if not line.strip():
+            continue
+        match = _LIST_ITEM.match(line)
+        if match:
+            depth = 1 if len(match.group(1)) >= 2 else 0
+            items.append((depth, match.group(2).strip()))
+            continue
+        if not items:
+            lead_lines.append(line.strip())
+            continue
+        depth, current = items[-1]
+        items[-1] = (depth, f"{current} {line.strip()}")
+    if not items:
+        return None
+    return "\n".join(lead_lines), items
 
 
 def _linkify_research_pdf_urls(escaped_text: str) -> str:
@@ -2810,6 +2845,22 @@ def _render_research_report_pdf(
         fontSize=8,
         leading=10,
     )
+    sub_heading_style = ParagraphStyle(
+        "ResearchSubHeading",
+        parent=styles["Heading2"],
+        fontSize=12,
+        leading=15,
+    )
+    list_item_styles = [
+        ParagraphStyle(
+            f"ResearchListItem{depth}",
+            parent=styles["BodyText"],
+            leftIndent=16 + depth * 14,
+            bulletIndent=4 + depth * 14,
+            spaceAfter=2,
+        )
+        for depth in (0, 1)
+    ]
     available_width = A4[0] - doc.leftMargin - doc.rightMargin
     story = [Paragraph(html.escape(title), styles["Title"]), Spacer(1, 12)]
     if metadata or metadata_lines:
@@ -2840,8 +2891,10 @@ def _render_research_report_pdf(
         if not text:
             continue
         if text.startswith("#") and _is_research_pdf_heading(text):
+            level = len(text) - len(text.lstrip("#"))
             heading = text.lstrip("#").strip()
-            story.append(Paragraph(html.escape(heading), styles["Heading2"]))
+            heading_style = sub_heading_style if level >= 3 else styles["Heading2"]
+            story.append(Paragraph(html.escape(heading), heading_style))
         elif table_rows := _parse_pipe_table(text):
             column_count = len(table_rows[0])
             table_data = [
@@ -2870,6 +2923,23 @@ def _render_research_report_pdf(
                 )
             )
             story.append(table)
+        elif parsed_list := _parse_markdown_list(text):
+            lead, list_items = parsed_list
+            if lead:
+                story.append(
+                    Paragraph(
+                        _research_pdf_inline_markup(_strip_markdown_heading_prefix(lead)),
+                        styles["BodyText"],
+                    )
+                )
+            for depth, item in list_items:
+                story.append(
+                    Paragraph(
+                        _research_pdf_inline_markup(item),
+                        list_item_styles[depth],
+                        bulletText="•" if depth == 0 else "–",
+                    )
+                )
         else:
             story.append(
                 Paragraph(

--- a/backend/routers/sessions.py
+++ b/backend/routers/sessions.py
@@ -2676,12 +2676,13 @@ def _research_pdf_inline_markup(text: str) -> str:
 
 
 def _is_research_pdf_heading(text: str) -> bool:
+    level = len(text) - len(text.lstrip("#"))
     heading = text.lstrip("#").strip()
     if not heading:
         return False
     if "\n" in heading:
         return False
-    if re.match(r"^\d+\.\s+", heading):
+    if level >= 2 and re.match(r"^\d+\.\s+", heading):
         return False
     if len(heading) > 85:
         return False

--- a/backend/routers/tiles.py
+++ b/backend/routers/tiles.py
@@ -121,13 +121,6 @@ def _step_tiles_predate_personnel_rows(tiles: list[Tile]) -> bool:
 
 
 def _regulation_tiles_predate_ip_flag(tiles: list[Tile]) -> bool:
-    """True, wenn Vorgabe-Kacheln vor dem IP-Flag persistiert wurden, also der
-    Schluessel ``is_business_information_obligation`` im Meta fehlt.
-
-    Bewusst auf Schluessel-Praesenz pruefen (``not in``), nicht auf Truthiness, da
-    ``False`` ein gueltiger Flag-Wert ist. Neu erzeugte Vorgabe-Kacheln tragen den
-    Schluessel immer, daher self-terminierend nach einem In-Place-Refresh.
-    """
     return any(
         tile.id.startswith("regulation_")
         and "is_business_information_obligation" not in (tile.meta_information or {})
@@ -229,12 +222,6 @@ async def list_tiles(
                 tiles,
             )
         if not needs_rebuild:
-            # Self-Heal fuer Alt-Sessions: Vorgabe-Kacheln, die vor dem IP-Flag
-            # persistiert wurden, in-place um is_business_information_obligation
-            # ergaenzen (Positionen/Text bleiben erhalten). Diese Kacheln aendern
-            # weder Struktur noch Gesamtkosten, wuerden hier also sonst unveraendert
-            # zurueckgegeben; deshalb der gezielte Refresh vor dem Early-Return statt
-            # eines Voll-Rebuilds. Nach dem Refresh feuert die Bedingung nicht erneut.
             if _regulation_tiles_predate_ip_flag(tiles):
                 regulations = db.list_regulations_for_session_and_addressee(
                     session_id, resolved

--- a/backend/routers/tiles.py
+++ b/backend/routers/tiles.py
@@ -11,7 +11,7 @@ from backend.core.session_graph import (
     build_session_tiles_snapshot,
     persist_session_tiles_snapshot,
 )
-from backend.core.tile_refresh import refresh_step_tiles
+from backend.core.tile_refresh import refresh_regulation_tiles, refresh_step_tiles
 from backend.core.models import Tile, TilesResponse
 from backend.core.norm_addressees import ADMINISTRATION
 from backend.routers._norm_addressee import normalize_norm_addressee_or_422
@@ -120,6 +120,21 @@ def _step_tiles_predate_personnel_rows(tiles: list[Tile]) -> bool:
     )
 
 
+def _regulation_tiles_predate_ip_flag(tiles: list[Tile]) -> bool:
+    """True, wenn Vorgabe-Kacheln vor dem IP-Flag persistiert wurden, also der
+    Schluessel ``is_business_information_obligation`` im Meta fehlt.
+
+    Bewusst auf Schluessel-Praesenz pruefen (``not in``), nicht auf Truthiness, da
+    ``False`` ein gueltiger Flag-Wert ist. Neu erzeugte Vorgabe-Kacheln tragen den
+    Schluessel immer, daher self-terminierend nach einem In-Place-Refresh.
+    """
+    return any(
+        tile.id.startswith("regulation_")
+        and "is_business_information_obligation" not in (tile.meta_information or {})
+        for tile in tiles
+    )
+
+
 def _tiles_need_total_cost_rebuild(
     expected_tiles: list[Tile],
     tiles: list[Tile],
@@ -214,6 +229,23 @@ async def list_tiles(
                 tiles,
             )
         if not needs_rebuild:
+            # Self-Heal fuer Alt-Sessions: Vorgabe-Kacheln, die vor dem IP-Flag
+            # persistiert wurden, in-place um is_business_information_obligation
+            # ergaenzen (Positionen/Text bleiben erhalten). Diese Kacheln aendern
+            # weder Struktur noch Gesamtkosten, wuerden hier also sonst unveraendert
+            # zurueckgegeben; deshalb der gezielte Refresh vor dem Early-Return statt
+            # eines Voll-Rebuilds. Nach dem Refresh feuert die Bedingung nicht erneut.
+            if _regulation_tiles_predate_ip_flag(tiles):
+                regulations = db.list_regulations_for_session_and_addressee(
+                    session_id, resolved
+                )
+                if regulations:
+                    refresh_regulation_tiles(
+                        session_id, regulations, norm_addressee=resolved
+                    )
+                    tiles = db.fetch_tiles(
+                        session_id=session_id, norm_addressee=resolved
+                    )
             return TilesResponse(tiles=tiles)
         has_process_steps = bool(
             db.list_process_steps_for_session_and_addressee(session_id, resolved)

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -125,6 +125,15 @@ body {
   min-height: 24px;
 }
 
+/* Linkes Cluster der Meta-Zeile: Change-Status-Pill und optionales IP-Pill. */
+.tile-node .tile-meta-left {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: 0 1 auto;
+  min-width: 0;
+}
+
 .tile-node .tile-title-wrap {
   display: flex;
   flex-direction: column;
@@ -169,6 +178,25 @@ body {
   background: #e2e8f0;
   color: #334155;
   border: 1px solid #cbd5e1;
+}
+
+/* Dezentes "IP"-Pill (Informationspflicht Wirtschaft): gleiche Pill-Form wie
+   der Status-Marker, gedaempftes Blau in Anlehnung an .tile-metric-right,
+   damit es zurueckhaltend, aber klar vom grauen Status unterscheidbar bleibt. */
+.tile-node .tile-ip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: fit-content;
+  border-radius: 999px;
+  padding: 2px 8px;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  background: #e0f2fe;
+  color: #075985;
+  border: 1px solid #bae6fd;
 }
 
 .tile-node .tile-body-row {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -125,7 +125,6 @@ body {
   min-height: 24px;
 }
 
-/* Linkes Cluster der Meta-Zeile: Change-Status-Pill und optionales IP-Pill. */
 .tile-node .tile-meta-left {
   display: flex;
   align-items: center;
@@ -180,9 +179,6 @@ body {
   border: 1px solid #cbd5e1;
 }
 
-/* Dezentes "IP"-Pill (Informationspflicht Wirtschaft): gleiche Pill-Form wie
-   der Status-Marker, gedaempftes Blau in Anlehnung an .tile-metric-right,
-   damit es zurueckhaltend, aber klar vom grauen Status unterscheidbar bleibt. */
 .tile-node .tile-ip {
   display: inline-flex;
   align-items: center;

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -179,22 +179,6 @@ body {
   border: 1px solid #cbd5e1;
 }
 
-.tile-node .tile-ip {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: fit-content;
-  border-radius: 999px;
-  padding: 2px 8px;
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.03em;
-  text-transform: uppercase;
-  background: #e0f2fe;
-  color: #075985;
-  border: 1px solid #bae6fd;
-}
-
 .tile-node .tile-body-row {
   display: flex;
   align-items: flex-end;
@@ -384,6 +368,12 @@ body {
 }
 
 .tile-node .tile-metric-right {
+  background: #e0f2fe;
+  border-color: #bae6fd;
+  color: #075985;
+}
+
+.tile-node .tile-ip {
   background: #e0f2fe;
   border-color: #bae6fd;
   color: #075985;

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -362,18 +362,13 @@ body {
   overflow: visible;
 }
 
-.tile-node .tile-metric-left {
+.tile-node .tile-metric-left,
+.tile-node .tile-ip {
   background: #e2e8f0;
   border-color: #cbd5e1;
 }
 
 .tile-node .tile-metric-right {
-  background: #e0f2fe;
-  border-color: #bae6fd;
-  color: #075985;
-}
-
-.tile-node .tile-ip {
   background: #e0f2fe;
   border-color: #bae6fd;
   color: #075985;

--- a/frontend/src/components/GraphCanvas.tsx
+++ b/frontend/src/components/GraphCanvas.tsx
@@ -570,6 +570,14 @@ function GraphCanvasInner() {
             relatedNodeIds.has(tile.id) &&
             focusedNodeId !== tile.id,
           changeStatus: normalizeChangeStatus(tile.meta_information?.["change_status"]),
+          // IP-Pill nur in der Wirtschaft-Sicht und nur bei gesetztem Flag anzeigen.
+          // Das Flag liegt adressat-unabhaengig in der Kachel-Meta; das Gating
+          // erfolgt bewusst rein im Frontend.
+          showIpBadge:
+            state.selectedNormAddressee === "business" &&
+            Boolean(
+              tile.meta_information?.["is_business_information_obligation"]
+            ),
         },
         className: expandedNodeIds[tile.id] ? "node-expanded" : "",
         style: expandedNodeIds[tile.id] ? { zIndex: 5 } : undefined,

--- a/frontend/src/components/GraphCanvas.tsx
+++ b/frontend/src/components/GraphCanvas.tsx
@@ -570,9 +570,6 @@ function GraphCanvasInner() {
             relatedNodeIds.has(tile.id) &&
             focusedNodeId !== tile.id,
           changeStatus: normalizeChangeStatus(tile.meta_information?.["change_status"]),
-          // IP-Pill nur in der Wirtschaft-Sicht und nur bei gesetztem Flag anzeigen.
-          // Das Flag liegt adressat-unabhaengig in der Kachel-Meta; das Gating
-          // erfolgt bewusst rein im Frontend.
           showIpBadge:
             state.selectedNormAddressee === "business" &&
             Boolean(

--- a/frontend/src/components/TileNode.tsx
+++ b/frontend/src/components/TileNode.tsx
@@ -73,18 +73,20 @@ export function TileNode({ data, id }: NodeProps<TileNodeData>) {
                     {getChangeStatusLabel(data.changeStatus)}
                   </span>
                 )}
-                {data.showIpBadge && (
-                  <span
-                    className="tile-ip"
-                    title="Informationspflicht Wirtschaft"
-                    aria-label="Informationspflicht Wirtschaft"
-                  >
-                    IP
-                  </span>
-                )}
               </div>
-              {(data.headerMetricLeft || data.headerMetricRight) && (
+              {(data.showIpBadge ||
+                data.headerMetricLeft ||
+                data.headerMetricRight) && (
                 <div className="tile-actions">
+                  {data.showIpBadge && (
+                    <span
+                      className="tile-metric tile-ip"
+                      title="Informationspflicht Wirtschaft"
+                      aria-label="Informationspflicht Wirtschaft"
+                    >
+                      IP
+                    </span>
+                  )}
                   {data.headerMetricLeft && (
                     <span className="tile-metric tile-metric-left">
                       {data.headerMetricLeft}

--- a/frontend/src/components/TileNode.tsx
+++ b/frontend/src/components/TileNode.tsx
@@ -19,6 +19,9 @@ export interface TileNodeData {
   isFocused: boolean;
   isNeighbor: boolean;
   changeStatus?: ChangeStatus | null;
+  // Dezentes "IP"-Pill fuer Business-Informationspflichten; wird ausschliesslich
+  // in der Wirtschaft-Sicht bei gesetztem Flag angezeigt (Gating in GraphCanvas).
+  showIpBadge?: boolean;
 }
 
 export function TileNode({ data, id }: NodeProps<TileNodeData>) {
@@ -31,7 +34,10 @@ export function TileNode({ data, id }: NodeProps<TileNodeData>) {
   const metricTableAlwaysVisible = Boolean(summaryMetric?.alwaysVisible);
   const suppressTitle = Boolean(summaryMetric?.suppressTitle);
   const showHeaderMeta = Boolean(
-    data.changeStatus || data.headerMetricLeft || data.headerMetricRight
+    data.changeStatus ||
+      data.showIpBadge ||
+      data.headerMetricLeft ||
+      data.headerMetricRight
   );
   const showTitle = Boolean(data.title) && !suppressTitle;
   const canExpand =
@@ -63,13 +69,22 @@ export function TileNode({ data, id }: NodeProps<TileNodeData>) {
         <div className="tile-header">
           {showHeaderMeta && (
             <div className="tile-meta-row">
-              {data.changeStatus ? (
-                <span className={`tile-status tile-status-${data.changeStatus}`}>
-                  {getChangeStatusLabel(data.changeStatus)}
-                </span>
-              ) : (
-                <span />
-              )}
+              <div className="tile-meta-left">
+                {data.changeStatus && (
+                  <span className={`tile-status tile-status-${data.changeStatus}`}>
+                    {getChangeStatusLabel(data.changeStatus)}
+                  </span>
+                )}
+                {data.showIpBadge && (
+                  <span
+                    className="tile-ip"
+                    title="Informationspflicht Wirtschaft"
+                    aria-label="Informationspflicht Wirtschaft"
+                  >
+                    IP
+                  </span>
+                )}
+              </div>
               {(data.headerMetricLeft || data.headerMetricRight) && (
                 <div className="tile-actions">
                   {data.headerMetricLeft && (

--- a/frontend/src/components/TileNode.tsx
+++ b/frontend/src/components/TileNode.tsx
@@ -19,8 +19,6 @@ export interface TileNodeData {
   isFocused: boolean;
   isNeighbor: boolean;
   changeStatus?: ChangeStatus | null;
-  // Dezentes "IP"-Pill fuer Business-Informationspflichten; wird ausschliesslich
-  // in der Wirtschaft-Sicht bei gesetztem Flag angezeigt (Gating in GraphCanvas).
   showIpBadge?: boolean;
 }
 

--- a/frontend/src/components/TotalCostPanel.tsx
+++ b/frontend/src/components/TotalCostPanel.tsx
@@ -67,12 +67,17 @@ function formatCitizenCostValue(row: TotalCostResponse | undefined): string {
   return `${hours} · ${expenses}`;
 }
 
+function formatBusinessCostValue(row: TotalCostResponse | undefined): string {
+  const total = formatCostValue(row?.total_cost, { zeroWhenMissing: true });
+  const bureaucracy = formatCostValue(row?.bureaucracy_cost, { zeroWhenMissing: true });
+  return `${total} · davon IP ${bureaucracy}`;
+}
+
 function buildCostSummaryCells(summary: CostSummary): {
   totalCell: { label: string; value: string };
   addresseeCells: {
     label: string;
     value: string;
-    sub?: { label: string; value: string };
   }[];
 } {
   const administration = summary.administration?.total_cost ?? 0;
@@ -84,17 +89,7 @@ function buildCostSummaryCells(summary: CostSummary): {
     },
     addresseeCells: [
       { label: "Bürger:innen", value: formatCitizenCostValue(summary.citizens) },
-      {
-        label: "Wirtschaft",
-        value: formatCostValue(summary.business?.total_cost, { zeroWhenMissing: true }),
-        // Bürokratiekosten aus Informationspflichten als "davon"-Anteil der Wirtschaft.
-        sub: {
-          label: "davon IP",
-          value: formatCostValue(summary.business?.bureaucracy_cost, {
-            zeroWhenMissing: true,
-          }),
-        },
-      },
+      { label: "Wirtschaft", value: formatBusinessCostValue(summary.business) },
       {
         label: "Verwaltung",
         value: formatCostValue(summary.administration?.total_cost, { zeroWhenMissing: true }),
@@ -107,11 +102,7 @@ function buildCostSummaryLabel(summary: CostSummary): string {
   const { totalCell, addresseeCells } = buildCostSummaryCells(summary);
   return [
     `${totalCell.label} ${totalCell.value}`,
-    ...addresseeCells.map((cell) =>
-      cell.sub
-        ? `${cell.label} ${cell.value} (${cell.sub.label} ${cell.sub.value})`
-        : `${cell.label} ${cell.value}`
-    ),
+    ...addresseeCells.map((cell) => `${cell.label} ${cell.value}`),
   ].join(" · ");
 }
 
@@ -157,14 +148,6 @@ function CostSummaryStrip({ summary }: { summary: CostSummary }) {
               >
                 {cell.value}
               </div>
-              {cell.sub && (
-                <div
-                  className="mt-0.5 whitespace-nowrap text-[11px] font-medium text-slate-500"
-                  title={`${cell.sub.label} ${cell.sub.value}`}
-                >
-                  {cell.sub.label} {cell.sub.value}
-                </div>
-              )}
             </div>
           ))}
         </div>

--- a/frontend/src/components/TotalCostPanel.tsx
+++ b/frontend/src/components/TotalCostPanel.tsx
@@ -69,7 +69,11 @@ function formatCitizenCostValue(row: TotalCostResponse | undefined): string {
 
 function buildCostSummaryCells(summary: CostSummary): {
   totalCell: { label: string; value: string };
-  addresseeCells: { label: string; value: string }[];
+  addresseeCells: {
+    label: string;
+    value: string;
+    sub?: { label: string; value: string };
+  }[];
 } {
   const administration = summary.administration?.total_cost ?? 0;
   const business = summary.business?.total_cost ?? 0;
@@ -83,6 +87,13 @@ function buildCostSummaryCells(summary: CostSummary): {
       {
         label: "Wirtschaft",
         value: formatCostValue(summary.business?.total_cost, { zeroWhenMissing: true }),
+        // Bürokratiekosten aus Informationspflichten als "davon"-Anteil der Wirtschaft.
+        sub: {
+          label: "davon IP",
+          value: formatCostValue(summary.business?.bureaucracy_cost, {
+            zeroWhenMissing: true,
+          }),
+        },
       },
       {
         label: "Verwaltung",
@@ -96,7 +107,11 @@ function buildCostSummaryLabel(summary: CostSummary): string {
   const { totalCell, addresseeCells } = buildCostSummaryCells(summary);
   return [
     `${totalCell.label} ${totalCell.value}`,
-    ...addresseeCells.map((cell) => `${cell.label} ${cell.value}`),
+    ...addresseeCells.map((cell) =>
+      cell.sub
+        ? `${cell.label} ${cell.value} (${cell.sub.label} ${cell.sub.value})`
+        : `${cell.label} ${cell.value}`
+    ),
   ].join(" · ");
 }
 
@@ -142,6 +157,14 @@ function CostSummaryStrip({ summary }: { summary: CostSummary }) {
               >
                 {cell.value}
               </div>
+              {cell.sub && (
+                <div
+                  className="mt-0.5 whitespace-nowrap text-[11px] font-medium text-slate-500"
+                  title={`${cell.sub.label} ${cell.sub.value}`}
+                >
+                  {cell.sub.label} {cell.sub.value}
+                </div>
+              )}
             </div>
           ))}
         </div>

--- a/frontend/src/components/TotalCostPanel.tsx
+++ b/frontend/src/components/TotalCostPanel.tsx
@@ -123,7 +123,7 @@ function CostSummaryStrip({ summary }: { summary: CostSummary }) {
       className="w-fit max-w-full overflow-x-auto rounded-xl border border-slate-300 bg-white px-4 py-2 shadow-sm ring-1 ring-slate-100"
       aria-label={`Kostenübersicht: ${buildCostSummaryLabel(summary)}`}
     >
-      <div className="flex min-w-max items-center">
+      <div className="flex min-w-max items-start">
         <div className="w-[120px] shrink-0">
           <div className="text-xs font-bold uppercase tracking-wide text-slate-500">
             Jährlicher

--- a/frontend/src/components/TotalCostPanel.tsx
+++ b/frontend/src/components/TotalCostPanel.tsx
@@ -69,8 +69,11 @@ function formatCitizenCostValue(row: TotalCostResponse | undefined): string {
 
 function formatBusinessCostValue(row: TotalCostResponse | undefined): string {
   const total = formatCostValue(row?.total_cost, { zeroWhenMissing: true });
-  const bureaucracy = formatCostValue(row?.bureaucracy_cost, { zeroWhenMissing: true });
-  return `${total} · davon IP ${bureaucracy}`;
+  const bureaucracy = row?.bureaucracy_cost;
+  if (typeof bureaucracy !== "number" || bureaucracy === 0) {
+    return total;
+  }
+  return `${total} · inkl. ${formatCompactCurrency(bureaucracy)} IP`;
 }
 
 function buildCostSummaryCells(summary: CostSummary): {

--- a/frontend/src/components/__tests__/TileNode.test.tsx
+++ b/frontend/src/components/__tests__/TileNode.test.tsx
@@ -57,6 +57,35 @@ describe("TileNode", () => {
     expect(screen.getByText("Neu")).toBeInTheDocument();
   });
 
+  it("renders the IP badge when showIpBadge is set", () => {
+    render(
+      <TileNode
+        {...buildTileNodeProps("regulation_5", {
+          changeStatus: "eingefuehrt",
+          showIpBadge: true,
+        })}
+      />
+    );
+
+    const badge = screen.getByLabelText("Informationspflicht Wirtschaft");
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveTextContent("IP");
+  });
+
+  it("does not render the IP badge when showIpBadge is unset", () => {
+    render(
+      <TileNode
+        {...buildTileNodeProps("regulation_6", {
+          changeStatus: "eingefuehrt",
+        })}
+      />
+    );
+
+    expect(
+      screen.queryByLabelText("Informationspflicht Wirtschaft")
+    ).not.toBeInTheDocument();
+  });
+
   it("does not bubble the expand click to parent handlers", async () => {
     const user = userEvent.setup();
     const onParentClick = jest.fn();

--- a/frontend/src/components/__tests__/TotalCostPanel.test.tsx
+++ b/frontend/src/components/__tests__/TotalCostPanel.test.tsx
@@ -277,6 +277,35 @@ describe("TotalCostPanel", () => {
     expect(mockGetTotalCostSummary).toHaveBeenCalledWith("ABC123");
   });
 
+  it("shows the business bureaucracy cost as a 'davon IP' subline", async () => {
+    mockGetTotalCostSummary.mockResolvedValue({
+      administration: { norm_addressee: "administration", total_cost: 320000 },
+      business: {
+        norm_addressee: "business",
+        total_cost: 920000,
+        bureaucracy_cost: 40000,
+      },
+      citizens: {
+        norm_addressee: "citizens",
+        total_cost: null,
+        total_time_hours: 14200,
+        total_expenses: 35000,
+      },
+    });
+    mockUseApp.mockReturnValue({
+      state: { ...baseState, totalCostReady: true },
+      setCurrentTab: jest.fn(),
+      setTotalCostReady: jest.fn(),
+    });
+
+    render(<TotalCostPanel />);
+
+    expect(await screen.findByText(/davon IP 40 Tsd\. €/)).toBeInTheDocument();
+    expect(
+      screen.getByLabelText(/Wirtschaft 920 Tsd\. € \(davon IP 40 Tsd\. €\)/i)
+    ).toBeInTheDocument();
+  });
+
   it("compacts very large citizen hours in the cost summary", async () => {
     mockGetTotalCostSummary.mockResolvedValue({
       administration: { norm_addressee: "administration", total_cost: null },

--- a/frontend/src/components/__tests__/TotalCostPanel.test.tsx
+++ b/frontend/src/components/__tests__/TotalCostPanel.test.tsx
@@ -277,7 +277,7 @@ describe("TotalCostPanel", () => {
     expect(mockGetTotalCostSummary).toHaveBeenCalledWith("ABC123");
   });
 
-  it("shows the business bureaucracy cost as an inline 'davon IP' segment", async () => {
+  it("shows the business bureaucracy cost as an inline 'inkl. IP' segment", async () => {
     mockGetTotalCostSummary.mockResolvedValue({
       administration: { norm_addressee: "administration", total_cost: 320000 },
       business: {
@@ -301,11 +301,38 @@ describe("TotalCostPanel", () => {
     render(<TotalCostPanel />);
 
     expect(
-      await screen.findByText(/920 Tsd\. € · davon IP 40 Tsd\. €/)
+      await screen.findByText(/920 Tsd\. € · inkl\. 40 Tsd\. € IP/)
     ).toBeInTheDocument();
     expect(
-      screen.getByLabelText(/Wirtschaft 920 Tsd\. € · davon IP 40 Tsd\. €/i)
+      screen.getByLabelText(/Wirtschaft 920 Tsd\. € · inkl\. 40 Tsd\. € IP/i)
     ).toBeInTheDocument();
+  });
+
+  it("omits the IP segment when the bureaucracy cost is zero", async () => {
+    mockGetTotalCostSummary.mockResolvedValue({
+      administration: { norm_addressee: "administration", total_cost: 320000 },
+      business: {
+        norm_addressee: "business",
+        total_cost: 920000,
+        bureaucracy_cost: 0,
+      },
+      citizens: {
+        norm_addressee: "citizens",
+        total_cost: null,
+        total_time_hours: 14200,
+        total_expenses: 35000,
+      },
+    });
+    mockUseApp.mockReturnValue({
+      state: { ...baseState, totalCostReady: true },
+      setCurrentTab: jest.fn(),
+      setTotalCostReady: jest.fn(),
+    });
+
+    render(<TotalCostPanel />);
+
+    expect(await screen.findByText("920 Tsd. €")).toBeInTheDocument();
+    expect(screen.queryByText(/IP/)).not.toBeInTheDocument();
   });
 
   it("compacts very large citizen hours in the cost summary", async () => {
@@ -357,9 +384,7 @@ describe("TotalCostPanel", () => {
     expect(group).toHaveClass("flex");
     expect(group).toHaveClass("gap-10");
     expect(screen.getByText("-32,7 Mio. h · 0 €")).toHaveClass("whitespace-nowrap");
-    expect(screen.getByText("-96,8 Mio. € · davon IP 0 €")).toHaveClass(
-      "whitespace-nowrap"
-    );
+    expect(screen.getByText("-96,8 Mio. €")).toHaveClass("whitespace-nowrap");
   });
 
   it("shows zero citizen effort instead of unavailable when citizen totals are empty", async () => {

--- a/frontend/src/components/__tests__/TotalCostPanel.test.tsx
+++ b/frontend/src/components/__tests__/TotalCostPanel.test.tsx
@@ -277,7 +277,7 @@ describe("TotalCostPanel", () => {
     expect(mockGetTotalCostSummary).toHaveBeenCalledWith("ABC123");
   });
 
-  it("shows the business bureaucracy cost as a 'davon IP' subline", async () => {
+  it("shows the business bureaucracy cost as an inline 'davon IP' segment", async () => {
     mockGetTotalCostSummary.mockResolvedValue({
       administration: { norm_addressee: "administration", total_cost: 320000 },
       business: {
@@ -300,9 +300,11 @@ describe("TotalCostPanel", () => {
 
     render(<TotalCostPanel />);
 
-    expect(await screen.findByText(/davon IP 40 Tsd\. €/)).toBeInTheDocument();
     expect(
-      screen.getByLabelText(/Wirtschaft 920 Tsd\. € \(davon IP 40 Tsd\. €\)/i)
+      await screen.findByText(/920 Tsd\. € · davon IP 40 Tsd\. €/)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText(/Wirtschaft 920 Tsd\. € · davon IP 40 Tsd\. €/i)
     ).toBeInTheDocument();
   });
 
@@ -355,7 +357,9 @@ describe("TotalCostPanel", () => {
     expect(group).toHaveClass("flex");
     expect(group).toHaveClass("gap-10");
     expect(screen.getByText("-32,7 Mio. h · 0 €")).toHaveClass("whitespace-nowrap");
-    expect(screen.getByText("-96,8 Mio. €")).toHaveClass("whitespace-nowrap");
+    expect(screen.getByText("-96,8 Mio. € · davon IP 0 €")).toHaveClass(
+      "whitespace-nowrap"
+    );
   });
 
   it("shows zero citizen effort instead of unavailable when citizen totals are empty", async () => {

--- a/frontend/src/components/__tests__/tileMetrics.test.ts
+++ b/frontend/src/components/__tests__/tileMetrics.test.ts
@@ -52,6 +52,22 @@ describe("tileMetrics", () => {
     });
   });
 
+  it("compacts large case group deltas", () => {
+    const tile = buildTile({
+      id: "case_group_14",
+      meta_information: {
+        change_status: "eingefuehrt",
+        cases_current: 0,
+        cases_proposed: 20_000_000,
+      },
+    });
+
+    expect(buildTileHeaderMetrics(tile)).toEqual({
+      left: "Δ +20 Mio.",
+      right: null,
+    });
+  });
+
   it("does not render case group delta pills for changed groups with incomplete cases", () => {
     const tile = buildTile({
       id: "case_group_13",

--- a/frontend/src/components/tileMetrics.ts
+++ b/frontend/src/components/tileMetrics.ts
@@ -1,6 +1,10 @@
 import { getColumnLabel } from "@/lib/effortLabels";
 import { normalizeChangeStatus } from "@/lib/changeStatus";
-import { formatCompactCurrency, formatCompactHours } from "@/lib/compactNumberFormat";
+import {
+  formatCompactCount,
+  formatCompactCurrency,
+  formatCompactHours,
+} from "@/lib/compactNumberFormat";
 import { NormAddressee, Tile } from "@/types";
 
 export type TileTableRow = {
@@ -461,7 +465,7 @@ export function buildTileHeaderMetrics(
     const delta = deltaValues.proposed - deltaValues.current;
     const prefix = delta > 0 ? "+" : "";
     return {
-      left: `Δ ${prefix}${formatCount(delta)}`,
+      left: `Δ ${prefix}${formatCompactCount(delta)}`,
       right: null,
     };
   }

--- a/frontend/src/lib/compactNumberFormat.ts
+++ b/frontend/src/lib/compactNumberFormat.ts
@@ -7,7 +7,7 @@ type CompactUnit = {
   suffix: string;
 };
 
-const CURRENCY_UNITS: CompactUnit[] = [
+const SCALE_UNITS: CompactUnit[] = [
   { divisor: 1_000_000_000, suffix: "Mrd." },
   { divisor: 1_000_000, suffix: "Mio." },
   { divisor: 1_000, suffix: "Tsd." },
@@ -46,16 +46,29 @@ function formatSmallEuro(value: number): string {
 }
 
 export function formatCompactCurrency(value: number): string {
-  const unit = resolveCompactUnit(value, CURRENCY_UNITS);
+  const unit = resolveCompactUnit(value, SCALE_UNITS);
   if (!unit) {
     return formatSmallEuro(value);
   }
-  const unitIndex = CURRENCY_UNITS.indexOf(unit);
+  const unitIndex = SCALE_UNITS.indexOf(unit);
   const promotedUnit =
     shouldPromoteAfterRounding(value, unit) && unitIndex > 0
-      ? CURRENCY_UNITS[unitIndex - 1]
+      ? SCALE_UNITS[unitIndex - 1]
       : unit;
   return `${formatCompactUnit(value, promotedUnit)} €`;
+}
+
+export function formatCompactCount(value: number): string {
+  const unit = resolveCompactUnit(value, SCALE_UNITS);
+  if (!unit) {
+    return WHOLE_NUMBER_FORMAT.format(value);
+  }
+  const unitIndex = SCALE_UNITS.indexOf(unit);
+  const promotedUnit =
+    shouldPromoteAfterRounding(value, unit) && unitIndex > 0
+      ? SCALE_UNITS[unitIndex - 1]
+      : unit;
+  return formatCompactUnit(value, promotedUnit);
 }
 
 export function formatCompactHours(value: number): string {

--- a/tests/test_compliance_text_export.py
+++ b/tests/test_compliance_text_export.py
@@ -599,3 +599,27 @@ def test_compliance_context_includes_deep_research_json_and_excerpt_status(test_
     assert context.snapshot["deep_research"]["result_json"] == {
         "prozesse": [{"prozess_id": 1}]
     }
+
+
+def test_export_attaches_vorgaben_per_process():
+    seeded = _seed_completed_session("COMP-VORGABEN-PROC")
+    session_id = seeded["session_id"]
+
+    context = build_compliance_export_context(
+        app_session_id="COMP-VORGABEN-PROC",
+        session_id=session_id,
+        user_edit_policy=USER_EDIT_REJECT,
+    )
+    adm = next(
+        a for a in context.snapshot["normadressaten"] if a["normadressat"] == ADMINISTRATION
+    )
+    prozess = adm["prozesse"][0]
+    vorgaben = prozess["vorgaben"]
+
+    assert len(vorgaben) == 1
+    vorgabe = vorgaben[0]
+    assert vorgabe["normzitat"] == "§ 1"
+    assert vorgabe["ist_informationspflicht_wirtschaft"] is False
+    assert {v["vorgaben_id"] for v in vorgaben} == {
+        v["vorgaben_id"] for v in adm["vorgaben"]
+    }

--- a/tests/test_costs_flow.py
+++ b/tests/test_costs_flow.py
@@ -1714,3 +1714,133 @@ def test_compute_costs_row_model_override_wins_and_expenses_once(test_client):
     ).fetchone()["cost_proposed"]
     # Override 50.0 * 60/60 + expenses 10 (once) = 60.0  (model 40.4 would give 50.4)
     assert cost == pytest.approx(60.0)
+
+
+def test_personnel_cost_by_level_maps_bund_land_ignores_durchschnitt():
+    from backend.core.cost_aggregation import _personnel_cost_by_level
+
+    rows = [
+        {"wage_source_kind": "verwaltungsebene", "wage_source_value": "bund",
+         "qualification": "gehobener_dienst", "time_required_in_min": 60, "model_hourly_rate": 40.0},
+        {"wage_source_kind": "verwaltungsebene", "wage_source_value": "laender",
+         "qualification": "gehobener_dienst", "time_required_in_min": 30, "model_hourly_rate": 44.0},
+        {"wage_source_kind": "verwaltungsebene", "wage_source_value": "kommunen",
+         "qualification": "gehobener_dienst", "time_required_in_min": 60, "model_hourly_rate": 40.0},
+        {"wage_source_kind": "verwaltungsebene", "wage_source_value": "durchschnitt",
+         "qualification": "gehobener_dienst", "time_required_in_min": 120, "model_hourly_rate": 42.0},
+    ]
+    result = _personnel_cost_by_level(rows, {})
+
+    # bund: 40*60/60 = 40; land: laender 44*30/60=22 + kommunen 40*60/60=40 = 62
+    assert result["bund"] == pytest.approx(40.0)
+    assert result["land"] == pytest.approx(62.0)
+    # durchschnitt/sozialversicherung sind keine Darstellungs-Ebenen -> kein Bucket.
+    assert "durchschnitt" not in result
+    assert set(result) == {"bund", "land"}
+
+
+def test_aggregate_addressee_costs_exposes_verwaltung_levels(test_client):
+    session_id, _ = db.upsert_session("COST-VERW-LEVELS", "test-model")
+    seeded = _seed_flow(session_id)
+    db.update_case_group_metrics(
+        session_id=session_id,
+        case_group_id=seeded["case_group_id"],
+        addressees_proposed=2,
+        annual_frequency_proposed=1,
+    )
+    step_one, step_two = seeded["step_one"], seeded["step_two"]
+    for step_id in (step_one, step_two):
+        db.update_process_step_effort_split(
+            session_id=session_id, step_id=step_id,
+            hourly_rates_current={}, time_required_current={}, expenses_current=None,
+            hourly_rates_proposed={"a": None, "b": 60, "c": None, "d": None},
+            time_required_proposed={"a": None, "b": 60, "c": None, "d": None},
+            expenses_proposed=None,
+        )
+    db.replace_process_step_personnel_effort(
+        session_id, ADMINISTRATION, step_one,
+        [
+            {"period": "proposed", "qualification": "gehobener_dienst",
+             "wage_source_kind": "verwaltungsebene", "wage_source_value": "bund",
+             "time_required_in_min": 60, "model_hourly_rate": 40.0},
+            {"period": "proposed", "qualification": "gehobener_dienst",
+             "wage_source_kind": "verwaltungsebene", "wage_source_value": "laender",
+             "time_required_in_min": 60, "model_hourly_rate": 40.0},
+            {"period": "proposed", "qualification": "hoeherer_dienst",
+             "wage_source_kind": "verwaltungsebene", "wage_source_value": "durchschnitt",
+             "time_required_in_min": 60, "model_hourly_rate": 42.0},
+        ],
+    )
+    db.replace_process_step_personnel_effort(
+        session_id, ADMINISTRATION, step_two,
+        [
+            {"period": "proposed", "qualification": "gehobener_dienst",
+             "wage_source_kind": "verwaltungsebene", "wage_source_value": "laender",
+             "time_required_in_min": 60, "model_hourly_rate": 40.0},
+        ],
+    )
+
+    from backend.core import cost_aggregation
+
+    cost = cost_aggregation.aggregate_addressee_costs(
+        session_id, ADMINISTRATION, apply_user_edits=True
+    )
+
+    total = cost["total_cost"]
+    bund = cost["verwaltung_bundesebene"]
+    land = cost["verwaltung_landesebene"]
+    # cases_proposed = 2, alle Zeilen per-Fall.
+    # bund: 40*60/60 * 2 = 80; land: (laender step1 40 + laender step2 40) * 2 = 160
+    assert bund == pytest.approx(80.0)
+    assert land == pytest.approx(160.0)
+    # durchschnitt (42*60/60*2 = 84) bleibt nur in der Gesamtsumme.
+    rest = total - bund - land
+    assert rest == pytest.approx(84.0)
+    assert total == pytest.approx(324.0)
+
+
+def test_aggregate_addressee_costs_verwaltung_levels_include_sachkosten(test_client):
+    session_id, _ = db.upsert_session("COST-VERW-SACH", "test-model")
+    seeded = _seed_flow(session_id)
+    db.update_case_group_metrics(
+        session_id=session_id,
+        case_group_id=seeded["case_group_id"],
+        addressees_proposed=10,
+        annual_frequency_proposed=1,
+    )
+    step_one, step_two = seeded["step_one"], seeded["step_two"]
+    db.update_process_step_effort_split(
+        session_id=session_id, step_id=step_one,
+        hourly_rates_current={}, time_required_current={}, expenses_current=None,
+        hourly_rates_proposed={"a": None, "b": 60, "c": None, "d": None},
+        time_required_proposed={"a": None, "b": 60, "c": None, "d": None},
+        expenses_proposed=100,
+    )
+    db.update_process_step_effort_split(
+        session_id=session_id, step_id=step_two,
+        hourly_rates_current={}, time_required_current={}, expenses_current=None,
+        hourly_rates_proposed={"a": None, "b": 60, "c": None, "d": None},
+        time_required_proposed={"a": None, "b": 60, "c": None, "d": None},
+        expenses_proposed=None,
+    )
+    for step_id in (step_one, step_two):
+        db.replace_process_step_personnel_effort(
+            session_id, ADMINISTRATION, step_id,
+            [
+                {"period": "proposed", "qualification": "gehobener_dienst",
+                 "wage_source_kind": "verwaltungsebene", "wage_source_value": "laender",
+                 "time_required_in_min": 60, "model_hourly_rate": 40.0},
+            ],
+        )
+
+    from backend.core import cost_aggregation
+
+    cost = cost_aggregation.aggregate_addressee_costs(
+        session_id, ADMINISTRATION, apply_user_edits=True
+    )
+    total = cost["total_cost"]
+    # Alles auf Laenderebene -> Sachkosten fliessen in die Landesebene, land == total.
+    # step_one: (Personal 40 + Sach 100) * 10 = 1400; step_two: 40 * 10 = 400; total 1800.
+    assert total == pytest.approx(1800.0)
+    assert cost["verwaltung_bundesebene"] == pytest.approx(0.0)
+    assert cost["verwaltung_landesebene"] == pytest.approx(1800.0)

--- a/tests/test_payload_builders.py
+++ b/tests/test_payload_builders.py
@@ -436,6 +436,93 @@ def test_build_step_analysis_payload_preserves_norm_addressees_and_business_flag
     ]
 
 
+def test_build_vorgaben_payload_suppresses_business_flag_outside_business_run():
+    regulations = [
+        {
+            "regulation_id": 31,
+            "process_id": 10,
+            "legal_citation": "§ 2",
+            "description": "Vorgabe B",
+            "change_status": "neu",
+            "applies_to_administration": 0,
+            "applies_to_business": 1,
+            "applies_to_citizens": 1,
+            "is_business_information_obligation": 1,
+        }
+    ]
+
+    citizens_payload = build_vorgaben_payload(regulations, norm_addressee="citizens")
+    business_payload = build_vorgaben_payload(regulations, norm_addressee="business")
+
+    assert citizens_payload[0]["normadressaten"] == ["citizens"]
+    assert citizens_payload[0]["ist_informationspflicht_wirtschaft"] is False
+    assert business_payload[0]["normadressaten"] == ["business"]
+    assert business_payload[0]["ist_informationspflicht_wirtschaft"] is True
+
+
+def test_build_step_analysis_payload_suppresses_business_flag_outside_business_run():
+    processes = [
+        {
+            "process_id": 10,
+            "process": "Prozess A",
+            "description": "Beschreibung A",
+            "change_status": "geaendert",
+        }
+    ]
+    case_groups = [
+        {
+            "case_group_id": 20,
+            "process_id": 10,
+            "case_group": "Fallgruppe A",
+            "description": "Beschreibung Fallgruppe A",
+            "change_status": "geaendert",
+        }
+    ]
+    steps = [
+        {
+            "step_id": 40,
+            "case_group_id": 20,
+            "step": "Schritt 1",
+            "description": "Beschreibung Schritt 1",
+            "change_status": "geaendert",
+            "previous_id": None,
+            "next_id": None,
+        }
+    ]
+    regulations = [
+        {
+            "regulation_id": 31,
+            "process_id": 10,
+            "legal_citation": "§ 2",
+            "description": "Vorgabe B",
+            "change_status": "neu",
+            "applies_to_administration": 0,
+            "applies_to_business": 1,
+            "applies_to_citizens": 1,
+            "is_business_information_obligation": 1,
+        }
+    ]
+
+    payload = build_step_analysis_payload(
+        processes=processes,
+        case_groups=case_groups,
+        steps=steps,
+        regulations=regulations,
+        norm_addressee="citizens",
+    )
+
+    assert payload[0]["vorgaben"] == [
+        {
+            "vorgaben_id": 31,
+            "normzitat": "§ 2",
+            "beschreibung": "Vorgabe B",
+            "aenderungsstatus": "neu",
+            "normadressaten": ["citizens"],
+            "ist_informationspflicht_wirtschaft": False,
+        }
+    ]
+
+
 def test_build_step_analysis_payload_omits_effort_fields_when_present():
     processes = [
         {

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -325,9 +325,9 @@ def test_compliance_text_prompt_keeps_detailed_labels_out_of_headings():
 
     assert "Überschriften müssen kurz bleiben" in prompt
     assert "Fallgruppen- oder Tätigkeitsbezeichnungen gehören in den Fließtext" in prompt
-    assert "### Vorgabe [Nummer]: [kurzes Stichwort]; [Norm]" in prompt
+    assert "### Vorgabe [Nummer]" not in prompt
+    assert "| Norm (§§); Bezeichnung der Vorgabe |" in prompt
     assert "Fallgruppen dürfen nicht als eigene Markdown-Überschriften" in prompt
-    assert "- Erstanerkennungsverfahren (Fallgruppe 1): ..." in prompt
     assert "steht bereits in der PDF-Infobox" in prompt
 
 

--- a/tests/test_regulations_flow.py
+++ b/tests/test_regulations_flow.py
@@ -1,6 +1,7 @@
 from backend.core import db
 from backend.core.norm_addressees import ADMINISTRATION
 from backend.core.prompts import PromptId, render_prompt
+from backend.core.session_graph import build_session_tiles_snapshot
 from backend.routers import regulations as regulations_router
 
 
@@ -551,8 +552,43 @@ def test_identify_regulations_parses_norm_addressees_and_business_information_fl
     first_tile = admin_tiles[rows[0]["regulation_id"]]
     assert first_tile.meta_information["normadressaten"] == ["administration", "business"]
 
+    # Persistierte Kacheln (Identify-Pfad) tragen das IP-Flag adressat-unabhaengig.
+    assert (
+        business_tiles[rows[0]["regulation_id"]].meta_information[
+            "is_business_information_obligation"
+        ]
+        is True
+    )
+    assert (
+        admin_tiles[rows[2]["regulation_id"]].meta_information[
+            "is_business_information_obligation"
+        ]
+        is False
+    )
 
-def test_identify_regulations_business_information_flag_adds_business_addressee(
+    # Der Snapshot-Builder (Self-Healing-Rebuild) muss das Flag ebenfalls setzen,
+    # sonst geht es beim Rebuild via GET /tiles verloren.
+    session = db.get_session_by_app_id("REG-ADDRESSEES")
+    for norm_addressee, expected in (("administration", True), ("business", True)):
+        snapshot = build_session_tiles_snapshot(session, norm_addressee)
+        flagged = next(
+            tile
+            for tile in snapshot
+            if tile.id == f"regulation_{rows[0]['regulation_id']}"
+        )
+        assert (
+            flagged.meta_information["is_business_information_obligation"] is expected
+        )
+    admin_snapshot = build_session_tiles_snapshot(session, "administration")
+    unflagged = next(
+        tile
+        for tile in admin_snapshot
+        if tile.id == f"regulation_{rows[2]['regulation_id']}"
+    )
+    assert unflagged.meta_information["is_business_information_obligation"] is False
+
+
+def test_identify_regulations_business_information_flag_cleared_when_business_missing(
     test_client, monkeypatch
 ):
     db.insert_law("business-current.txt", "aktuelles gesetz")
@@ -606,9 +642,12 @@ def test_identify_regulations_business_information_flag_adds_business_addressee(
     session_id = db.get_session_id_by_app_id("REG-BUSINESS-FLAG")
     assert session_id is not None
     row = db.list_regulations_for_session(session_id)[0]
+    # Leitfaden: IP existiert nur fuer Wirtschaft. Das LLM setzt das Flag hier ohne
+    # business im Adressaten-Set -> das Flag ist ungueltig und wird auf 0 gesetzt.
+    # Verwaltung bleibt unveraendert, es wird kein business-Adressat erfunden.
     assert row["applies_to_administration"] == 1
-    assert row["applies_to_business"] == 1
+    assert row["applies_to_business"] == 0
     assert row["applies_to_citizens"] == 0
-    assert row["is_business_information_obligation"] == 1
+    assert row["is_business_information_obligation"] == 0
 
 

--- a/tests/test_sessions_deep_research.py
+++ b/tests/test_sessions_deep_research.py
@@ -49,6 +49,95 @@ def test_research_pdf_inline_markup_deemphasizes_long_fallgruppe_bold_text():
     assert "Fallgruppe 1 Unternehmen" in rendered
 
 
+def test_research_pdf_inline_markup_renders_italic_and_keeps_unbalanced_stars():
+    rendered = sessions_router._research_pdf_inline_markup(
+        "*Fallzahl:* Jährlich sind 2 800 000 Fälle * pro Betrieb zu erwarten."
+    )
+
+    assert rendered.startswith("<i>Fallzahl:</i> Jährlich")
+    assert "Fälle * pro Betrieb" in rendered
+
+
+def test_research_pdf_inline_markup_combines_bold_and_italic():
+    rendered = sessions_router._research_pdf_inline_markup(
+        "**Zu lfd. Nr. 4.1.1:** *Fallzahl:* 2 800 000"
+    )
+
+    assert rendered == "<b>Zu lfd. Nr. 4.1.1:</b> <i>Fallzahl:</i> 2 800 000"
+
+
+def test_parse_markdown_list_reads_bullets_and_continuation_lines():
+    block = "- Erster Punkt\n  mit Fortsetzung\n* Zweiter Punkt\n  - Unterpunkt"
+
+    assert sessions_router._parse_markdown_list(block) == (
+        "",
+        [
+            (0, "Erster Punkt mit Fortsetzung"),
+            (0, "Zweiter Punkt"),
+            (1, "Unterpunkt"),
+        ],
+    )
+
+
+def test_parse_markdown_list_keeps_paragraph_that_precedes_the_bullets():
+    block = "**Zu lfd. Nr. 4.1.1:** Einhaltung\n* *Fallzahl:* 2 800 000 Fälle"
+
+    assert sessions_router._parse_markdown_list(block) == (
+        "**Zu lfd. Nr. 4.1.1:** Einhaltung",
+        [(0, "*Fallzahl:* 2 800 000 Fälle")],
+    )
+
+
+def test_parse_markdown_list_rejects_plain_paragraph():
+    assert sessions_router._parse_markdown_list("Ein Absatz ohne Aufzählung.") is None
+
+
+def test_markdown_lists_render_as_bullets_in_pdf(monkeypatch):
+    from reportlab.platypus import Paragraph, SimpleDocTemplate
+
+    captured: dict[str, list] = {}
+
+    def fake_build(self, story, *args, **kwargs):
+        captured["story"] = story
+
+    monkeypatch.setattr(SimpleDocTemplate, "build", fake_build)
+
+    report_md = (
+        "**Zu lfd. Nr. 4.1.1:** Einhaltung verbraucherschützender Vorgaben\n"
+        "* *Fallzahl:* Jährlich 2 800 000 Fälle\n"
+        "* *Digitaler Abschluss:* 1 200 000 Fälle"
+    )
+    sessions_router._render_research_report_pdf(report_md, "Titel")
+
+    paragraphs = [item for item in captured["story"] if isinstance(item, Paragraph)]
+    lead = next(
+        item
+        for item in paragraphs
+        if item.style.name == "BodyText" and "lfd. Nr." in item.text
+    )
+    bullets = [item for item in paragraphs if item.style.name == "ResearchListItem0"]
+
+    assert lead.text.startswith("<b>Zu lfd. Nr. 4.1.1:</b> Einhaltung")
+    assert len(bullets) == 2
+    assert bullets[0].text.startswith("<i>Fallzahl:</i> Jährlich")
+    assert all("*" not in bullet.text for bullet in bullets)
+
+
+def test_render_research_report_pdf_builds_document_with_lists_and_markup():
+    report_md = "\n\n".join(
+        [
+            "# 4. Erfüllungsaufwand",
+            "### Davon Bürokratiekosten aus Informationspflichten",
+            "**Zu lfd. Nr. 4.1.1:** *Fallzahl:* 2 800 000 Fälle",
+            "- Erster Punkt\n  - Unterpunkt",
+        ]
+    )
+
+    pdf = sessions_router._render_research_report_pdf(report_md, "Titel")
+
+    assert pdf.startswith(b"%PDF")
+
+
 def test_research_pdf_heading_detection_rejects_long_heading_like_paragraphs():
     assert sessions_router._is_research_pdf_heading("# E. Erfüllungsaufwand") is True
     assert sessions_router._is_research_pdf_heading("# 4. Erfüllungsaufwand") is True
@@ -106,6 +195,38 @@ def test_section_4_headings_render_as_headings_in_pdf(monkeypatch):
     assert (
         style_by_text.get("1. Erstanerkennungsverfahren (Fallgruppe 1)") == "BodyText"
     )
+
+
+def test_sub_headings_render_smaller_than_section_headings(monkeypatch):
+    from reportlab.platypus import Paragraph, SimpleDocTemplate
+
+    captured: dict[str, list] = {}
+
+    def fake_build(self, story, *args, **kwargs):
+        captured["story"] = story
+
+    monkeypatch.setattr(SimpleDocTemplate, "build", fake_build)
+
+    report_md = "\n\n".join(
+        [
+            "## E.2 Erfüllungsaufwand für die Wirtschaft",
+            "### Davon Bürokratiekosten aus Informationspflichten",
+        ]
+    )
+    sessions_router._render_research_report_pdf(report_md, "Titel")
+
+    style_by_text = {
+        getattr(item, "text", ""): item.style
+        for item in captured["story"]
+        if isinstance(item, Paragraph)
+    }
+    section = style_by_text["E.2 Erfüllungsaufwand für die Wirtschaft"]
+    sub_section = style_by_text["Davon Bürokratiekosten aus Informationspflichten"]
+
+    assert section.name == "Heading2"
+    assert sub_section.name == "ResearchSubHeading"
+    assert sub_section.fontSize < section.fontSize
+    assert sub_section.fontName == section.fontName
 
 
 def test_strip_markdown_heading_prefix_for_demoted_body_text():

--- a/tests/test_sessions_deep_research.py
+++ b/tests/test_sessions_deep_research.py
@@ -51,6 +51,7 @@ def test_research_pdf_inline_markup_deemphasizes_long_fallgruppe_bold_text():
 
 def test_research_pdf_heading_detection_rejects_long_heading_like_paragraphs():
     assert sessions_router._is_research_pdf_heading("# E. Erfüllungsaufwand") is True
+    assert sessions_router._is_research_pdf_heading("# 4. Erfüllungsaufwand") is True
     assert (
         sessions_router._is_research_pdf_heading(
             "### 1. Erstanerkennungsverfahren (Fallgruppe 1)"
@@ -64,6 +65,46 @@ def test_research_pdf_heading_detection_rejects_long_heading_like_paragraphs():
             "organisatorischen Sonderfällen"
         )
         is False
+    )
+
+
+def test_section_4_headings_render_as_headings_in_pdf(monkeypatch):
+    from reportlab.platypus import Paragraph, SimpleDocTemplate
+
+    captured: dict[str, list] = {}
+
+    def fake_build(self, story, *args, **kwargs):
+        captured["story"] = story
+
+    monkeypatch.setattr(SimpleDocTemplate, "build", fake_build)
+
+    report_md = "\n\n".join(
+        [
+            "# E. Erfüllungsaufwand",
+            "# 4. Erfüllungsaufwand",
+            "## 4.1 Erfüllungsaufwand für Bürgerinnen und Bürger",
+            "## 4.2 Erfüllungsaufwand für die Wirtschaft",
+            "## 4.3 Erfüllungsaufwand der Verwaltung",
+            "### 1. Erstanerkennungsverfahren (Fallgruppe 1)",
+        ]
+    )
+    sessions_router._render_research_report_pdf(report_md, "Titel")
+
+    style_by_text = {
+        getattr(item, "text", ""): item.style.name
+        for item in captured["story"]
+        if isinstance(item, Paragraph)
+    }
+    for heading in (
+        "E. Erfüllungsaufwand",
+        "4. Erfüllungsaufwand",
+        "4.1 Erfüllungsaufwand für Bürgerinnen und Bürger",
+        "4.2 Erfüllungsaufwand für die Wirtschaft",
+        "4.3 Erfüllungsaufwand der Verwaltung",
+    ):
+        assert style_by_text.get(heading) == "Heading2"
+    assert (
+        style_by_text.get("1. Erstanerkennungsverfahren (Fallgruppe 1)") == "BodyText"
     )
 
 

--- a/tests/test_sessions_deep_research.py
+++ b/tests/test_sessions_deep_research.py
@@ -116,7 +116,7 @@ def test_format_compliance_export_metadata_lines_includes_scope_disclaimer():
     joined = "\n".join(lines)
     assert "jaehrlichen Erfuellungsaufwand" in joined
     assert "Einmaliger Erfuellungsaufwand ist nicht Gegenstand" in joined
-    assert "Laender und Kommunen sind nicht Gegenstand" in joined
+    assert "Bundesebene und Landesebene" in joined
 
 
 def test_case_group_research_toggle_locks_after_run_started(test_client):

--- a/tests/test_sessions_deep_research.py
+++ b/tests/test_sessions_deep_research.py
@@ -66,6 +66,22 @@ def test_research_pdf_inline_markup_combines_bold_and_italic():
     assert rendered == "<b>Zu lfd. Nr. 4.1.1:</b> <i>Fallzahl:</i> 2 800 000"
 
 
+def test_research_pdf_inline_markup_renders_html_line_breaks_in_table_cells():
+    rendered = sessions_router._research_pdf_inline_markup(
+        "Digital: 11 Min.<br>Stationär: 14 Min.<br />Papier: 20 Min."
+    )
+
+    assert rendered == (
+        "Digital: 11 Min.<br/>Stationär: 14 Min.<br/>Papier: 20 Min."
+    )
+
+
+def test_research_pdf_inline_markup_still_escapes_other_html_tags():
+    rendered = sessions_router._research_pdf_inline_markup("Prüfung <script> und <b>")
+
+    assert rendered == "Prüfung &lt;script&gt; und &lt;b&gt;"
+
+
 def test_parse_markdown_list_reads_bullets_and_continuation_lines():
     block = "- Erster Punkt\n  mit Fortsetzung\n* Zweiter Punkt\n  - Unterpunkt"
 

--- a/tests/test_tiles_rebuild_steps.py
+++ b/tests/test_tiles_rebuild_steps.py
@@ -367,3 +367,120 @@ def test_list_tiles_auto_rebuilds_missing_citizens_tiles(test_client):
     assert listed.status_code == 200
     listed_tiles = listed.json()["tiles"]
     assert any(tile["id"] == f"process_{process_id}" for tile in listed_tiles)
+
+
+def test_list_tiles_self_heals_regulation_ip_flag(test_client, monkeypatch):
+    """Alt-Sessions: Vorgabe-Kacheln ohne IP-Flag werden beim ersten Anschauen
+    in-place um den echten Flag-Wert je Vorgabe ergaenzt (idempotent)."""
+    app_session_id = "TILES-IP-HEAL"
+    session_id, _ = db.upsert_session(app_session_id, "test-model")
+    reg_ip = db.insert_regulation(
+        session_id,
+        "§ 1",
+        "Informationspflicht",
+        applies_to_administration=False,
+        applies_to_business=True,
+        is_business_information_obligation=True,
+    )
+    reg_plain = db.insert_regulation(
+        session_id,
+        "§ 2",
+        "Keine Informationspflicht",
+        applies_to_administration=False,
+        applies_to_business=True,
+        is_business_information_obligation=False,
+    )
+
+    # Kanonischen Snapshot (mit Flag) fuer die Wirtschaft-Sicht persistieren.
+    rebuild = test_client.post(
+        "/tiles/rebuild",
+        json={"app_session_id": app_session_id, "norm_addressee": BUSINESS},
+    )
+    assert rebuild.status_code == 200
+
+    # Alt-Session simulieren: Flag-Schluessel aus der Vorgabe-Kachel-Meta entfernen,
+    # Positionen/Text unveraendert lassen.
+    tiles = db.fetch_tiles(session_id=session_id, norm_addressee=BUSINESS)
+    for reg_id in (reg_ip, reg_plain):
+        tile = next(t for t in tiles if t.id == f"regulation_{reg_id}")
+        stripped_meta = {
+            key: value
+            for key, value in tile.meta_information.items()
+            if key != "is_business_information_obligation"
+        }
+        assert "is_business_information_obligation" not in stripped_meta
+        db.upsert_tile(
+            Tile(
+                id=tile.id,
+                title=tile.title,
+                text=tile.text,
+                meta_information=stripped_meta,
+                column=tile.column,
+                row=tile.row,
+                deletable=tile.deletable,
+                link_from_tile=tile.link_from_tile,
+            ),
+            session_id=session_id,
+            norm_addressee=BUSINESS,
+        )
+
+    # Der Heal muss gezielt (refresh_regulation_tiles) statt ueber einen
+    # Voll-Rebuild erfolgen: Struktur/Gesamtkosten sind unveraendert, daher darf
+    # _rebuild_tiles_for_session nicht aufgerufen werden.
+    from backend.routers import tiles as tiles_router
+
+    rebuild_calls: list[int] = []
+    original_rebuild = tiles_router._rebuild_tiles_for_session
+
+    def _spy_rebuild(*args, **kwargs):
+        rebuild_calls.append(1)
+        return original_rebuild(*args, **kwargs)
+
+    monkeypatch.setattr(tiles_router, "_rebuild_tiles_for_session", _spy_rebuild)
+
+    # Erstes Anschauen heilt die Kacheln in-place mit dem echten Flag je Vorgabe.
+    listed = test_client.get(
+        "/tiles",
+        params={"app_session_id": app_session_id, "norm_addressee": BUSINESS},
+    )
+    assert listed.status_code == 200
+    assert rebuild_calls == []
+    listed_tiles = {tile["id"]: tile for tile in listed.json()["tiles"]}
+    assert (
+        listed_tiles[f"regulation_{reg_ip}"]["meta_information"][
+            "is_business_information_obligation"
+        ]
+        is True
+    )
+    assert (
+        listed_tiles[f"regulation_{reg_plain}"]["meta_information"][
+            "is_business_information_obligation"
+        ]
+        is False
+    )
+
+    # Der Refresh persistiert das Flag (nicht nur die Antwort) und erhaelt Positionen.
+    persisted = {
+        tile.id: tile
+        for tile in db.fetch_tiles(session_id=session_id, norm_addressee=BUSINESS)
+    }
+    healed_ip = persisted[f"regulation_{reg_ip}"]
+    original_ip = next(t for t in tiles if t.id == f"regulation_{reg_ip}")
+    assert healed_ip.meta_information["is_business_information_obligation"] is True
+    assert healed_ip.column == original_ip.column
+    assert healed_ip.row == original_ip.row
+    assert healed_ip.text == original_ip.text
+    assert (
+        persisted[f"regulation_{reg_plain}"].meta_information[
+            "is_business_information_obligation"
+        ]
+        is False
+    )
+
+    # Idempotenz: zweiter Aufruf aendert nichts mehr (Bedingung feuert nicht erneut).
+    listed_again = test_client.get(
+        "/tiles",
+        params={"app_session_id": app_session_id, "norm_addressee": BUSINESS},
+    )
+    assert listed_again.status_code == 200
+    assert listed_again.json()["tiles"] == listed.json()["tiles"]

--- a/tests_review/contracts/test_prompt_template_anchors.py
+++ b/tests_review/contracts/test_prompt_template_anchors.py
@@ -276,3 +276,61 @@ class TestComplianceExportVerwaltungLevels:
         compact = _compact(template)
         assert "ausschließlich den Bund" not in compact
         assert "Stelle keine Beträge für Länder" not in compact
+
+
+class TestComplianceExportSection4VorgabeTables:
+    """LF-EA4-001: Abschnitt 4 der Begruendung stellt je Normadressat genau eine
+    konsolidierte, an den Beispieldokumenten ausgerichtete Tabelle dar. Spalten:
+    `lfd. Nr.`, `Norm (§§); Bezeichnung der Vorgabe`, `Jährliche Fallzahl und
+    Einheit` sowie ein `Jährlicher Aufwand pro Fall`. Die Wirtschaftstabelle (4.2)
+    fuehrt eine `IP`-Spalte (`Ja`/leer, gebunden an
+    `ist_informationspflicht_wirtschaft`) und eine Summenzeile
+    `…davon aus Informationspflichten (IP)` (an `summen.bureaucracy_cost`
+    gebunden). Die Verwaltung (4.3) fuehrt Bund/Land nur in den Summenzeilen
+    `davon auf Bundesebene`/`davon auf Landesebene (inklusive Kommunen)`. Die
+    frueheren Zwischenueberschriften je Vorgabe entfallen.
+    """
+
+    @pytest.fixture
+    def template(self) -> str:
+        return PROMPT_TEMPLATES[PromptId.COMPLIANCE_TEXT_EXTRACTION]
+
+    def test_each_section_table_has_vorgabe_column(self, template: str):
+        assert template.count("| Norm (§§); Bezeichnung der Vorgabe |") >= 3
+
+    def test_tables_use_running_number_and_case_count_columns(self, template: str):
+        assert "| lfd. Nr. |" in template
+        assert "Jährliche Fallzahl und Einheit" in template
+
+    def test_business_table_has_ip_column(self, template: str):
+        assert "| Norm (§§); Bezeichnung der Vorgabe | IP |" in _compact(template)
+
+    def test_ip_column_uses_ja_not_symbols(self, template: str):
+        assert "In der Spalte `IP` steht `Ja`" in template
+        assert "✓" not in template
+
+    def test_business_table_has_ip_sum_row_bound_to_bureaucracy_cost(self, template: str):
+        assert "davon aus Informationspflichten (IP)" in template
+        assert "bureaucracy_cost" in template
+
+    def test_ip_column_bound_to_flag(self, template: str):
+        assert "ist_informationspflicht_wirtschaft" in template
+
+    def test_citizen_table_sum_rows(self, template: str):
+        assert "Summe Zeitaufwand (in Stunden)" in template
+        assert "Summe Sachaufwand (in Tsd. Euro)" in template
+
+    def test_per_vorgabe_heading_is_gone(self, template: str):
+        assert "### Vorgabe [Nummer]" not in template
+
+    def test_geringfuegig_row_rule_present(self, template: str):
+        assert "geringfügig" in template
+
+    def test_administration_split_stays_in_summary_rows(self, template: str):
+        assert "davon auf Bundesebene" in template
+        assert "davon auf Landesebene (inklusive Kommunen)" in template
+        assert "summen.verwaltung_bundesebene" in template
+        assert "summen.verwaltung_landesebene" in template
+
+    def test_footnote_format_present(self, template: str):
+        assert "**Zu lfd. Nr. X:**" in template

--- a/tests_review/contracts/test_prompt_template_anchors.py
+++ b/tests_review/contracts/test_prompt_template_anchors.py
@@ -334,3 +334,20 @@ class TestComplianceExportSection4VorgabeTables:
 
     def test_footnote_format_present(self, template: str):
         assert "**Zu lfd. Nr. X:**" in template
+
+
+class TestComplianceExportRounding:
+    """LF-RUND-001: Euro-Betraege im Export werden auf ganze Euro gerundet.
+    Cent-Angaben wie `14 017 746,67 Euro` sind bei Betraegen dieser
+    Groessenordnung nicht ueblich und wurden im Review beanstandet.
+    """
+
+    @pytest.fixture
+    def template(self) -> str:
+        return PROMPT_TEMPLATES[PromptId.COMPLIANCE_TEXT_EXTRACTION]
+
+    def test_template_demands_whole_euro_amounts(self, template: str):
+        assert "auf ganze Euro gerundet" in _compact(template)
+
+    def test_template_forbids_cent_amounts(self, template: str):
+        assert "Cent werden nicht ausgewiesen" in _compact(template)

--- a/tests_review/contracts/test_prompt_template_anchors.py
+++ b/tests_review/contracts/test_prompt_template_anchors.py
@@ -194,3 +194,22 @@ class TestRecurringOnlyContract:
             PromptId.PROCESS_STEP_ANALYSIS,
         ):
             assert "z.B. Einfuehrung, Implementierung" not in PROMPT_TEMPLATES[pid]
+
+
+class TestInformationspflichtDefinitionAnchor:
+    """LF-IP-001: Die inhaltliche NKRG-Definition der Informationspflicht muss
+    im REGULATIONS_IDENTIFICATION-Prompt stehen (dort wird das Flag gesetzt),
+    und die Step-Analyse muss die Checkliste Teil A an das gesetzte Flag koppeln,
+    statt die IP-Eigenschaft neu einzuschaetzen.
+    """
+
+    def test_identification_prompt_defines_informationspflicht(self):
+        template = PROMPT_TEMPLATES[PromptId.REGULATIONS_IDENTIFICATION]
+        assert "NKRG" in template
+        assert "verfuegbar zu halten" in template
+        assert "uebermitteln" in template
+
+    def test_step_analysis_business_rule_couples_teil_a_to_flag(self):
+        rule = PROCESS_STEP_ANALYSIS_ADDRESSEE_RULES[BUSINESS]
+        assert "ist_informationspflicht_wirtschaft" in rule
+        assert "Teil A" in rule

--- a/tests_review/contracts/test_prompt_template_anchors.py
+++ b/tests_review/contracts/test_prompt_template_anchors.py
@@ -213,3 +213,30 @@ class TestInformationspflichtDefinitionAnchor:
         rule = PROCESS_STEP_ANALYSIS_ADDRESSEE_RULES[BUSINESS]
         assert "ist_informationspflicht_wirtschaft" in rule
         assert "Teil A" in rule
+
+
+class TestComplianceExportInformationspflichtBinding:
+    """LF-IP-002: Der Compliance-Text-Export-Prompt muss IP-Status und IP-Summe
+    deterministisch an die Snapshot-Felder binden, statt sie vom LLM neu
+    herleiten zu lassen. Konkret muss das Template den IP-Status an das Flag
+    `ist_informationspflicht_wirtschaft` koppeln, die IP-Summe an
+    `summen.bureaucracy_cost` binden und die "Keine"-Aussage verschaerfen.
+    """
+
+    @pytest.fixture
+    def template(self) -> str:
+        return PROMPT_TEMPLATES[PromptId.COMPLIANCE_TEXT_EXTRACTION]
+
+    def test_template_binds_ip_status_to_flag(self, template: str):
+        # IP-Status muss an das Snapshot-Flag gekoppelt sein.
+        assert "ist_informationspflicht_wirtschaft" in template
+
+    def test_template_binds_ip_sum_to_bureaucracy_cost(self, template: str):
+        # IP-Summe muss an summen.bureaucracy_cost gebunden sein.
+        assert "bureaucracy_cost" in template
+
+    def test_template_tightens_keine_rule(self, template: str):
+        # Verschaerfte "Keine"-Regel: "Keine" nur zulaessig, wenn keine
+        # Wirtschafts-Vorgabe das IP-Flag traegt. Stabiler Positiv-Marker,
+        # der bei harmloser Umformulierung nicht bricht.
+        assert "ist nur zulässig, wenn keine" in _compact(template)

--- a/tests_review/contracts/test_prompt_template_anchors.py
+++ b/tests_review/contracts/test_prompt_template_anchors.py
@@ -240,3 +240,39 @@ class TestComplianceExportInformationspflichtBinding:
         # Wirtschafts-Vorgabe das IP-Flag traegt. Stabiler Positiv-Marker,
         # der bei harmloser Umformulierung nicht bricht.
         assert "ist nur zulässig, wenn keine" in _compact(template)
+
+
+class TestComplianceExportVerwaltungLevels:
+    """LF-VERW-001: Die Verwaltung wird im Export nicht mehr als reine
+    Bundesverwaltung dargestellt, sondern getrennt nach Bundesebene und
+    Landesebene (einschliesslich Kommunen), deterministisch gebunden an die
+    Snapshot-Felder summen.verwaltung_bundesebene / summen.verwaltung_landesebene
+    (StBA-Leitfaden Kap. 8: der Laenderanteil enthaelt die Kommunen).
+    """
+
+    @pytest.fixture
+    def template(self) -> str:
+        return PROMPT_TEMPLATES[PromptId.COMPLIANCE_TEXT_EXTRACTION]
+
+    def test_headings_use_verwaltung_not_bundesverwaltung(self, template: str):
+        assert "## E.3 Erfüllungsaufwand der Verwaltung" in template
+        assert "## 4.3 Erfüllungsaufwand der Verwaltung" in template
+        assert "Bundesverwaltung" not in template
+
+    def test_davon_lines_bound_to_snapshot_fields(self, template: str):
+        assert "summen.verwaltung_bundesebene" in template
+        assert "summen.verwaltung_landesebene" in template
+        assert "Bundesebene" in template
+        assert "Landesebene" in template
+
+    def test_kommunen_belong_to_landesebene(self, template: str):
+        compact = _compact(template)
+        assert (
+            "Landesebene (einschließlich Kommunen)" in compact
+            or "Länderanteil schließt die Kommunen ein" in compact
+        )
+
+    def test_no_bund_only_rule(self, template: str):
+        compact = _compact(template)
+        assert "ausschließlich den Bund" not in compact
+        assert "Stelle keine Beträge für Länder" not in compact

--- a/tests_review/contracts/test_prompt_template_anchors.py
+++ b/tests_review/contracts/test_prompt_template_anchors.py
@@ -323,6 +323,9 @@ class TestComplianceExportSection4VorgabeTables:
     def test_per_vorgabe_heading_is_gone(self, template: str):
         assert "### Vorgabe [Nummer]" not in template
 
+    def test_result_column_forbids_superscript_footnote_markers(self, template: str):
+        assert "keine hochgestellten Fußnotenziffern" in template
+
     def test_geringfuegig_row_rule_present(self, template: str):
         assert "geringfügig" in template
 


### PR DESCRIPTION
## Überblick

Dieser PR bringt zwei zusammenhängende Themen:

1. **#24 – Informationspflichten der Wirtschaft sichtbar machen:** Bürokratiekosten aus Informationspflichten (IP) werden im UI ausgewiesen und im Export an die berechneten Werte gebunden.
2. **#66 – Compliance-Text-Export (Vorblatt/Begründung):** Der Export wird an die echten BT-Drucksachen-Beispiele (`resources/compliance_text_examples`) und den Leitfaden angeglichen.

## Änderungen im Detail

### 1. IP der Wirtschaft sichtbar machen (#24)
- **Kosten-Strip:** Bürokratiekosten werden als „davon IP" ausgewiesen (inline), Spalten oben ausgerichtet. `TotalCostPanel.tsx`, `globals.css`
- **Graph-Kacheln:** Informationspflicht-Vorgaben erhalten eine „IP"-Pill; das Flag wird über die Tile-Rebuild-/Refresh-Pfade geliefert. `TileNode.tsx`, `GraphCanvas.tsx`, `tiles.py`, `tile_refresh.py`, `session_graph.py`
- **Regulations:** Business-IP-Flag wird sauber gehalten (kein Ausufern auf andere Normadressaten). `regulations.py`
- **Export-Bindung:** IP-Status an `ist_informationspflicht_wirtschaft`, IP-Summe an `summen.bureaucracy_cost` gebunden — das LLM leitet den Status nicht mehr selbst her.

### 2. Compliance-Text-Export leitfaden-/beispielkonform (#66)
- **Abschnitt 4 – konsolidierte Tabellen:** Statt eines eigenen Kapitels je Vorgabe nun **eine** kompakte Tabelle je Normadressat (4.1/4.2/4.3), wörtlich an den Beispiel-Extrakten ausgerichtet: Spalten `lfd. Nr. | Norm (§§); Bezeichnung der Vorgabe | [IP nur 4.2] | Jährliche Fallzahl und Einheit | Aufwand pro Fall | Jährlicher Erfüllungsaufwand`; „davon"-Summenzeilen; „Zu lfd. Nr."-Fußnoten unter der Tabelle.
- **Verwaltung Bund/Länder:** Kostenaufteilung in `summen.verwaltung_bundesebene`/`-landesebene`, im Export als „davon auf Bundesebene / Landesebene (inkl. Kommunen)"-Summenzeilen. `cost_aggregation.py`
- **Heading-Fix:** `# 4. Erfüllungsaufwand` rendert wieder als Überschrift im PDF.
- **PDF-Aufräumen:** Token-/Kosten-Footer aus dem Vorblatt-/Begründungs-PDF entfernt.
- **Snapshot:** je Prozess eine `vorgaben`-Liste, damit die Vorgabe-Spalte deterministisch gefüllt wird (Cache bustet über `snapshot_sha256`). `compliance_text_export.py`

## Designentscheidungen
- Der Export folgt den **Beispiel-Extrakten** (`resources/compliance_text_examples`)
- **Werte = die Änderung** des Erfüllungsaufwands (Entlastung negativ); kein einmaliger Aufwand.
- **IP nur bei der Wirtschaft** (IP-Spalte/-Summe nur in 4.2).
- **Verwaltung Bund/Länder** vorerst nur in den Summenzeilen, nicht als Spalte je Zeile.

## Tests
- **Backend:** Verwaltung-Ebenen-Split (`test_costs_flow.py`), Export-Snapshot (`test_compliance_text_export.py`), Prompt-Anker-Contracts `TestComplianceExport{InformationspflichtBinding,VerwaltungLevels,Section4VorgabeTables}` (`test_prompt_template_anchors.py`), Heading-Rendering (`test_sessions_deep_research.py`), IP-Flag (`test_regulations_flow.py`), Tile-Rebuild (`test_tiles_rebuild_steps.py`).
- **Frontend:** `TileNode.test.tsx`, `TotalCostPanel.test.tsx`.
- Export-/Contract-Tests in dieser Iteration grün verifiziert.
- Diverse Durchläufe mit unterschiedlichen Modellen