### PR TITLE
Update recommended LLM models and cost estimates

### DIFF
--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -48,30 +48,45 @@ class Settings(BaseSettings):
 settings = Settings()
 
 OPENAI_RECOMMENDED = [
-    "gpt-5.5",
     "gpt-5.4",
     "gpt-5.4-mini",
-    "gpt-5.4-nano",
-    "gpt-5.2",
 ]
 
 DEEPINFRA_RECOMMENDED = [
     "anthropic/claude-sonnet-4-6",
-    "anthropic/claude-opus-4-7",
     "deepseek-ai/DeepSeek-V3.2",
-    "Qwen/Qwen3.5-397B-A17B",
-    "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8",
 ]
 
 GEMINI_RECOMMENDED = [
-    "gemini-3.5-flash",
     "gemini-3.1-pro-preview",
-    "gemini-3.1-flash-lite",
+    "gemini-3.5-flash",
     "gemini-3-flash-preview",
-    "gemini-2.5-pro",
-    # "gemini-2.0-flash",
-    # "gemini-2.0-flash-lite",
 ]
+
+GEMINI_EXCLUDED_MODEL_TOKENS = (
+    "preview",
+    "exp",
+    "image",
+    "audio",
+    "embedding",
+    "imagen",
+    "veo",
+    "lyria",
+    "aqa",
+    "nano-banana",
+    "robotics",
+    "computer-use",
+    "deep-research",
+)
+
+
+def _is_supported_gemini_text_model(model: str) -> bool:
+    if model in GEMINI_RECOMMENDED:
+        return True
+    model_lower = model.lower()
+    return model.startswith("gemini-") and not any(
+        token in model_lower for token in GEMINI_EXCLUDED_MODEL_TOKENS
+    )
 
 
 @lru_cache(maxsize=1)
@@ -121,11 +136,14 @@ def get_openai_models(api_key: str | None = None) -> List[str]:
                     logger.info("Fetched %s OpenAI models", len(text_models))
                     return text_models
 
-        logger.warning("OpenAI API returned status %s, using hardcoded models", response.status_code)
+        logger.warning(
+            "OpenAI API returned status %s, no OpenAI models available",
+            response.status_code,
+        )
     except Exception as exc:
         logger.error("Failed to fetch OpenAI models: %s", exc)
 
-    return hardcoded_models
+    return []
 
 
 @lru_cache(maxsize=1)
@@ -154,6 +172,8 @@ def get_deepinfra_models(api_key: str | None = None) -> List[str]:
                     for model in models
                     if any(keyword in model.lower() for keyword in [
                         "llama",
+                        "anthropic",
+                        "claude",
                         "deepseek",
                         "qwen",
                         "mixtral",
@@ -170,11 +190,14 @@ def get_deepinfra_models(api_key: str | None = None) -> List[str]:
                     logger.info("Fetched %s DeepInfra models", len(text_models))
                     return text_models
 
-        logger.warning("DeepInfra API returned status %s, using hardcoded models", response.status_code)
+        logger.warning(
+            "DeepInfra API returned status %s, no DeepInfra models available",
+            response.status_code,
+        )
     except Exception as exc:
         logger.error("Failed to fetch DeepInfra models: %s", exc)
 
-    return hardcoded_models
+    return []
 
 
 @lru_cache(maxsize=1)
@@ -208,32 +231,20 @@ def get_gemini_models(api_key: str | None = None) -> List[str]:
                 text_models = [
                     model
                     for model in normalized
-                    if model.startswith("gemini-")
-                    and not any(exclude in model.lower() for exclude in [
-                        "preview",
-                        "exp",
-                        "image",
-                        "audio",
-                        "embedding",
-                        "imagen",
-                        "veo",
-                        "lyria",
-                        "aqa",
-                        "nano-banana",
-                        "robotics",
-                        "computer-use",
-                        "deep-research",
-                    ])
+                    if _is_supported_gemini_text_model(model)
                 ]
                 if text_models:
                     logger.info("Fetched %s Gemini models", len(text_models))
                     return text_models
 
-        logger.warning("Gemini API returned status %s, using hardcoded models", response.status_code)
+        logger.warning(
+            "Gemini API returned status %s, no Gemini models available",
+            response.status_code,
+        )
     except Exception as exc:
         logger.error("Failed to fetch Gemini models: %s", exc)
 
-    return hardcoded_models
+    return []
 
 
 def is_deepinfra_model(model: str) -> bool:

--- a/backend/core/llm_service.py
+++ b/backend/core/llm_service.py
@@ -1618,9 +1618,10 @@ def _estimate_cost_usd(
         return None
 
     # Standard API pricing, USD per 1M tokens.
-    # Sources (checked on 2026-06-01):
+    # Sources (checked on 2026-07-02):
     # - https://openai.com/api/pricing
     # - https://ai.google.dev/gemini-api/docs/pricing
+    # - https://deepinfra.com/pricing
     pricing_per_million: dict[str, dict[str, tuple[float, float]]] = {
         "openai": {
             "gpt-5.5": (5.00, 30.00),
@@ -1641,6 +1642,7 @@ def _estimate_cost_usd(
             "gpt-4o": (2.50, 10.00),
         },
         "gemini": {
+            "deep-research-max-preview": (2.00, 12.00),
             "deep-research-pro-preview": (2.00, 12.00),
             "deep-research-preview": (2.00, 12.00),
             "gemini-3.5-flash": (1.50, 9.00),
@@ -1651,6 +1653,19 @@ def _estimate_cost_usd(
             "gemini-2.5-pro": (1.25, 10.00),
             "gemini-2.5-flash-lite": (0.10, 0.40),
             "gemini-2.5-flash": (0.30, 2.50),
+        },
+        "deepinfra": {
+            "anthropic/claude-opus-4-8": (5.00, 25.00),
+            "anthropic/claude-opus-4-7": (5.00, 25.00),
+            "anthropic/claude-sonnet-4-6": (3.00, 15.00),
+            "deepseek-ai/deepseek-v4-flash": (0.09, 0.18),
+            "deepseek-ai/deepseek-v4-pro": (1.30, 2.60),
+            "deepseek-ai/deepseek-v3.2": (0.26, 0.38),
+            "qwen/qwen3.5-397b-a17b": (0.45, 3.00),
+            "qwen/qwen3.6-35b-a3b": (0.15, 0.95),
+            "qwen/qwen3-max": (1.20, 6.00),
+            "google/gemma-4-26b-a4b-it": (0.07, 0.34),
+            "meta-llama/llama-4-maverick-17b-128e-instruct-fp8": (0.19, 0.60),
         },
     }
     provider_pricing = pricing_per_million.get(provider.lower(), {})

--- a/frontend/src/components/ModelSelector.tsx
+++ b/frontend/src/components/ModelSelector.tsx
@@ -12,6 +12,16 @@ import { Model, OrganizedModels, ProviderModels } from "@/types";
 const emptyProvider: ProviderModels = { recommended: [], additional: [] };
 const isLikelyValidApiKey = (value: string) => value.trim().length > 10;
 const modelMenuWidth = 340;
+const recommendedModelsCheckedAt = "02.07.2026";
+const recommendedModelPriceLabels: Record<string, string> = {
+  "gpt-5.4": "$2.50 in / $15 out",
+  "gpt-5.4-mini": "$0.75 in / $4.50 out",
+  "gemini-3.1-pro-preview": "≤200k $2/$12 · >200k $4/$18",
+  "gemini-3.5-flash": "$1.50 in / $9 out",
+  "gemini-3-flash-preview": "$0.50 in / $3 out",
+  "anthropic/claude-sonnet-4-6": "$3 in / $15 out",
+  "deepseek-ai/DeepSeek-V3.2": "$0.26 in / $0.38 out",
+};
 const flattenModels = (organized: OrganizedModels) => [
   ...organized.openai.recommended,
   ...organized.openai.additional,
@@ -25,6 +35,15 @@ const compactModelName = (value: string) =>
     .replace(/^.+\//, "")
     .replace(/^gemini-/i, "g-")
     .replace(/^deep-research-/i, "dr-");
+const recommendationGroupLabel = (provider: string) =>
+  `Empfohlen - ${provider} (Stand ${recommendedModelsCheckedAt})`;
+const modelOptionLabel = (model: Model, recommended = false) => {
+  const priceLabel = recommended ? recommendedModelPriceLabels[model.id] : undefined;
+  if (!priceLabel) {
+    return model.name;
+  }
+  return `${model.id} · ${priceLabel}`;
+};
 
 const buildSelectedModelLabels = (
   selectedModel: string,
@@ -238,31 +257,37 @@ export default function ModelSelector() {
       ) : (
         <div className="mt-4 space-y-4">
           <div>
-            <label className="text-xs font-semibold text-slate-500">Modell</label>
+            <label
+              htmlFor="model-selector-select"
+              className="text-xs font-semibold text-slate-500"
+            >
+              Modell
+            </label>
             <select
+              id="model-selector-select"
               value={state.selectedModel}
               onChange={(event) => setSelectedModel(event.target.value)}
               className="mt-2 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm"
             >
               <option value="">Modell auswählen</option>
-              <optgroup label="Empfohlen - OpenAI">
+              <optgroup label={recommendationGroupLabel("OpenAI")}>
                 {visibleOrganizedModels.openai.recommended.map((model) => (
                   <option key={model.id} value={model.id}>
-                    {model.name}
+                    {modelOptionLabel(model, true)}
                   </option>
                 ))}
               </optgroup>
-              <optgroup label="Empfohlen - DeepInfra">
+              <optgroup label={recommendationGroupLabel("DeepInfra")}>
                 {visibleOrganizedModels.deepinfra.recommended.map((model) => (
                   <option key={model.id} value={model.id}>
-                    {model.name}
+                    {modelOptionLabel(model, true)}
                   </option>
                 ))}
               </optgroup>
-              <optgroup label="Empfohlen - Gemini">
+              <optgroup label={recommendationGroupLabel("Gemini")}>
                 {visibleOrganizedModels.gemini.recommended.map((model) => (
                   <option key={model.id} value={model.id}>
-                    {model.name}
+                    {modelOptionLabel(model, true)}
                   </option>
                 ))}
               </optgroup>
@@ -288,6 +313,12 @@ export default function ModelSelector() {
                 ))}
               </optgroup>
             </select>
+            {flattenModels(visibleOrganizedModels).length === 0 ? (
+              <p className="mt-2 text-[11px] leading-4 text-slate-500">
+                Kein Modell verfügbar. Bitte einen gültigen API-Schlüssel
+                eintragen oder prüfen.
+              </p>
+            ) : null}
             <p className="mt-2 text-[11px] leading-4 text-slate-500">
               Dieses Modell wird für zukünftige Prompts verwendet. Bereits
               berechnete Schritte ändern sich dadurch nicht.

--- a/frontend/src/components/__tests__/ModelSelector.test.tsx
+++ b/frontend/src/components/__tests__/ModelSelector.test.tsx
@@ -149,6 +149,86 @@ describe("ModelSelector", () => {
     expect(setAvailableModels).toHaveBeenCalled();
   });
 
+  it("shows dated recommendation groups with price guidance on recommended models", async () => {
+    localStorage.setItem("openai_api_key", "sk-very-valid-test-key");
+    localStorage.setItem("deepinfra_api_key", "di-very-valid-test-key");
+    localStorage.setItem("gemini_api_key", "AIza-very-valid-test-key");
+    const setSelectedModel = jest.fn();
+    mockUseApp.mockReturnValue({
+      state: {
+        selectedModel: "",
+        availableModels: [],
+      },
+      setAvailableModels: jest.fn(),
+      setSelectedModel,
+    });
+    mockFetchModels.mockResolvedValue({
+      organized: {
+        openai: {
+          recommended: [{ id: "gpt-5.4", name: "GPT 5.4", provider: "OpenAI" }],
+          additional: [],
+        },
+        deepinfra: {
+          recommended: [
+            {
+              id: "deepseek-ai/DeepSeek-V3.2",
+              name: "DeepSeek V3.2",
+              provider: "DeepInfra",
+            },
+          ],
+          additional: [],
+        },
+        gemini: {
+          recommended: [
+            {
+              id: "gemini-3.5-flash",
+              name: "Gemini 3.5 flash",
+              provider: "Gemini",
+            },
+          ],
+          additional: [],
+        },
+      },
+      default: "gpt-5.4",
+    });
+
+    render(<ModelSelector />);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: /llm-auswahl öffnen/i }));
+
+    expect(
+      await screen.findByRole("option", {
+        name: "gpt-5.4 · $2.50 in / $15 out",
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("option", {
+        name: "deepseek-ai/DeepSeek-V3.2 · $0.26 in / $0.38 out",
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("option", {
+        name: "gemini-3.5-flash · $1.50 in / $9 out",
+      })
+    ).toBeInTheDocument();
+    expect(
+      document.querySelector('optgroup[label="Empfohlen - OpenAI (Stand 02.07.2026)"]')
+    ).toBeInTheDocument();
+    expect(
+      document.querySelector('optgroup[label="Empfohlen - DeepInfra (Stand 02.07.2026)"]')
+    ).toBeInTheDocument();
+    expect(
+      document.querySelector('optgroup[label="Empfohlen - Gemini (Stand 02.07.2026)"]')
+    ).toBeInTheDocument();
+
+    await user.selectOptions(
+      screen.getByLabelText("Modell"),
+      "gemini-3.5-flash"
+    );
+    expect(setSelectedModel).toHaveBeenCalledWith("gemini-3.5-flash");
+  });
+
   it("only opens from the chevron control in the header split button", async () => {
     mockUseApp.mockReturnValue({
       state: {

--- a/frontend/src/lib/__tests__/llmOptions.test.ts
+++ b/frontend/src/lib/__tests__/llmOptions.test.ts
@@ -45,4 +45,20 @@ describe("buildLlmRequestOptions", () => {
       },
     });
   });
+
+  it("routes DeepInfra Claude models with the DeepInfra provider", () => {
+    const result = buildLlmRequestOptions({
+      selectedModel: "anthropic/claude-sonnet-4-6",
+      availableModels: [
+        {
+          id: "anthropic/claude-sonnet-4-6",
+          name: "Claude Sonnet 4 6",
+          provider: "DeepInfra",
+        },
+      ],
+      storage: { getItem: () => null },
+    });
+
+    expect(result.provider).toBe("deepinfra");
+  });
 });

--- a/tests/test_config_models.py
+++ b/tests/test_config_models.py
@@ -1,0 +1,104 @@
+from backend.core import config
+
+
+class _FakeGeminiResponse:
+    status_code = 200
+
+    def json(self):
+        return {
+            "data": [
+                {"id": "models/gemini-3.1-pro-preview"},
+                {"id": "models/gemini-3-flash-preview"},
+                {"id": "models/gemini-2.5-flash"},
+                {"id": "models/gemini-random-preview"},
+                {"id": "models/gemini-embedding-test"},
+            ]
+        }
+
+
+class _FakeDeepInfraResponse:
+    status_code = 200
+
+    def json(self):
+        return {
+            "data": [
+                {"id": "anthropic/claude-sonnet-4-6"},
+                {"id": "deepseek-ai/DeepSeek-V3.2"},
+                {"id": "openai/gpt-test"},
+            ]
+        }
+
+
+class _FakeUnauthorizedResponse:
+    status_code = 401
+
+    def json(self):
+        return {"error": "invalid key"}
+
+
+class _FakeGeminiClient:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return None
+
+    def get(self, *args, **kwargs):
+        return _FakeGeminiResponse()
+
+
+class _FakeDeepInfraClient(_FakeGeminiClient):
+    def get(self, *args, **kwargs):
+        return _FakeDeepInfraResponse()
+
+
+class _FakeUnauthorizedClient(_FakeGeminiClient):
+    def get(self, *args, **kwargs):
+        return _FakeUnauthorizedResponse()
+
+
+def test_get_gemini_models_keeps_recommended_preview_models(monkeypatch):
+    config.get_gemini_models.cache_clear()
+    monkeypatch.setattr(config.httpx, "Client", _FakeGeminiClient)
+
+    try:
+        models = config.get_gemini_models("AIza-valid-test-key")
+
+        assert "gemini-3.1-pro-preview" in models
+        assert "gemini-3-flash-preview" in models
+        assert "gemini-2.5-flash" in models
+        assert "gemini-random-preview" not in models
+        assert "gemini-embedding-test" not in models
+    finally:
+        config.get_gemini_models.cache_clear()
+
+
+def test_get_deepinfra_models_keeps_anthropic_claude_models(monkeypatch):
+    config.get_deepinfra_models.cache_clear()
+    monkeypatch.setattr(config.httpx, "Client", _FakeDeepInfraClient)
+
+    try:
+        models = config.get_deepinfra_models("di-valid-test-key")
+
+        assert "anthropic/claude-sonnet-4-6" in models
+        assert "deepseek-ai/DeepSeek-V3.2" in models
+        assert "openai/gpt-test" not in models
+    finally:
+        config.get_deepinfra_models.cache_clear()
+
+
+def test_get_models_return_empty_for_rejected_api_key(monkeypatch):
+    config.get_openai_models.cache_clear()
+    monkeypatch.setattr(config.httpx, "Client", _FakeUnauthorizedClient)
+
+    try:
+        assert config.get_openai_models("sk-invalid-test-key") == []
+    finally:
+        config.get_openai_models.cache_clear()
+
+
+def test_is_deepinfra_model_routes_anthropic_claude_ids():
+    assert config.is_deepinfra_model("anthropic/claude-sonnet-4-6")

--- a/tests/test_llm_service_costs.py
+++ b/tests/test_llm_service_costs.py
@@ -55,6 +55,17 @@ def test_estimate_cost_supports_deep_research_agent_alias():
     assert resolved == 26.0
 
 
+def test_estimate_cost_supports_deep_research_max_agent_alias():
+    resolved = llm_service._resolve_estimated_cost_usd(
+        provider="gemini",
+        model="deep-research-max-preview-04-2026",
+        input_tokens=1_000_000,
+        output_tokens=2_000_000,
+    )
+
+    assert resolved == 26.0
+
+
 def test_estimate_cost_supports_current_recommended_openai_models():
     assert (
         llm_service._resolve_estimated_cost_usd(
@@ -325,7 +336,7 @@ def test_estimate_cost_supports_current_recommended_gemini_models():
     )
 
 
-def test_estimate_cost_returns_none_for_deepinfra_without_provider_reported_cost():
+def test_estimate_cost_supports_deepinfra_models_without_provider_reported_cost():
     assert (
         llm_service._resolve_estimated_cost_usd(
             provider="deepinfra",
@@ -333,7 +344,25 @@ def test_estimate_cost_returns_none_for_deepinfra_without_provider_reported_cost
             input_tokens=1_000_000,
             output_tokens=1_000_000,
         )
-        is None
+        == 18.0
+    )
+    assert (
+        llm_service._resolve_estimated_cost_usd(
+            provider="deepinfra",
+            model="deepseek-ai/DeepSeek-V3.2",
+            input_tokens=1_000_000,
+            output_tokens=1_000_000,
+        )
+        == 0.64
+    )
+    assert (
+        llm_service._resolve_estimated_cost_usd(
+            provider="deepinfra",
+            model="Qwen/Qwen3.5-397B-A17B",
+            input_tokens=1_000_000,
+            output_tokens=1_000_000,
+        )
+        == 3.45
     )
 
 


### PR DESCRIPTION
**Summary**

This PR refreshes the LLM model recommendations and cost guidance used in the app.

- Updates the curated recommended models for OpenAI, Gemini, and DeepInfra.
- Shows recommendation groups in the LLM selector with `Stand 02.07.2026`.
- Adds compact price guidance for recommended models.
- Adds DeepInfra cost estimates and support for the current Deep Research Max cost alias.
- Keeps provider-reported request cost preferred over local estimates.
- Prevents invalid provider keys from showing fallback recommendations.
- Fixes model filtering so DeepInfra Claude/Sonnet models and curated Gemini preview models appear correctly.

**Reviewer Notes**

Please check the LLM selector manually with valid keys for all three providers, especially that:
- Claude Sonnet appears under DeepInfra recommendations.
- Gemini preview recommendations appear.
- Invalid keys do not show fake recommended models. (e.g. GPT5.2, I think...)
- Recommended model price labels remain compact enough in the native selector.