### PR TITLE
feat(llm): atomic-step retry, response_format observability, truncated-stream detection (#64 follow-up)

### DIFF
--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -63,6 +63,8 @@ GEMINI_RECOMMENDED = [
     "gemini-3-flash-preview",
 ]
 
+HIGH_RETRY_MODELS = ["gemini-3.5-flash", "gemini-3-flash-preview", "gpt-5.4-mini"]
+
 GEMINI_EXCLUDED_MODEL_TOKENS = (
     "preview",
     "exp",

--- a/backend/core/db.py
+++ b/backend/core/db.py
@@ -3727,6 +3727,9 @@ def list_recent_llm_answers_for_session(session_id: int, limit: int = 80) -> lis
                 "error_kind": metadata.get("error_kind"),
                 "error_status_code": metadata.get("error_status_code"),
                 "error": metadata.get("error"),
+                "response_format_requested": metadata.get("response_format_requested"),
+                "response_format_used": metadata.get("response_format_used"),
+                "response_format_downgraded": metadata.get("response_format_downgraded"),
                 "created_at": row.get("created_at"),
             }
         )

--- a/backend/core/llm_attempts.py
+++ b/backend/core/llm_attempts.py
@@ -20,6 +20,10 @@ from backend.core.llm_service import (
     coerce_llm_result,
     query_llm,
 )
+from backend.core.payload_builders import (
+    build_cases_calculation_output_schema,
+    build_effort_calculation_output_schema,
+)
 from backend.core.prompt_audit import append_prompt_audit_entry
 from backend.core.prompts import PromptId
 from backend.core.request_context import get_request_context
@@ -35,6 +39,37 @@ STRUCTURED_JSON_PROMPT_IDS = frozenset(
         PromptId.EFFORT_CALCULATION,
     }
 )
+
+JSON_OBJECT_RESPONSE_FORMAT = {"type": "json_object"}
+
+_JSON_SCHEMA_BUILDERS = {
+    PromptId.CASES_CALCULATION: (
+        "cases_calculation",
+        build_cases_calculation_output_schema,
+    ),
+    PromptId.EFFORT_CALCULATION: (
+        "effort_calculation",
+        build_effort_calculation_output_schema,
+    ),
+}
+
+
+def _structured_response_format(
+    prompt_id: str,
+    norm_addressee: str | None,
+) -> dict[str, Any] | None:
+    if prompt_id not in STRUCTURED_JSON_PROMPT_IDS:
+        return None
+    builder = _JSON_SCHEMA_BUILDERS.get(prompt_id)
+    if builder is None or not norm_addressee:
+        return JSON_OBJECT_RESPONSE_FORMAT
+    schema_name, build_schema = builder
+    return {
+        "type": "json_schema",
+        "name": schema_name,
+        "schema": build_schema(norm_addressee),
+        "strict": True,
+    }
 
 
 def _provider_metadata(provider: str | None) -> dict[str, str | None]:
@@ -371,11 +406,13 @@ async def query_and_stage_llm_answer(
             )
         if supports_on_event:
             query_kwargs["on_event"] = _on_stream_event
-        if (
-            prompt_id in STRUCTURED_JSON_PROMPT_IDS
-            and _supports_keyword_argument(query_impl, "response_format")
+        if prompt_id in STRUCTURED_JSON_PROMPT_IDS and _supports_keyword_argument(
+            query_impl, "response_format"
         ):
-            query_kwargs["response_format"] = {"type": "json_object"}
+            query_kwargs["response_format"] = _structured_response_format(
+                prompt_id,
+                norm_addressee,
+            )
         llm_result = coerce_llm_result(
             await query_impl(
                 prompt,

--- a/backend/core/llm_attempts.py
+++ b/backend/core/llm_attempts.py
@@ -696,6 +696,9 @@ def publish_llm_answer_applied(
             "output_tokens": answer.get("output_tokens"),
             "hidden_thinking_tokens": answer.get("hidden_thinking_tokens"),
             "estimated_cost_usd": answer.get("estimated_cost_usd"),
+            "response_format_requested": metadata.get("response_format_requested"),
+            "response_format_used": metadata.get("response_format_used"),
+            "response_format_downgraded": metadata.get("response_format_downgraded"),
         },
     )
 
@@ -737,6 +740,9 @@ def mark_llm_answer_apply_failed(
             "state_reason": f"session_update_failed: {_error_detail(exc)}",
             "elapsed_ms": metadata.get("elapsed_ms"),
             "error": str(exc),
+            "response_format_requested": metadata.get("response_format_requested"),
+            "response_format_used": metadata.get("response_format_used"),
+            "response_format_downgraded": metadata.get("response_format_downgraded"),
         },
     )
 

--- a/backend/core/llm_attempts.py
+++ b/backend/core/llm_attempts.py
@@ -21,8 +21,11 @@ from backend.core.llm_service import (
     query_llm,
 )
 from backend.core.payload_builders import (
+    build_case_group_development_output_schema,
     build_cases_calculation_output_schema,
     build_effort_calculation_output_schema,
+    build_process_compilation_output_schema,
+    build_step_analysis_output_schema,
 )
 from backend.core.prompt_audit import append_prompt_audit_entry
 from backend.core.prompts import PromptId
@@ -43,6 +46,18 @@ STRUCTURED_JSON_PROMPT_IDS = frozenset(
 JSON_OBJECT_RESPONSE_FORMAT = {"type": "json_object"}
 
 _JSON_SCHEMA_BUILDERS = {
+    PromptId.PROCESS_COMPILATION: (
+        "process_compilation",
+        build_process_compilation_output_schema,
+    ),
+    PromptId.CASE_GROUP_DEVELOPMENT: (
+        "case_group_development",
+        build_case_group_development_output_schema,
+    ),
+    PromptId.PROCESS_STEP_ANALYSIS: (
+        "process_step_analysis",
+        build_step_analysis_output_schema,
+    ),
     PromptId.CASES_CALCULATION: (
         "cases_calculation",
         build_cases_calculation_output_schema,
@@ -282,6 +297,9 @@ def stage_llm_response(
         "request_id": request_context.get("request_id"),
         "route_method": request_context.get("route_method"),
         "route_path": request_context.get("route_path"),
+        "response_format_requested": llm_result.response_format_requested,
+        "response_format_used": llm_result.response_format_used,
+        "response_format_downgraded": llm_result.response_format_downgraded,
     }
     if elapsed_ms is not None:
         metadata_extra["elapsed_ms"] = elapsed_ms
@@ -552,6 +570,9 @@ async def query_and_stage_llm_answer(
             "output_tokens": llm_result.output_tokens,
             "hidden_thinking_tokens": llm_result.hidden_thinking_tokens,
             "estimated_cost_usd": llm_result.estimated_cost_usd,
+            "response_format_requested": llm_result.response_format_requested,
+            "response_format_used": llm_result.response_format_used,
+            "response_format_downgraded": llm_result.response_format_downgraded,
         },
     )
     return answer_id, llm_result

--- a/backend/core/llm_json.py
+++ b/backend/core/llm_json.py
@@ -69,12 +69,42 @@ def parse_json_object_with_mode(payload: str) -> tuple[dict[str, Any] | None, st
     return data, "extract_last_json_object"
 
 
+def looks_truncated(payload: str) -> bool:
+    text = clean_llm_payload(payload)
+    if not text.startswith("{"):
+        return False
+    try:
+        json.loads(text)
+    except json.JSONDecodeError as exc:
+        return exc.pos >= len(text)
+    return False
+
+
 def require_json_object(
     payload: str,
     *,
     error_context: str,
     required_top_level_key: str | None = None,
 ) -> tuple[dict[str, Any], str]:
+    if looks_truncated(payload):
+        expected = (
+            f", expected top-level key '{required_top_level_key}'"
+            if required_top_level_key is not None
+            else ""
+        )
+        logger.warning(
+            "llm_json: abgeschnittene LLM-Antwort erkannt "
+            "(payload_len=%d, context=%s)",
+            len(clean_llm_payload(payload)),
+            error_context,
+        )
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"{error_context}: truncated LLM response, "
+                f"stream ended mid-JSON{expected}"
+            ),
+        )
     data, parse_mode = parse_json_object_with_mode(payload)
     if not isinstance(data, dict):
         raise HTTPException(

--- a/backend/core/llm_monitor.py
+++ b/backend/core/llm_monitor.py
@@ -191,6 +191,9 @@ def _update_stream_attempt_from_event(
         "error",
         "error_kind",
         "error_status_code",
+        "response_format_requested",
+        "response_format_used",
+        "response_format_downgraded",
     ]:
         if key in event and event.get(key) is not None:
             attempt[key] = event.get(key)

--- a/backend/core/llm_service.py
+++ b/backend/core/llm_service.py
@@ -237,9 +237,9 @@ async def query_llm(
     `response_format` erzwingt (wo der Provider/das Modell es unterstuetzt) die
     JSON-Ausgabe bereits am Generierungszeitpunkt. Lehnt der Provider den
     Parameter mit Bad Request ab, wird gestaffelt zurueckgefallen:
-    `json_schema -> json_object -> None`. So verliert ein Provider, der nur das
-    strikte Schema ablehnt, nicht auch die reine JSON-Syntax-Erzwingung, und der
-    Workflow scheitert nicht an fehlender Provider-Unterstuetzung.
+    `json_schema -> json_object -> None`. So verliert ein Provider in diesem
+    Bad-Request-Fall, wenn er nur das strikte Schema ablehnt, nicht auch die
+    reine JSON-Syntax-Erzwingung.
     """
     provider = (provider or "").lower().strip()
     if not provider:

--- a/backend/core/llm_service.py
+++ b/backend/core/llm_service.py
@@ -20,6 +20,7 @@ DB integration:
 import asyncio
 from dataclasses import dataclass
 import json
+import logging
 import re
 from typing import Any, Awaitable, Callable, Optional
 
@@ -36,6 +37,8 @@ from openai import (
 from .auth import ApiKeys
 from .config import is_deepinfra_model, is_gemini_model, settings
 
+
+logger = logging.getLogger("uvicorn.error")
 
 DEEPINFRA_BASE_URL = "https://api.deepinfra.com/v1/openai/chat/completions"
 GEMINI_OPENAI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/openai/"
@@ -118,6 +121,9 @@ class LlmResult:
     hidden_thinking_tokens: int | None = None
     estimated_cost_usd: float | None = None
     provider_response_json: dict[str, Any] | list[Any] | None = None
+    response_format_requested: str | None = None
+    response_format_used: str | None = None
+    response_format_downgraded: bool = False
 
 
 class LlmQueryError(RuntimeError):
@@ -211,6 +217,12 @@ def _response_format_fallback_chain(
     return [response_format, None]
 
 
+def _response_format_label(response_format: dict[str, Any] | None) -> str:
+    if not isinstance(response_format, dict):
+        return "none"
+    return str(response_format.get("type") or "none")
+
+
 async def query_llm(
     prompt: str,
     api_keys: ApiKeys,
@@ -267,15 +279,38 @@ async def query_llm(
         )
 
     if response_format is None:
-        return await _dispatch(None)
+        result = await _dispatch(None)
+        result.response_format_requested = "none"
+        result.response_format_used = "none"
+        result.response_format_downgraded = False
+        return result
+
+    requested_label = _response_format_label(response_format)
     chain = _response_format_fallback_chain(response_format)
     for index, candidate in enumerate(chain):
         try:
-            return await _dispatch(candidate)
+            result = await _dispatch(candidate)
         except LlmQueryError as exc:
             if exc.status_code == 400 and index < len(chain) - 1:
+                next_label = _response_format_label(chain[index + 1])
+                logger.warning(
+                    (
+                        "LLM response_format downgrade | provider=%s model=%s "
+                        "from=%s to=%s status=%s"
+                    ),
+                    provider,
+                    model,
+                    _response_format_label(candidate),
+                    next_label,
+                    exc.status_code,
+                )
                 continue
             raise
+        used_label = _response_format_label(candidate)
+        result.response_format_requested = requested_label
+        result.response_format_used = used_label
+        result.response_format_downgraded = used_label != requested_label
+        return result
     raise RuntimeError("unreachable response_format fallback state")
 
 

--- a/backend/core/llm_service.py
+++ b/backend/core/llm_service.py
@@ -168,6 +168,49 @@ async def _emit_stream_event(
         await maybe_awaitable
 
 
+def _is_json_schema_response_format(response_format: dict[str, Any] | None) -> bool:
+    return (
+        isinstance(response_format, dict)
+        and response_format.get("type") == "json_schema"
+    )
+
+
+def _response_format_for_responses(
+    response_format: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    if not _is_json_schema_response_format(response_format):
+        return response_format
+    return {
+        "type": "json_schema",
+        "name": response_format["name"],
+        "schema": response_format["schema"],
+        "strict": response_format.get("strict", True),
+    }
+
+
+def _response_format_for_chat(
+    response_format: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    if not _is_json_schema_response_format(response_format):
+        return response_format
+    return {
+        "type": "json_schema",
+        "json_schema": {
+            "name": response_format["name"],
+            "strict": response_format.get("strict", True),
+            "schema": response_format["schema"],
+        },
+    }
+
+
+def _response_format_fallback_chain(
+    response_format: dict[str, Any],
+) -> list[dict[str, Any] | None]:
+    if _is_json_schema_response_format(response_format):
+        return [response_format, {"type": "json_object"}, None]
+    return [response_format, None]
+
+
 async def query_llm(
     prompt: str,
     api_keys: ApiKeys,
@@ -181,8 +224,10 @@ async def query_llm(
 
     `response_format` erzwingt (wo der Provider/das Modell es unterstuetzt) die
     JSON-Ausgabe bereits am Generierungszeitpunkt. Lehnt der Provider den
-    Parameter ab (Bad Request), wird der Call einmal ohne Erzwingung wiederholt,
-    sodass der Workflow nicht an fehlender Provider-Unterstuetzung scheitert.
+    Parameter mit Bad Request ab, wird gestaffelt zurueckgefallen:
+    `json_schema -> json_object -> None`. So verliert ein Provider, der nur das
+    strikte Schema ablehnt, nicht auch die reine JSON-Syntax-Erzwingung, und der
+    Workflow scheitert nicht an fehlender Provider-Unterstuetzung.
     """
     provider = (provider or "").lower().strip()
     if not provider:
@@ -223,12 +268,15 @@ async def query_llm(
 
     if response_format is None:
         return await _dispatch(None)
-    try:
-        return await _dispatch(response_format)
-    except LlmQueryError as exc:
-        if exc.status_code == 400:
-            return await _dispatch(None)
-        raise
+    chain = _response_format_fallback_chain(response_format)
+    for index, candidate in enumerate(chain):
+        try:
+            return await _dispatch(candidate)
+        except LlmQueryError as exc:
+            if exc.status_code == 400 and index < len(chain) - 1:
+                continue
+            raise
+    raise RuntimeError("unreachable response_format fallback state")
 
 
 def _is_stream_unsupported_error(exc: Exception) -> bool:
@@ -475,7 +523,7 @@ async def query_openai(
         "messages": [{"role": "user", "content": prompt}],
     }
     if response_format is not None:
-        payload["response_format"] = response_format
+        payload["response_format"] = _response_format_for_chat(response_format)
     if settings.openai_max_tokens > 0:
         payload[_openai_chat_token_limit_key(model)] = _openai_chat_max_tokens(
             model,
@@ -604,7 +652,7 @@ async def query_gemini_openai(
         "messages": [{"role": "user", "content": prompt}],
     }
     if response_format is not None:
-        payload["response_format"] = response_format
+        payload["response_format"] = _response_format_for_chat(response_format)
     if settings.enable_web_search:
         payload["tools"] = [{"type": "web_search"}]
     async def _run_once(local_payload: dict[str, Any]) -> LlmResult:
@@ -697,7 +745,7 @@ async def _query_openai_responses(
 ) -> LlmResult:
     payload = {"model": model, "input": prompt}
     if response_format is not None:
-        payload["text"] = {"format": response_format}
+        payload["text"] = {"format": _response_format_for_responses(response_format)}
     if settings.openai_max_tokens > 0:
         payload["max_output_tokens"] = _openai_safe_max_tokens(
             settings.openai_max_tokens
@@ -946,7 +994,7 @@ async def _query_openai_responses_stream(
 ) -> LlmResult:
     payload = {"model": model, "input": prompt}
     if response_format is not None:
-        payload["text"] = {"format": response_format}
+        payload["text"] = {"format": _response_format_for_responses(response_format)}
     if settings.openai_max_tokens > 0:
         payload["max_output_tokens"] = _openai_safe_max_tokens(
             settings.openai_max_tokens
@@ -1064,7 +1112,7 @@ async def _query_deepinfra_non_stream(
         "temperature": settings.deepinfra_temperature,
     }
     if response_format is not None:
-        payload["response_format"] = response_format
+        payload["response_format"] = _response_format_for_chat(response_format)
     if settings.deepinfra_max_tokens > 0:
         payload["max_tokens"] = settings.deepinfra_max_tokens
     timeout = httpx.Timeout(600.0)
@@ -1128,7 +1176,7 @@ async def _query_deepinfra_stream(
         "stream_options": {"include_usage": True},
     }
     if response_format is not None:
-        payload["response_format"] = response_format
+        payload["response_format"] = _response_format_for_chat(response_format)
     if settings.deepinfra_max_tokens > 0:
         payload["max_tokens"] = settings.deepinfra_max_tokens
     timeout = httpx.Timeout(600.0)

--- a/backend/core/payload_builders.py
+++ b/backend/core/payload_builders.py
@@ -300,3 +300,76 @@ def build_step_analysis_output_skeleton(
         for group in process.get("fallgruppen", [])
     ]
     return {"normadressat": norm_addressee, "fallgruppen": fallgruppen}
+
+
+_CASES_METRIC_KEYS = (
+    "anzahl_betroffene_gueltig",
+    "haeufigkeit_pro_jahr_gueltig",
+    "anzahl_betroffene_vorschlag",
+    "haeufigkeit_pro_jahr_vorschlag",
+)
+
+
+def build_cases_calculation_output_skeleton(
+    case_groups_payload: list[dict],
+    *,
+    norm_addressee: str,
+) -> dict:
+    fallgruppen = [
+        {
+            "fallgruppen_id": group["fallgruppen_id"],
+            "anzahl_betroffene_gueltig": "",
+            "haeufigkeit_pro_jahr_gueltig": "",
+            "anzahl_betroffene_vorschlag": "",
+            "haeufigkeit_pro_jahr_vorschlag": "",
+            "erklaerungen": {key: "" for key in _CASES_METRIC_KEYS},
+            "confidence": {key: "" for key in _CASES_METRIC_KEYS},
+        }
+        for process in case_groups_payload
+        for group in process.get("fallgruppen", [])
+    ]
+    return {"normadressat": norm_addressee, "fallgruppen": fallgruppen}
+
+
+def _effort_taetigkeit_slots(norm_addressee: str) -> dict:
+    if norm_addressee == CITIZENS:
+        return {
+            "zeitaufwand_in_min_gueltig": "",
+            "sachaufwand_gueltig": "",
+            "zeitaufwand_in_min_vorschlag": "",
+            "sachaufwand_vorschlag": "",
+        }
+    return {
+        "personalaufwand_gueltig": [
+            {"qualifikation": "", "lohnquelle": "", "zeitaufwand_in_min": ""}
+        ],
+        "sachaufwand_gueltig": "",
+        "personalaufwand_vorschlag": [
+            {"qualifikation": "", "lohnquelle": "", "zeitaufwand_in_min": ""}
+        ],
+        "sachaufwand_vorschlag": "",
+    }
+
+
+def build_effort_calculation_output_skeleton(
+    step_analysis_payload: list[dict],
+    *,
+    norm_addressee: str,
+) -> dict:
+    fallgruppen: list[dict] = []
+    for process in step_analysis_payload:
+        for group in process.get("fallgruppen", []):
+            taetigkeiten = [
+                {
+                    "taetigkeiten_id": step["taetigkeiten_id"],
+                    **_effort_taetigkeit_slots(norm_addressee),
+                }
+                for step in group.get("taetigkeiten", [])
+            ]
+            fallgruppen.append(
+                {
+                    "fallgruppen_id": group["fallgruppen_id"],
+                    "taetigkeiten": taetigkeiten,
+                }
+            )
+    return {"normadressat": norm_addressee, "fallgruppen": fallgruppen}

--- a/backend/core/payload_builders.py
+++ b/backend/core/payload_builders.py
@@ -284,3 +284,19 @@ def build_step_analysis_payload(
         )
         payload.append(process_payload.model_dump())
     return payload
+
+
+def build_step_analysis_output_skeleton(
+    case_groups_payload: list[dict],
+    *,
+    norm_addressee: str,
+) -> dict:
+    fallgruppen = [
+        {
+            "fallgruppen_id": group["fallgruppen_id"],
+            "taetigkeiten": [],
+        }
+        for process in case_groups_payload
+        for group in process.get("fallgruppen", [])
+    ]
+    return {"normadressat": norm_addressee, "fallgruppen": fallgruppen}

--- a/backend/core/payload_builders.py
+++ b/backend/core/payload_builders.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 import json
 from typing import Any
 
@@ -317,13 +318,8 @@ def build_cases_calculation_output_skeleton(
 ) -> dict:
     fallgruppen = [
         {
+            **_CASES_FALLGRUPPE.to_slots(),
             "fallgruppen_id": group["fallgruppen_id"],
-            "anzahl_betroffene_gueltig": "",
-            "haeufigkeit_pro_jahr_gueltig": "",
-            "anzahl_betroffene_vorschlag": "",
-            "haeufigkeit_pro_jahr_vorschlag": "",
-            "erklaerungen": {key: "" for key in _CASES_METRIC_KEYS},
-            "confidence": {key: "" for key in _CASES_METRIC_KEYS},
         }
         for process in case_groups_payload
         for group in process.get("fallgruppen", [])
@@ -331,38 +327,19 @@ def build_cases_calculation_output_skeleton(
     return {"normadressat": norm_addressee, "fallgruppen": fallgruppen}
 
 
-def _effort_taetigkeit_slots(norm_addressee: str) -> dict:
-    if norm_addressee == CITIZENS:
-        return {
-            "zeitaufwand_in_min_gueltig": "",
-            "sachaufwand_gueltig": "",
-            "zeitaufwand_in_min_vorschlag": "",
-            "sachaufwand_vorschlag": "",
-        }
-    return {
-        "personalaufwand_gueltig": [
-            {"qualifikation": "", "lohnquelle": "", "zeitaufwand_in_min": ""}
-        ],
-        "sachaufwand_gueltig": "",
-        "personalaufwand_vorschlag": [
-            {"qualifikation": "", "lohnquelle": "", "zeitaufwand_in_min": ""}
-        ],
-        "sachaufwand_vorschlag": "",
-    }
-
-
 def build_effort_calculation_output_skeleton(
     step_analysis_payload: list[dict],
     *,
     norm_addressee: str,
 ) -> dict:
+    taetigkeit = _effort_taetigkeit(norm_addressee)
     fallgruppen: list[dict] = []
     for process in step_analysis_payload:
         for group in process.get("fallgruppen", []):
             taetigkeiten = [
                 {
+                    **taetigkeit.to_slots(),
                     "taetigkeiten_id": step["taetigkeiten_id"],
-                    **_effort_taetigkeit_slots(norm_addressee),
                 }
                 for step in group.get("taetigkeiten", [])
             ]
@@ -377,8 +354,6 @@ def build_effort_calculation_output_skeleton(
 
 _CONFIDENCE_ENUM = ("high", "medium", "low")
 
-_NULLABLE_NUMBER = {"type": ["number", "null"]}
-
 
 def _strict_object(properties: dict[str, Any]) -> dict:
     return {
@@ -389,78 +364,205 @@ def _strict_object(properties: dict[str, Any]) -> dict:
     }
 
 
-def build_cases_calculation_output_schema(norm_addressee: str) -> dict:
-    fallgruppe = _strict_object(
-        {
-            "fallgruppen_id": {"type": "integer"},
-            "anzahl_betroffene_gueltig": _NULLABLE_NUMBER,
-            "haeufigkeit_pro_jahr_gueltig": _NULLABLE_NUMBER,
-            "anzahl_betroffene_vorschlag": _NULLABLE_NUMBER,
-            "haeufigkeit_pro_jahr_vorschlag": _NULLABLE_NUMBER,
-            "erklaerungen": _strict_object(
-                {key: {"type": "string"} for key in _CASES_METRIC_KEYS}
-            ),
-            "confidence": _strict_object(
-                {
-                    key: {"type": "string", "enum": list(_CONFIDENCE_ENUM)}
-                    for key in _CASES_METRIC_KEYS
-                }
-            ),
-        }
-    )
-    return _strict_object(
-        {
-            "normadressat": {"type": "string", "enum": [norm_addressee]},
-            "fallgruppen": {"type": "array", "items": fallgruppe},
-        }
-    )
+_EMPTY_SLOT = ""
 
 
-def _effort_taetigkeit_schema(norm_addressee: str) -> dict:
-    if norm_addressee == CITIZENS:
+class _Node:
+    def to_schema(self) -> dict:
+        raise NotImplementedError
+
+    def to_slots(self) -> Any:
+        return _EMPTY_SLOT
+
+
+@dataclass(frozen=True)
+class _Str(_Node):
+    def to_schema(self) -> dict:
+        return {"type": "string"}
+
+
+@dataclass(frozen=True)
+class _Int(_Node):
+    def to_schema(self) -> dict:
+        return {"type": "integer"}
+
+
+@dataclass(frozen=True)
+class _Num(_Node):
+    def to_schema(self) -> dict:
+        return {"type": ["number", "null"]}
+
+
+@dataclass(frozen=True)
+class _Enum(_Node):
+    values: tuple[str, ...]
+
+    def to_schema(self) -> dict:
+        return {"type": "string", "enum": list(self.values)}
+
+
+@dataclass(frozen=True)
+class _Arr(_Node):
+    item: _Node
+
+    def to_schema(self) -> dict:
+        return {"type": "array", "items": self.item.to_schema()}
+
+    def to_slots(self) -> Any:
+        return [self.item.to_slots()]
+
+
+@dataclass(frozen=True)
+class _Obj(_Node):
+    properties: dict[str, _Node]
+
+    def to_schema(self) -> dict:
         return _strict_object(
+            {key: node.to_schema() for key, node in self.properties.items()}
+        )
+
+    def to_slots(self) -> Any:
+        return {key: node.to_slots() for key, node in self.properties.items()}
+
+
+_CHANGE_STATUS = _Enum(("eingefuehrt", "geaendert", "abgeschafft"))
+
+_CHANGE_STATUS_WITH_UNCHANGED = _Enum(
+    ("eingefuehrt", "geaendert", "abgeschafft", "unveraendert")
+)
+
+
+_STEP_ANALYSIS_TAETIGKEIT = _Obj(
+    {
+        "taetigkeit": _Str(),
+        "beschreibung": _Str(),
+        "aenderungsstatus": _CHANGE_STATUS_WITH_UNCHANGED,
+    }
+)
+
+
+def _fallgruppen_envelope(norm_addressee: str, fallgruppe: _Node) -> _Obj:
+    return _Obj(
+        {
+            "normadressat": _Enum((norm_addressee,)),
+            "fallgruppen": _Arr(fallgruppe),
+        }
+    )
+
+
+def _prozesse_envelope(norm_addressee: str, prozess: _Node) -> _Obj:
+    return _Obj(
+        {
+            "normadressat": _Enum((norm_addressee,)),
+            "prozesse": _Arr(prozess),
+        }
+    )
+
+
+def build_step_analysis_output_schema(norm_addressee: str) -> dict:
+    fallgruppe = _Obj(
+        {
+            "fallgruppen_id": _Int(),
+            "taetigkeiten": _Arr(_STEP_ANALYSIS_TAETIGKEIT),
+        }
+    )
+    return _fallgruppen_envelope(norm_addressee, fallgruppe).to_schema()
+
+
+_VORGABE = _Obj(
+    {
+        "vorgaben_id": _Int(),
+        "normzitat": _Str(),
+        "beschreibung": _Str(),
+        "aenderungsstatus": _CHANGE_STATUS,
+    }
+)
+
+_CASE_GROUP_FALLGRUPPE = _Obj(
+    {
+        "fallgruppe_bezeichnung": _Str(),
+        "fallgruppe_beschreibung": _Str(),
+        "aenderungsstatus": _CHANGE_STATUS,
+    }
+)
+
+
+def build_case_group_development_output_schema(norm_addressee: str) -> dict:
+    prozess = _Obj(
+        {
+            "prozess_id": _Int(),
+            "prozess_bezeichnung": _Str(),
+            "prozess_beschreibung": _Str(),
+            "aenderungsstatus": _CHANGE_STATUS,
+            "vorgaben": _Arr(_VORGABE),
+            "fallgruppen": _Arr(_CASE_GROUP_FALLGRUPPE),
+        }
+    )
+    return _prozesse_envelope(norm_addressee, prozess).to_schema()
+
+
+def build_process_compilation_output_schema(norm_addressee: str) -> dict:
+    prozess = _Obj(
+        {
+            "prozess_bezeichnung": _Str(),
+            "prozess_beschreibung": _Str(),
+            "aenderungsstatus": _CHANGE_STATUS,
+            "vorgaben": _Arr(_VORGABE),
+        }
+    )
+    return _prozesse_envelope(norm_addressee, prozess).to_schema()
+
+
+_CASES_FALLGRUPPE = _Obj(
+    {
+        "fallgruppen_id": _Int(),
+        **{key: _Num() for key in _CASES_METRIC_KEYS},
+        "erklaerungen": _Obj({key: _Str() for key in _CASES_METRIC_KEYS}),
+        "confidence": _Obj({key: _Enum(_CONFIDENCE_ENUM) for key in _CASES_METRIC_KEYS}),
+    }
+)
+
+
+def build_cases_calculation_output_schema(norm_addressee: str) -> dict:
+    return _fallgruppen_envelope(norm_addressee, _CASES_FALLGRUPPE).to_schema()
+
+
+def _effort_taetigkeit(norm_addressee: str) -> _Obj:
+    if norm_addressee == CITIZENS:
+        return _Obj(
             {
-                "taetigkeiten_id": {"type": "integer"},
-                "zeitaufwand_in_min_gueltig": _NULLABLE_NUMBER,
-                "sachaufwand_gueltig": _NULLABLE_NUMBER,
-                "zeitaufwand_in_min_vorschlag": _NULLABLE_NUMBER,
-                "sachaufwand_vorschlag": _NULLABLE_NUMBER,
+                "taetigkeiten_id": _Int(),
+                "zeitaufwand_in_min_gueltig": _Num(),
+                "sachaufwand_gueltig": _Num(),
+                "zeitaufwand_in_min_vorschlag": _Num(),
+                "sachaufwand_vorschlag": _Num(),
             }
         )
-    personalaufwand_item = _strict_object(
-        {
-            "qualifikation": {"type": "string"},
-            "lohnquelle": {"type": "string"},
-            "zeitaufwand_in_min": _NULLABLE_NUMBER,
-        }
+    personalaufwand = _Arr(
+        _Obj(
+            {
+                "qualifikation": _Str(),
+                "lohnquelle": _Str(),
+                "zeitaufwand_in_min": _Num(),
+            }
+        )
     )
-    return _strict_object(
+    return _Obj(
         {
-            "taetigkeiten_id": {"type": "integer"},
-            "personalaufwand_gueltig": {"type": "array", "items": personalaufwand_item},
-            "sachaufwand_gueltig": _NULLABLE_NUMBER,
-            "personalaufwand_vorschlag": {
-                "type": "array",
-                "items": personalaufwand_item,
-            },
-            "sachaufwand_vorschlag": _NULLABLE_NUMBER,
+            "taetigkeiten_id": _Int(),
+            "personalaufwand_gueltig": personalaufwand,
+            "sachaufwand_gueltig": _Num(),
+            "personalaufwand_vorschlag": personalaufwand,
+            "sachaufwand_vorschlag": _Num(),
         }
     )
 
 
 def build_effort_calculation_output_schema(norm_addressee: str) -> dict:
-    fallgruppe = _strict_object(
+    fallgruppe = _Obj(
         {
-            "fallgruppen_id": {"type": "integer"},
-            "taetigkeiten": {
-                "type": "array",
-                "items": _effort_taetigkeit_schema(norm_addressee),
-            },
+            "fallgruppen_id": _Int(),
+            "taetigkeiten": _Arr(_effort_taetigkeit(norm_addressee)),
         }
     )
-    return _strict_object(
-        {
-            "normadressat": {"type": "string", "enum": [norm_addressee]},
-            "fallgruppen": {"type": "array", "items": fallgruppe},
-        }
-    )
+    return _fallgruppen_envelope(norm_addressee, fallgruppe).to_schema()

--- a/backend/core/payload_builders.py
+++ b/backend/core/payload_builders.py
@@ -373,3 +373,94 @@ def build_effort_calculation_output_skeleton(
                 }
             )
     return {"normadressat": norm_addressee, "fallgruppen": fallgruppen}
+
+
+_CONFIDENCE_ENUM = ("high", "medium", "low")
+
+_NULLABLE_NUMBER = {"type": ["number", "null"]}
+
+
+def _strict_object(properties: dict[str, Any]) -> dict:
+    return {
+        "type": "object",
+        "properties": properties,
+        "required": list(properties.keys()),
+        "additionalProperties": False,
+    }
+
+
+def build_cases_calculation_output_schema(norm_addressee: str) -> dict:
+    fallgruppe = _strict_object(
+        {
+            "fallgruppen_id": {"type": "integer"},
+            "anzahl_betroffene_gueltig": _NULLABLE_NUMBER,
+            "haeufigkeit_pro_jahr_gueltig": _NULLABLE_NUMBER,
+            "anzahl_betroffene_vorschlag": _NULLABLE_NUMBER,
+            "haeufigkeit_pro_jahr_vorschlag": _NULLABLE_NUMBER,
+            "erklaerungen": _strict_object(
+                {key: {"type": "string"} for key in _CASES_METRIC_KEYS}
+            ),
+            "confidence": _strict_object(
+                {
+                    key: {"type": "string", "enum": list(_CONFIDENCE_ENUM)}
+                    for key in _CASES_METRIC_KEYS
+                }
+            ),
+        }
+    )
+    return _strict_object(
+        {
+            "normadressat": {"type": "string", "enum": [norm_addressee]},
+            "fallgruppen": {"type": "array", "items": fallgruppe},
+        }
+    )
+
+
+def _effort_taetigkeit_schema(norm_addressee: str) -> dict:
+    if norm_addressee == CITIZENS:
+        return _strict_object(
+            {
+                "taetigkeiten_id": {"type": "integer"},
+                "zeitaufwand_in_min_gueltig": _NULLABLE_NUMBER,
+                "sachaufwand_gueltig": _NULLABLE_NUMBER,
+                "zeitaufwand_in_min_vorschlag": _NULLABLE_NUMBER,
+                "sachaufwand_vorschlag": _NULLABLE_NUMBER,
+            }
+        )
+    personalaufwand_item = _strict_object(
+        {
+            "qualifikation": {"type": "string"},
+            "lohnquelle": {"type": "string"},
+            "zeitaufwand_in_min": _NULLABLE_NUMBER,
+        }
+    )
+    return _strict_object(
+        {
+            "taetigkeiten_id": {"type": "integer"},
+            "personalaufwand_gueltig": {"type": "array", "items": personalaufwand_item},
+            "sachaufwand_gueltig": _NULLABLE_NUMBER,
+            "personalaufwand_vorschlag": {
+                "type": "array",
+                "items": personalaufwand_item,
+            },
+            "sachaufwand_vorschlag": _NULLABLE_NUMBER,
+        }
+    )
+
+
+def build_effort_calculation_output_schema(norm_addressee: str) -> dict:
+    fallgruppe = _strict_object(
+        {
+            "fallgruppen_id": {"type": "integer"},
+            "taetigkeiten": {
+                "type": "array",
+                "items": _effort_taetigkeit_schema(norm_addressee),
+            },
+        }
+    )
+    return _strict_object(
+        {
+            "normadressat": {"type": "string", "enum": [norm_addressee]},
+            "fallgruppen": {"type": "array", "items": fallgruppe},
+        }
+    )

--- a/backend/core/prompts.py
+++ b/backend/core/prompts.py
@@ -436,106 +436,38 @@ EFFORT_APPENDICES: Dict[str, str] = {
 }
 
 
-EFFORT_JSON_SCHEMA_DEFAULT = """
+EFFORT_TAETIGKEIT_FORM_DEFAULT = """
 {
-"normadressat": "{norm_addressee}",
-"prozesse": [
-    {
-    "prozess_id": "",
-    "prozess_bezeichnung": "",
-    "prozess_beschreibung": "",
-    "aenderungsstatus": "",
-    "vorgaben": [
+    "taetigkeiten_id": "",
+    "personalaufwand_gueltig": [
         {
-            "vorgaben_id": "",
-            "normzitat": "",
-            "beschreibung": "",
-            "aenderungsstatus": ""
+            "qualifikation": "",
+            "lohnquelle": "",
+            "zeitaufwand_in_min": ""
         }
     ],
-    "fallgruppen": [
+    "sachaufwand_gueltig": "",
+    "personalaufwand_vorschlag": [
         {
-            "fallgruppen_id": "",
-            "fallgruppe_bezeichnung": "",
-            "fallgruppe_beschreibung": "",
-            "aenderungsstatus": "",
-            "taetigkeiten": [
-                {
-                    "taetigkeiten_id": "",
-                    "taetigkeit": "",
-                    "beschreibung": "",
-                    "aenderungsstatus": "",
-                    "personalaufwand_gueltig": [
-                        {
-                            "qualifikation": "",
-                            "lohnquelle": "",
-                            "zeitaufwand_in_min": ""
-                        }
-                    ],
-                    "sachaufwand_gueltig": "",
-                    "personalaufwand_vorschlag": [
-                        {
-                            "qualifikation": "",
-                            "lohnquelle": "",
-                            "zeitaufwand_in_min": ""
-                        }
-                    ],
-                    "sachaufwand_vorschlag": ""
-                }
-            ]
+            "qualifikation": "",
+            "lohnquelle": "",
+            "zeitaufwand_in_min": ""
         }
-    ]
-    }
-]
+    ],
+    "sachaufwand_vorschlag": ""
 }
-
-Das Feld `normadressat` ist fuer diesen Lauf fest vorgegeben und muss exakt `{norm_addressee}` lauten.
 """
 
 
-EFFORT_JSON_SCHEMA_BY_ADDRESSEE: Dict[str, str] = {
+EFFORT_TAETIGKEIT_FORM_BY_ADDRESSEE: Dict[str, str] = {
     CITIZENS: """
 {
-"normadressat": "citizens",
-"prozesse": [
-    {
-    "prozess_id": "",
-    "prozess_bezeichnung": "",
-    "prozess_beschreibung": "",
-    "aenderungsstatus": "",
-    "vorgaben": [
-        {
-            "vorgaben_id": "",
-            "normzitat": "",
-            "beschreibung": "",
-            "aenderungsstatus": ""
-        }
-    ],
-    "fallgruppen": [
-        {
-            "fallgruppen_id": "",
-            "fallgruppe_bezeichnung": "",
-            "fallgruppe_beschreibung": "",
-            "aenderungsstatus": "",
-            "taetigkeiten": [
-                {
-                    "taetigkeiten_id": "",
-                    "taetigkeit": "",
-                    "beschreibung": "",
-                    "aenderungsstatus": "",
-                    "zeitaufwand_in_min_gueltig": "",
-                    "sachaufwand_gueltig": "",
-                    "zeitaufwand_in_min_vorschlag": "",
-                    "sachaufwand_vorschlag": ""
-                }
-            ]
-        }
-    ]
-    }
-]
+    "taetigkeiten_id": "",
+    "zeitaufwand_in_min_gueltig": "",
+    "sachaufwand_gueltig": "",
+    "zeitaufwand_in_min_vorschlag": "",
+    "sachaufwand_vorschlag": ""
 }
-
-Das Feld `normadressat` ist immer `citizens` fuer dieses Schema.
 """
 }
 
@@ -914,6 +846,8 @@ PROMPT_TEMPLATES: Dict[str, str] = {
     ),
     # Render contract:
     # - case_groups_json: JSON string of list[ProzessWithFallgruppenPayload]
+    # - output_skeleton_json: JSON string of the prefilled flat output shell
+    #   ({"normadressat", "fallgruppen": [{"fallgruppen_id", <cases slots>}]})
     # - norm_addressee: "administration" | "business" | "citizens"
     # - law_summary: str, optional if session_id/app_session_id is provided
     # Auto-filled by render_prompt:
@@ -921,6 +855,7 @@ PROMPT_TEMPLATES: Dict[str, str] = {
     # - handbook_cases_case_example
     # - norm_addressee_prompt_opening
     # - norm_addressee_rule
+    # - output_skeleton_json (empty-fallgruppen default when not provided)
     PromptId.CASES_CALCULATION: (
         LEGIST_PROMPT_OPENING
         + """
@@ -966,122 +901,36 @@ PROMPT_TEMPLATES: Dict[str, str] = {
 
         Geben Sie zu jeder vorgegebenen `fallgruppen_id` genau eine Kennzahlenmenge aus; pruefen Sie vor der Ausgabe, dass keine `fallgruppen_id` mehrfach vorkommt. Uebernehmen Sie alle IDs exakt wie vorgegeben.
 
-        Geben Sie nur und ausschliesslich JSON im folgenden Format zurueck:
+        Geben Sie nur und ausschliesslich JSON zurueck. Fuellen Sie ausschliesslich die Kennzahlenfelder je Fallgruppe im folgenden vorbefuellten Skelett aus. Fuegen Sie keine Fallgruppen-Objekte hinzu, entfernen, verschieben oder duplizieren Sie keine und uebernehmen Sie jede `fallgruppen_id` exakt an ihrer vorgegebenen Position.
 
         Fuegen Sie fuer jede Fallgruppe zusaetzlich erklaerungen und confidence hinzu. Die erklaerungen
         muessen pro Kennzahl kurz und eigenstaendig darstellen, auf welcher Grundlage der jeweilige Wert hergeleitet wurde.
         confidence muss pro Kennzahl genau einen der Werte high, medium oder low enthalten und gibt an,
         wie belastbar die jeweilige Schaetzung ist.
 
+        Jede Fallgruppe hat folgende Kennzahlenform:
+
         {{
-        "normadressat": "{norm_addressee}",
-        "prozesse": [
-            {{
-            "prozess_id": "",
-            "prozess_bezeichnung": "",
-            "prozess_beschreibung": "",
-            "aenderungsstatus": "",
-            "vorgaben": [
-                {{
-                    "vorgaben_id": "",
-                    "normzitat": "",
-                    "beschreibung": "",
-                    "aenderungsstatus": ""
-                }}
-            ],
-            "fallgruppen": [
-                {{
-                    "fallgruppen_id": "",
-                    "fallgruppe_bezeichnung": "",
-                    "fallgruppe_beschreibung": "",
-                    "aenderungsstatus": "",
-                    "anzahl_betroffene_gueltig": "",
-                    "haeufigkeit_pro_jahr_gueltig": "",
-                    "anzahl_betroffene_vorschlag": "",
-                    "haeufigkeit_pro_jahr_vorschlag": "",
-                    "erklaerungen": {{
-                        "anzahl_betroffene_gueltig": "",
-                        "haeufigkeit_pro_jahr_gueltig": "",
-                        "anzahl_betroffene_vorschlag": "",
-                        "haeufigkeit_pro_jahr_vorschlag": ""
-                    }},
-                    "confidence": {{
-                        "anzahl_betroffene_gueltig": "high | medium | low",
-                        "haeufigkeit_pro_jahr_gueltig": "high | medium | low",
-                        "anzahl_betroffene_vorschlag": "high | medium | low",
-                        "haeufigkeit_pro_jahr_vorschlag": "high | medium | low"
-                    }}
-                }},
-                {{
-                    "fallgruppen_id": "",
-                    "fallgruppe_bezeichnung": "",
-                    "fallgruppe_beschreibung": "",
-                    "aenderungsstatus": "",
-                    "anzahl_betroffene_gueltig": "",
-                    "haeufigkeit_pro_jahr_gueltig": "",
-                    "anzahl_betroffene_vorschlag": "",
-                    "haeufigkeit_pro_jahr_vorschlag": "",
-                    "erklaerungen": {{
-                        "anzahl_betroffene_gueltig": "",
-                        "haeufigkeit_pro_jahr_gueltig": "",
-                        "anzahl_betroffene_vorschlag": "",
-                        "haeufigkeit_pro_jahr_vorschlag": ""
-                    }},
-                    "confidence": {{
-                        "anzahl_betroffene_gueltig": "high | medium | low",
-                        "haeufigkeit_pro_jahr_gueltig": "high | medium | low",
-                        "anzahl_betroffene_vorschlag": "high | medium | low",
-                        "haeufigkeit_pro_jahr_vorschlag": "high | medium | low"
-                    }}
-                }}
-            ]
+            "fallgruppen_id": "",
+            "anzahl_betroffene_gueltig": "",
+            "haeufigkeit_pro_jahr_gueltig": "",
+            "anzahl_betroffene_vorschlag": "",
+            "haeufigkeit_pro_jahr_vorschlag": "",
+            "erklaerungen": {{
+                "anzahl_betroffene_gueltig": "",
+                "haeufigkeit_pro_jahr_gueltig": "",
+                "anzahl_betroffene_vorschlag": "",
+                "haeufigkeit_pro_jahr_vorschlag": ""
             }},
-            {{
-            "prozess_id": "",
-            "prozess_bezeichnung": "",
-            "prozess_beschreibung": "",
-            "aenderungsstatus": "",
-            "vorgaben": [
-                {{
-                    "vorgaben_id": "",
-                    "normzitat": "",
-                    "beschreibung": "",
-                    "aenderungsstatus": ""
-                }},
-                {{
-                    "vorgaben_id": "",
-                    "normzitat": "",
-                    "beschreibung": "",
-                    "aenderungsstatus": ""
-                }}
-            ],
-            "fallgruppen": [
-                {{
-                    "fallgruppen_id": "",
-                    "fallgruppe_bezeichnung": "",
-                    "fallgruppe_beschreibung": "",
-                    "aenderungsstatus": "",
-                    "anzahl_betroffene_gueltig": "",
-                    "haeufigkeit_pro_jahr_gueltig": "",
-                    "anzahl_betroffene_vorschlag": "",
-                    "haeufigkeit_pro_jahr_vorschlag": "",
-                    "erklaerungen": {{
-                        "anzahl_betroffene_gueltig": "",
-                        "haeufigkeit_pro_jahr_gueltig": "",
-                        "anzahl_betroffene_vorschlag": "",
-                        "haeufigkeit_pro_jahr_vorschlag": ""
-                    }},
-                    "confidence": {{
-                        "anzahl_betroffene_gueltig": "high | medium | low",
-                        "haeufigkeit_pro_jahr_gueltig": "high | medium | low",
-                        "anzahl_betroffene_vorschlag": "high | medium | low",
-                        "haeufigkeit_pro_jahr_vorschlag": "high | medium | low"
-                    }}
-                }}
-            ]
+            "confidence": {{
+                "anzahl_betroffene_gueltig": "high | medium | low",
+                "haeufigkeit_pro_jahr_gueltig": "high | medium | low",
+                "anzahl_betroffene_vorschlag": "high | medium | low",
+                "haeufigkeit_pro_jahr_vorschlag": "high | medium | low"
             }}
-        ]
         }}
+
+        {output_skeleton_json}
 
         Das Feld `normadressat` ist fuer diesen Lauf fest vorgegeben und muss exakt `{norm_addressee}` lauten.
 
@@ -1092,12 +941,16 @@ PROMPT_TEMPLATES: Dict[str, str] = {
     #                        Vorgaben kann jedoch zusaetzlichen Sach- und Personalaufwand erzeugen.
     # Render contract:
     # - step_analysis_json: JSON string of list[ProzessStepAnalysisPayload]
+    # - output_skeleton_json: JSON string of the prefilled flat output shell
+    #   ({"normadressat", "fallgruppen": [{"fallgruppen_id", "taetigkeiten":
+    #   [{"taetigkeiten_id", <effort slots by addressee>}]}]})
     # - norm_addressee: "administration" | "business" | "citizens"
     # - law_summary: str, optional if session_id/app_session_id is provided
     # Auto-filled by render_prompt:
     # - effort_method_guidance
     # - effort_appendix
-    # - effort_json_schema
+    # - effort_taetigkeit_form
+    # - output_skeleton_json (empty-fallgruppen default when not provided)
     # - norm_addressee_prompt_opening
     PromptId.EFFORT_CALCULATION: (
         LEGIST_PROMPT_OPENING
@@ -1126,10 +979,15 @@ PROMPT_TEMPLATES: Dict[str, str] = {
 
         Geben Sie zu jeder vorgegebenen `taetigkeiten_id` genau ein Ergebnisobjekt aus und lassen Sie keine aus; faellt fuer eine Taetigkeit kein Aufwand an, geben Sie das Objekt mit ausdruecklichen Nullwerten aus. Pruefen Sie vor der Ausgabe, dass keine `taetigkeiten_id` mehrfach vorkommt, und uebernehmen Sie alle IDs exakt wie vorgegeben.
 
-        Geben Sie nur und ausschliesslich JSON im folgenden Format zurueck:
+        Geben Sie nur und ausschliesslich JSON zurueck. Fuellen Sie ausschliesslich die Aufwandsfelder je Taetigkeit im folgenden vorbefuellten Skelett aus. Fuegen Sie keine Fallgruppen- oder Taetigkeits-Objekte hinzu, entfernen, verschieben oder duplizieren Sie keine und uebernehmen Sie jede `fallgruppen_id` und `taetigkeiten_id` exakt an ihrer vorgegebenen Position. Die Aufwandsangaben innerhalb einer Taetigkeit fuellen und gliedern Sie hingegen selbst gemaess den obigen Hinweisen.
 
-        {effort_json_schema}
-        Verwenden Sie keine ein- oder ausleitenden Texte und keine sonstigen Zeichen. 
+        Jede Taetigkeit hat folgende Aufwandsform:
+
+        {effort_taetigkeit_form}
+
+        {output_skeleton_json}
+
+        Verwenden Sie keine ein- oder ausleitenden Texte und keine sonstigen Zeichen.
         """
     ),
 
@@ -1600,10 +1458,20 @@ def render_prompt(prompt_id: str, **kwargs: Any) -> str:
             dump_prompt_json({"normadressat": norm_addressee, "fallgruppen": []}),
         )
 
+    if prompt_id == PromptId.CASES_CALCULATION:
+        render_values.setdefault(
+            "output_skeleton_json",
+            dump_prompt_json({"normadressat": norm_addressee, "fallgruppen": []}),
+        )
+
     if prompt_id == PromptId.EFFORT_CALCULATION:
         render_values["effort_method_guidance"] = _render_effort_method_guidance(norm_addressee)
         render_values["effort_appendix"] = _render_effort_appendix(norm_addressee)
-        render_values["effort_json_schema"] = _render_effort_json_schema(norm_addressee)
+        render_values["effort_taetigkeit_form"] = _render_effort_taetigkeit_form(norm_addressee)
+        render_values.setdefault(
+            "output_skeleton_json",
+            dump_prompt_json({"normadressat": norm_addressee, "fallgruppen": []}),
+        )
 
     needs_law_summary = "{law_summary}" in template and not render_values.get("law_summary")
     needs_regulation_laws = (
@@ -1836,8 +1704,8 @@ def _render_effort_method_guidance(norm_addressee: str) -> str:
     return EFFORT_METHOD_GUIDANCE.get(norm_addressee, EFFORT_METHOD_GUIDANCE[ADMINISTRATION])
 
 
-def _render_effort_json_schema(norm_addressee: str) -> str:
-    schema = EFFORT_JSON_SCHEMA_BY_ADDRESSEE.get(norm_addressee)
-    if schema is not None:
-        return schema.strip()
-    return EFFORT_JSON_SCHEMA_DEFAULT.replace("{norm_addressee}", norm_addressee).strip()
+def _render_effort_taetigkeit_form(norm_addressee: str) -> str:
+    form = EFFORT_TAETIGKEIT_FORM_BY_ADDRESSEE.get(norm_addressee)
+    if form is not None:
+        return form.strip()
+    return EFFORT_TAETIGKEIT_FORM_DEFAULT.strip()

--- a/backend/core/prompts.py
+++ b/backend/core/prompts.py
@@ -12,6 +12,7 @@ from backend.core.norm_addressees import (
     BUSINESS,
     CITIZENS,
 )
+from backend.core.payload_builders import dump_prompt_json
 
 
 class PromptId:
@@ -849,12 +850,15 @@ PROMPT_TEMPLATES: Dict[str, str] = {
     ),
     # Render contract:
     # - case_groups_json: JSON string of list[ProzessWithFallgruppenPayload]
+    # - output_skeleton_json: JSON string of the prefilled flat output shell
+    #   ({"normadressat", "fallgruppen": [{"fallgruppen_id", "taetigkeiten": []}]})
     # - norm_addressee: "administration" | "business" | "citizens"
     # - law_summary: str, optional if session_id/app_session_id is provided
     # Auto-filled by render_prompt:
     # - step_analysis_checklist
     # - norm_addressee_prompt_opening
     # - step_analysis_addressee_rule
+    # - output_skeleton_json (empty-fallgruppen default when not provided)
     PromptId.PROCESS_STEP_ANALYSIS: (
         LEGIST_PROMPT_OPENING
         + """
@@ -888,80 +892,19 @@ PROMPT_TEMPLATES: Dict[str, str] = {
 
         {step_analysis_checklist}
 
-        Belassen Sie jede vorgegebene `fallgruppen_id` unter ihrem vorgegebenen Prozess und geben Sie sie genau einmal aus; pruefen Sie vor der Ausgabe, dass keine `fallgruppen_id` mehrfach oder unter einem fremden Prozess vorkommt. Fuehren Sie Fallgruppen nicht zusammen, teilen Sie sie nicht auf und uebernehmen Sie alle IDs exakt wie vorgegeben.
+        Geben Sie jede vorgegebene `fallgruppen_id` genau einmal aus; pruefen Sie vor der Ausgabe, dass keine `fallgruppen_id` mehrfach vorkommt. Fuehren Sie Fallgruppen nicht zusammen, teilen Sie sie nicht auf und uebernehmen Sie alle IDs exakt wie vorgegeben.
 
-        Geben Sie nur und ausschliesslich JSON im folgenden Format zurueck:
+        Geben Sie nur und ausschliesslich JSON zurueck. Fuellen Sie ausschliesslich das Feld `taetigkeiten` im folgenden vorbefuellten Skelett aus. Fuegen Sie keine Fallgruppen-Objekte hinzu, entfernen, verschieben oder duplizieren Sie keine und uebernehmen Sie jede `fallgruppen_id` exakt an ihrer vorgegebenen Position.
+
+        Jedes Element von `taetigkeiten` hat folgende Form:
 
         {{
-        "normadressat": "{norm_addressee}",
-        "prozesse": [
-            {{
-            "prozess_id": "",
-            "prozess_bezeichnung": "",
-            "prozess_beschreibung": "",
-            "aenderungsstatus": "",
-            "fallgruppen": [
-                {{
-                    "fallgruppen_id": "",
-                    "fallgruppe_bezeichnung": "",
-                    "fallgruppe_beschreibung": "",
-                    "aenderungsstatus": "",
-                    "taetigkeiten": [
-                        {{
-                            "taetigkeit": "",
-                            "beschreibung": "",
-                            "aenderungsstatus": "eingefuehrt | geaendert | abgeschafft | unveraendert"
-                        }},
-                        {{
-                            "taetigkeit": "",
-                            "beschreibung": "",
-                            "aenderungsstatus": "eingefuehrt | geaendert | abgeschafft | unveraendert"
-                        }}
-                    ]
-                }},
-                {{
-                    "fallgruppen_id": "",
-                    "fallgruppe_bezeichnung": "",
-                    "fallgruppe_beschreibung": "",
-                    "aenderungsstatus": "",
-                    "taetigkeiten": [
-                        {{
-                            "taetigkeit": "",
-                            "beschreibung": "",
-                            "aenderungsstatus": "eingefuehrt | geaendert | abgeschafft | unveraendert"
-                        }}
-                    ]
-                }}
-            ]
-            }},
-            {{
-            "prozess_id": "",
-            "prozess_bezeichnung": "",
-            "prozess_beschreibung": "",
-            "aenderungsstatus": "",
-            "fallgruppen": [
-                {{
-                    "fallgruppen_id": "",
-                    "fallgruppe_bezeichnung": "",
-                    "fallgruppe_beschreibung": "",
-                    "aenderungsstatus": "",
-                    "taetigkeiten": [
-                        {{
-                            "taetigkeit": "",
-                            "beschreibung": "",
-                            "aenderungsstatus": "eingefuehrt | geaendert | abgeschafft | unveraendert"
-                        }},
-                        {{
-                            "taetigkeit": "",
-                            "beschreibung": "",
-                            "aenderungsstatus": "eingefuehrt | geaendert | abgeschafft | unveraendert"
-                        }}
-                    ]
-                }}
-            ]
-            }}
-        ]
+            "taetigkeit": "",
+            "beschreibung": "",
+            "aenderungsstatus": "eingefuehrt | geaendert | abgeschafft | unveraendert"
         }}
+
+        {output_skeleton_json}
 
         Das Feld `normadressat` ist fuer diesen Lauf fest vorgegeben und muss exakt `{norm_addressee}` lauten.
 
@@ -1651,6 +1594,10 @@ def render_prompt(prompt_id: str, **kwargs: Any) -> str:
         render_values["step_analysis_checklist"] = _render_step_analysis_checklist(norm_addressee)
         render_values["step_analysis_addressee_rule"] = _render_step_analysis_addressee_rule(
             norm_addressee,
+        )
+        render_values.setdefault(
+            "output_skeleton_json",
+            dump_prompt_json({"normadressat": norm_addressee, "fallgruppen": []}),
         )
 
     if prompt_id == PromptId.EFFORT_CALCULATION:

--- a/backend/routers/effort.py
+++ b/backend/routers/effort.py
@@ -20,6 +20,8 @@ from backend.core.norm_addressees import (
 from backend.core.parsing import parse_first_int, parse_optional_number
 from backend.core.payload_builders import (
     build_case_groups_payload,
+    build_cases_calculation_output_skeleton,
+    build_effort_calculation_output_skeleton,
     build_step_analysis_payload,
     dump_prompt_json,
 )
@@ -60,7 +62,7 @@ def _parse_cases_payload(
     data, parse_mode = require_json_object(
         payload,
         error_context="Invalid cases_calculation payload",
-        required_top_level_key="prozesse",
+        required_top_level_key="fallgruppen",
     )
     fallback_kinds: set[str] = set()
     if parse_mode == "extract_last_json_object":
@@ -578,7 +580,7 @@ def _parse_effort_payload(payload: str, norm_addressee: str) -> tuple[list[dict]
     data, parse_mode = require_json_object(
         payload,
         error_context=f"Invalid effort_calculation payload for {norm_addressee}",
-        required_top_level_key="prozesse",
+        required_top_level_key="fallgruppen",
     )
     fallback_kinds: set[str] = set()
     if parse_mode == "extract_last_json_object":
@@ -680,6 +682,12 @@ def prepare_effort_calculation(
         PromptId.EFFORT_CALCULATION,
         session_id=session_id,
         step_analysis_json=dump_prompt_json(steps_payload),
+        output_skeleton_json=dump_prompt_json(
+            build_effort_calculation_output_skeleton(
+                steps_payload,
+                norm_addressee=norm_addressee,
+            )
+        ),
         norm_addressee=norm_addressee,
     )
 
@@ -695,6 +703,12 @@ def prepare_effort_calculation(
             PromptId.CASES_CALCULATION,
             session_id=session_id,
             case_groups_json=dump_prompt_json(case_groups_payload),
+            output_skeleton_json=dump_prompt_json(
+                build_cases_calculation_output_skeleton(
+                    case_groups_payload,
+                    norm_addressee=norm_addressee,
+                )
+            ),
             norm_addressee=norm_addressee,
         )
 

--- a/backend/routers/process_steps.py
+++ b/backend/routers/process_steps.py
@@ -14,7 +14,11 @@ from backend.core.norm_addressees import (
     NORM_ADDRESSEE_ECHO_MISMATCH,
     check_norm_addressee_echo,
 )
-from backend.core.payload_builders import build_case_groups_payload, dump_prompt_json
+from backend.core.payload_builders import (
+    build_case_groups_payload,
+    build_step_analysis_output_skeleton,
+    dump_prompt_json,
+)
 from backend.core.prompts import PromptId, render_prompt
 from backend.core.tile_refresh import refresh_step_tiles
 from backend.routers._edit_schemas import (
@@ -105,6 +109,12 @@ def build_process_step_analysis_prompt(
         PromptId.PROCESS_STEP_ANALYSIS,
         session_id=session_id,
         case_groups_json=dump_prompt_json(payload_groups),
+        output_skeleton_json=dump_prompt_json(
+            build_step_analysis_output_skeleton(
+                payload_groups,
+                norm_addressee=norm_addressee,
+            )
+        ),
         norm_addressee=norm_addressee,
     )
     return prompt, {
@@ -366,7 +376,7 @@ def _parse_process_steps(
     data, parse_mode = require_json_object(
         payload,
         error_context="Invalid process_step_analysis payload",
-        required_top_level_key="prozesse",
+        required_top_level_key="fallgruppen",
     )
     fallback_kinds: set[str] = set()
     if parse_mode == "extract_last_json_object":
@@ -380,72 +390,6 @@ def _parse_process_steps(
     fallback_kinds.update(echo_kinds)
 
     parsed: list[dict] = []
-    processes = data.get("prozesse")
-    if not isinstance(processes, list):
-        processes = []
-
-    for process in processes:
-        if not isinstance(process, dict):
-            continue
-        process_status = extract_change_status(process)
-        fallgruppen = process.get("fallgruppen")
-        if not isinstance(fallgruppen, list):
-            continue
-        for fallgruppe in fallgruppen:
-            if not isinstance(fallgruppe, dict):
-                continue
-            case_group_id = parse_first_int(
-                fallgruppe,
-                "fallgruppen_id",
-                "fallgruppe_id",
-                "case_group_id",
-            )
-            if case_group_id is None:
-                continue
-            case_group_status = extract_change_status(fallgruppe)
-            taetigkeiten = fallgruppe.get("taetigkeiten") or fallgruppe.get("tätigkeiten")
-            if not isinstance(taetigkeiten, list):
-                taetigkeiten = []
-            steps: list[dict] = []
-            for entry in taetigkeiten:
-                if not isinstance(entry, dict):
-                    continue
-                step = str(
-                    entry.get("taetigkeit")
-                    or entry.get("tätigkeit")
-                    or entry.get("step")
-                    or ""
-                ).strip()
-                description = str(
-                    entry.get("beschreibung")
-                    or entry.get("description")
-                    or ""
-                ).strip()
-                step_status = extract_change_status(entry)
-                if not step and not description:
-                    continue
-                steps.append(
-                    {
-                        "taetigkeit": step,
-                        "beschreibung": description,
-                        "aenderungsstatus": step_status,
-                        "regulation_ids": _parse_regulation_ids(
-                            entry.get("vorgaben_ids") or entry.get("vorgaben")
-                        ),
-                    }
-                )
-            if steps:
-                parsed.append(
-                    {
-                        "case_group_id": case_group_id,
-                        "aenderungsstatus": case_group_status or process_status,
-                        "taetigkeiten": steps,
-                    }
-                )
-
-    if parsed:
-        return parsed, fallback_kinds
-
     fallgruppen = extract_fallgruppen(data)
     for fallgruppe in fallgruppen:
         case_group_id = parse_first_int(
@@ -496,8 +440,6 @@ def _parse_process_steps(
                     "taetigkeiten": steps,
                 }
             )
-    if parsed:
-        fallback_kinds.add("process_steps_flattened_fallgruppen")
     return parsed, fallback_kinds
 
 

--- a/backend/routers/sessions.py
+++ b/backend/routers/sessions.py
@@ -1126,7 +1126,7 @@ def _promote_pending_retry(answer_ids: list[int]) -> None:
         )
 
 
-_ATOMIC_STEP_MAX_ATTEMPTS = 2
+_ATOMIC_STEP_MAX_ATTEMPTS = 4
 
 
 def _is_retryable_atomic_step_error(exc: Exception) -> bool:

--- a/backend/routers/sessions.py
+++ b/backend/routers/sessions.py
@@ -24,7 +24,7 @@ from backend.core.compliance_text_export import (
     normalize_user_edit_policy,
 )
 from backend.core import db, llm_monitor, llm_trace
-from backend.core.config import settings
+from backend.core.config import HIGH_RETRY_MODELS, settings
 from backend.core.deep_research_cases import (
     CASE_GROUP_RESEARCH_PURPOSE,
     apply_deep_research_case_metrics,
@@ -1126,7 +1126,14 @@ def _promote_pending_retry(answer_ids: list[int]) -> None:
         )
 
 
-_ATOMIC_STEP_MAX_ATTEMPTS = 4
+_ATOMIC_STEP_DEFAULT_MAX_ATTEMPTS = 2
+_ATOMIC_STEP_HIGH_MAX_ATTEMPTS = 4
+
+
+def _max_attempts_for_model(model: str) -> int:
+    if model in HIGH_RETRY_MODELS:
+        return _ATOMIC_STEP_HIGH_MAX_ATTEMPTS
+    return _ATOMIC_STEP_DEFAULT_MAX_ATTEMPTS
 
 
 def _is_retryable_atomic_step_error(exc: Exception) -> bool:
@@ -1246,7 +1253,7 @@ async def _run_atomic_single_prompt_step(
                 except Exception as exc:
                     if (
                         not _is_retryable_atomic_step_error(exc)
-                        or attempt >= _ATOMIC_STEP_MAX_ATTEMPTS
+                        or attempt >= _max_attempts_for_model(model)
                     ):
                         raise
                     attempt += 1
@@ -1576,7 +1583,7 @@ async def _run_atomic_effort_step(
                 except Exception as exc:
                     if (
                         not _is_retryable_atomic_step_error(exc)
-                        or attempt >= _ATOMIC_STEP_MAX_ATTEMPTS
+                        or attempt >= _max_attempts_for_model(model)
                     ):
                         raise
                     attempt += 1

--- a/backend/routers/sessions.py
+++ b/backend/routers/sessions.py
@@ -44,6 +44,7 @@ from backend.core.llm_attempts import (
     mark_llm_parse_fallback,
     prompt_sha256,
     publish_llm_answer_applied,
+    query_and_stage_llm_answer,
     query_and_stage_llm_answers_parallel,
 )
 from backend.core.llm_service import LlmResult, query_llm
@@ -1125,6 +1126,13 @@ def _promote_pending_retry(answer_ids: list[int]) -> None:
         )
 
 
+_ATOMIC_STEP_MAX_ATTEMPTS = 2
+
+
+def _is_retryable_atomic_step_error(exc: Exception) -> bool:
+    return isinstance(exc, HTTPException) and exc.status_code == 422
+
+
 async def _run_atomic_single_prompt_step(
     *,
     step: _AtomicSinglePromptStep,
@@ -1188,7 +1196,12 @@ async def _run_atomic_single_prompt_step(
                     result_key=key,
                 )
             )
-        prepared[norm_addressee] = {"status": "ready", "context": context, "key": key}
+        prepared[norm_addressee] = {
+            "status": "ready",
+            "context": context,
+            "key": key,
+            "prompt": prompt,
+        }
 
     if specs:
         staged_ids, staged_results, query_errors = await query_and_stage_llm_answers_parallel(
@@ -1221,16 +1234,37 @@ async def _run_atomic_single_prompt_step(
             if info["status"] != "ready":
                 continue
             key = info["key"]
-            answer_id = pending_answer_ids[key]
-            result = query_results[key]
-            parsed, fallback_kinds = step.parse_fn(
-                response_text=result.text,
-                norm_addressee=norm_addressee,
-                context=info["context"],
-            )
+            attempt = 1
+            while True:
+                try:
+                    parsed, fallback_kinds = step.parse_fn(
+                        response_text=query_results[key].text,
+                        norm_addressee=norm_addressee,
+                        context=info["context"],
+                    )
+                    break
+                except Exception as exc:
+                    if (
+                        not _is_retryable_atomic_step_error(exc)
+                        or attempt >= _ATOMIC_STEP_MAX_ATTEMPTS
+                    ):
+                        raise
+                    attempt += 1
+                    retry_answer_id, retry_result = await query_and_stage_llm_answer(
+                        session_id=session_id,
+                        prompt_id=step.prompt_id,
+                        prompt=info["prompt"],
+                        api_keys=api_keys,
+                        model=model,
+                        provider=payload.provider,
+                        query_fn=step.query_fn,
+                        norm_addressee=norm_addressee,
+                    )
+                    pending_answer_ids[key] = retry_answer_id
+                    query_results[key] = retry_result
             for fallback_kind in sorted(fallback_kinds):
                 mark_llm_parse_fallback(
-                    answer_id=answer_id,
+                    answer_id=pending_answer_ids[key],
                     session_id=session_id,
                     prompt_id=step.prompt_id,
                     fallback_kind=fallback_kind,
@@ -1313,6 +1347,49 @@ async def _run_atomic_single_prompt_step(
                 {"key": step.step_key, "norm_addressee": norm_addressee},
             )
     return created_by_addressee
+
+
+async def _requery_effort_page(
+    *,
+    session_id: int,
+    norm_addressee: str,
+    context: dict,
+    use_deep_research: bool,
+    api_keys: ApiKeys,
+    model: str,
+    provider: str | None,
+) -> tuple[dict[str, int], dict[str, LlmResult]]:
+    specs = [
+        LlmPromptSpec(
+            prompt_id=PromptId.EFFORT_CALCULATION,
+            query_label=f"EFFORT_CALCULATION/{norm_addressee}",
+            prompt=context["effort_prompt"],
+            norm_addressee=norm_addressee,
+            result_key=_result_key(PromptId.EFFORT_CALCULATION, norm_addressee),
+        )
+    ]
+    if not use_deep_research:
+        specs.insert(
+            0,
+            LlmPromptSpec(
+                prompt_id=PromptId.CASES_CALCULATION,
+                query_label=f"CASES_CALCULATION/{norm_addressee}",
+                prompt=context["cases_prompt"],
+                norm_addressee=norm_addressee,
+                result_key=_result_key(PromptId.CASES_CALCULATION, norm_addressee),
+            ),
+        )
+    staged_ids, staged_results, query_errors = await query_and_stage_llm_answers_parallel(
+        session_id=session_id,
+        specs=specs,
+        api_keys=api_keys,
+        model=model,
+        provider=provider,
+        query_fn=effort_router.query_llm,
+    )
+    if query_errors:
+        raise HTTPException(status_code=502, detail="; ".join(query_errors))
+    return staged_ids, staged_results
 
 
 async def _run_atomic_effort_step(
@@ -1473,23 +1550,47 @@ async def _run_atomic_effort_step(
                 continue
             effort_key = _result_key(PromptId.EFFORT_CALCULATION, norm_addressee)
             cases_key = _result_key(PromptId.CASES_CALCULATION, norm_addressee)
-            parsed_by_addressee[norm_addressee] = effort_router.parse_effort_calculation_outputs(
-                session_id=session_id,
-                norm_addressee=norm_addressee,
-                context=context,
-                cases_text=(
-                    None
-                    if use_deep_research
-                    else query_results[cases_key].text
-                ),
-                effort_text=query_results[effort_key].text,
-                cases_answer_id=(
-                    None
-                    if use_deep_research
-                    else pending_answer_ids[cases_key]
-                ),
-                effort_answer_id=pending_answer_ids[effort_key],
-            )
+            attempt = 1
+            while True:
+                try:
+                    parsed_by_addressee[norm_addressee] = (
+                        effort_router.parse_effort_calculation_outputs(
+                            session_id=session_id,
+                            norm_addressee=norm_addressee,
+                            context=context,
+                            cases_text=(
+                                None
+                                if use_deep_research
+                                else query_results[cases_key].text
+                            ),
+                            effort_text=query_results[effort_key].text,
+                            cases_answer_id=(
+                                None
+                                if use_deep_research
+                                else pending_answer_ids[cases_key]
+                            ),
+                            effort_answer_id=pending_answer_ids[effort_key],
+                        )
+                    )
+                    break
+                except Exception as exc:
+                    if (
+                        not _is_retryable_atomic_step_error(exc)
+                        or attempt >= _ATOMIC_STEP_MAX_ATTEMPTS
+                    ):
+                        raise
+                    attempt += 1
+                    retry_ids, retry_results = await _requery_effort_page(
+                        session_id=session_id,
+                        norm_addressee=norm_addressee,
+                        context=context,
+                        use_deep_research=use_deep_research,
+                        api_keys=api_keys,
+                        model=model,
+                        provider=payload.provider,
+                    )
+                    pending_answer_ids.update(retry_ids)
+                    query_results.update(retry_results)
     except Exception as exc:
         failed_addressee = norm_addressee
         failed_ids = [

--- a/frontend/src/components/LlmMonitorConsole.tsx
+++ b/frontend/src/components/LlmMonitorConsole.tsx
@@ -6,7 +6,7 @@ import { createPortal } from "react-dom";
 import { useApp } from "@/contexts/AppContext";
 import { apiClient } from "@/lib/api";
 import { logClientError } from "@/lib/errorFeedback";
-import { selectVisibleRecent } from "@/lib/llmMonitor";
+import { resolveResponseFormatBadge, selectVisibleRecent } from "@/lib/llmMonitor";
 import {
   LlmMonitorEvent,
   LlmMonitorPendingCall,
@@ -126,6 +126,28 @@ function NormAddresseeBadge({ value }: { value?: string | null }) {
   );
 }
 
+function ResponseFormatBadge({ row }: { row: LlmMonitorRecentCall }) {
+  const badge = resolveResponseFormatBadge(row);
+  if (!badge) {
+    return null;
+  }
+  const title = `angefragt: ${row.response_format_requested || "-"} · genutzt: ${
+    row.response_format_used || "-"
+  } · downgraded: ${row.response_format_downgraded ? "ja" : "nein"}`;
+  return (
+    <span
+      title={title}
+      className={`rounded border px-1.5 py-0.5 text-[10px] font-semibold ${
+        badge.variant === "warning"
+          ? "ccc-status-warning border-amber-200 bg-amber-50 text-amber-800"
+          : "border-slate-200 bg-slate-50 text-slate-600"
+      }`}
+    >
+      {badge.label}
+    </span>
+  );
+}
+
 function eventToRecentRow(event: LlmMonitorEvent): LlmMonitorRecentCall | null {
   const eventType = String(event.event_type || "");
   if (
@@ -170,6 +192,9 @@ function eventToRecentRow(event: LlmMonitorEvent): LlmMonitorRecentCall | null {
     error_kind: event.error_kind || null,
     error_status_code: event.error_status_code ?? null,
     error: event.error || null,
+    response_format_requested: event.response_format_requested ?? null,
+    response_format_used: event.response_format_used ?? null,
+    response_format_downgraded: event.response_format_downgraded ?? null,
     created_at: event.timestamp_ms ? new Date(event.timestamp_ms).toISOString() : null,
   };
 }
@@ -591,6 +616,7 @@ export default function LlmMonitorConsole({ open, onClose }: LlmMonitorConsolePr
                             {row.prompt_id || "-"}
                           </span>
                           <NormAddresseeBadge value={row.norm_addressee} />
+                          <ResponseFormatBadge row={row} />
                         </div>
                         <span
                           className={`rounded px-1.5 py-0.5 text-[10px] font-semibold ${

--- a/frontend/src/lib/__tests__/llmMonitor.test.ts
+++ b/frontend/src/lib/__tests__/llmMonitor.test.ts
@@ -1,4 +1,4 @@
-import { selectVisibleRecent } from "@/lib/llmMonitor";
+import { resolveResponseFormatBadge, selectVisibleRecent } from "@/lib/llmMonitor";
 import { LlmMonitorRecentCall } from "@/types";
 
 function call(overrides: Partial<LlmMonitorRecentCall>): LlmMonitorRecentCall {
@@ -48,5 +48,36 @@ describe("selectVisibleRecent (#64 P7)", () => {
 
     expect(visibleRecent.map((row) => row.answer_id)).toEqual([3, 2]);
     expect(staleRecentCount).toBe(0);
+  });
+});
+
+describe("resolveResponseFormatBadge (#64 PR75)", () => {
+  it("liefert kein Badge, wenn response_format_used im Datensatz fehlt", () => {
+    expect(resolveResponseFormatBadge({})).toBeNull();
+    expect(resolveResponseFormatBadge({ response_format_used: null })).toBeNull();
+  });
+
+  it("zeigt No format neutral, wenn kein response_format angefragt wurde", () => {
+    expect(
+      resolveResponseFormatBadge({ response_format_used: "none", response_format_downgraded: false })
+    ).toEqual({ label: "No format", variant: "neutral" });
+  });
+
+  it("zeigt Schema neutral, wenn json_schema ohne Downgrade griff", () => {
+    expect(
+      resolveResponseFormatBadge({
+        response_format_used: "json_schema",
+        response_format_downgraded: false,
+      })
+    ).toEqual({ label: "Schema", variant: "neutral" });
+  });
+
+  it("zeigt das tatsaechlich genutzte Format im Warn-Ton bei Downgrade", () => {
+    expect(
+      resolveResponseFormatBadge({
+        response_format_used: "json_object",
+        response_format_downgraded: true,
+      })
+    ).toEqual({ label: "JSON", variant: "warning" });
   });
 });

--- a/frontend/src/lib/llmMonitor.ts
+++ b/frontend/src/lib/llmMonitor.ts
@@ -1,5 +1,34 @@
 import { LlmMonitorRecentCall } from "@/types";
 
+export type ResponseFormatBadgeInfo = {
+  label: "Schema" | "JSON" | "No format";
+  variant: "neutral" | "warning";
+};
+
+const RESPONSE_FORMAT_LABELS: Record<string, ResponseFormatBadgeInfo["label"]> = {
+  json_schema: "Schema",
+  json_object: "JSON",
+  none: "No format",
+};
+
+export function resolveResponseFormatBadge(row: {
+  response_format_used?: string | null;
+  response_format_downgraded?: boolean | null;
+}): ResponseFormatBadgeInfo | null {
+  const used = row.response_format_used;
+  if (used === undefined || used === null) {
+    return null;
+  }
+  const label = RESPONSE_FORMAT_LABELS[used];
+  if (!label) {
+    return null;
+  }
+  return {
+    label,
+    variant: row.response_format_downgraded ? "warning" : "neutral",
+  };
+}
+
 /**
  * #64 (P7): Ueberholte (superseded) Fehlversuche im Debug-Monitor herausfiltern.
  *

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -151,6 +151,9 @@ export interface LlmMonitorEvent {
   output_tokens?: number | null;
   hidden_thinking_tokens?: number | null;
   estimated_cost_usd?: number | null;
+  response_format_requested?: string | null;
+  response_format_used?: string | null;
+  response_format_downgraded?: boolean | null;
   timestamp_ms?: number | null;
   sequence?: number | null;
 }
@@ -235,6 +238,9 @@ export interface LlmMonitorRecentCall {
   error_kind?: string | null;
   error_status_code?: number | null;
   error?: string | null;
+  response_format_requested?: string | null;
+  response_format_used?: string | null;
+  response_format_downgraded?: boolean | null;
   created_at?: string | null;
 }
 

--- a/tests/test_llm_json.py
+++ b/tests/test_llm_json.py
@@ -87,3 +87,58 @@ def test_require_json_object_accepts_prozesse_envelope_with_required_key():
     )
     assert "prozesse" in data
     assert mode == "direct_json_loads"
+
+
+def test_require_json_object_reports_truncated_stream_response():
+    # Reales Gemini-Muster (OpenAI-kompatibler Stream): der Provider meldet
+    # finish_reason "stop", der zusammengesetzte Text bricht aber vor der
+    # schliessenden Klammer ab. Muss als Transportfehler benannt werden, nicht
+    # als fehlender Key.
+    payload = (
+        '{"normadressat": "business", "prozesse": ['
+        '{"prozess_id": 1, "fallgruppen": [{"fallgruppen_id": 7}]}]'
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        require_json_object(
+            payload,
+            error_context="process compilation",
+            required_top_level_key="prozesse",
+        )
+    assert exc_info.value.status_code == 422
+    assert "truncated LLM response" in exc_info.value.detail
+    assert "prozesse" in exc_info.value.detail
+
+
+def test_require_json_object_rejects_truncated_payload_even_if_fragment_has_key():
+    # Kein stilles Weiterarbeiten mit Teildaten: hier birgt der Fallback ein
+    # inneres Prozess-Objekt, das ein `fallgruppen` traegt. Die Antwort ist aber
+    # abgeschnitten, also darf sie auch mit passendem Key nicht durchrutschen.
+    payload = (
+        '{"normadressat": "business", "prozesse": ['
+        '{"prozess_id": 1, "fallgruppen": [{"fallgruppen_id": 7}]},'
+        '{"prozess_id": 2, "fallgruppen": [{"fallgruppen_id": 8}'
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        require_json_object(
+            payload,
+            error_context="process step analysis",
+            required_top_level_key="fallgruppen",
+        )
+    assert exc_info.value.status_code == 422
+    assert "truncated LLM response" in exc_info.value.detail
+
+
+def test_require_json_object_keeps_missing_key_error_for_complete_json():
+    # Abgrenzung zur Truncation: syntaktisch vollstaendiges JSON ohne das
+    # geforderte Envelope bleibt der bisherige Fehler. Sonst wuerden die
+    # Completeness-Faelle faelschlich als Stream-Abbruch gemeldet.
+    payload = '{"fallgruppen": [{"fallgruppen_id": 7}]}'
+    with pytest.raises(HTTPException) as exc_info:
+        require_json_object(
+            payload,
+            error_context="process compilation",
+            required_top_level_key="prozesse",
+        )
+    assert exc_info.value.status_code == 422
+    assert "expected top-level key 'prozesse'" in exc_info.value.detail
+    assert "truncated" not in exc_info.value.detail

--- a/tests/test_llm_response_format_observability.py
+++ b/tests/test_llm_response_format_observability.py
@@ -2,9 +2,13 @@ import asyncio
 
 import pytest
 
-from backend.core import db, llm_service
+from backend.core import db, llm_monitor, llm_service
 from backend.core.auth import ApiKeys
-from backend.core.llm_attempts import query_and_stage_llm_answer
+from backend.core.llm_attempts import (
+    mark_llm_answer_applied,
+    mark_llm_answer_apply_failed,
+    query_and_stage_llm_answer,
+)
 from backend.core.llm_service import LlmQueryError, LlmResult, query_llm
 from backend.core.prompts import PromptId
 
@@ -262,3 +266,100 @@ def test_downgrade_is_persisted_in_answer_metadata(test_client):
     assert metadata["response_format_requested"] == "json_schema"
     assert metadata["response_format_used"] == "json_object"
     assert metadata["response_format_downgraded"] is True
+
+
+# --- Monitor-UI: das Ergebnis erreicht die recent-call API und den Live-Stream ---
+
+
+def _stage_downgraded_answer(app_session_id: str) -> tuple[int, int]:
+    session_id, _ = db.upsert_session(app_session_id, "test-model")
+
+    async def fake_query_fn(prompt, api_keys, model, provider, **kwargs):
+        return LlmResult(
+            text="Antworttext",
+            response_format_requested="json_schema",
+            response_format_used="json_object",
+            response_format_downgraded=True,
+        )
+
+    answer_id, _ = asyncio.run(
+        query_and_stage_llm_answer(
+            session_id=session_id,
+            prompt_id=PromptId.CASES_CALCULATION,
+            prompt="p",
+            api_keys=_keys(),
+            model="test-model",
+            provider="openai",
+            query_fn=fake_query_fn,
+        )
+    )
+    return session_id, answer_id
+
+
+def test_downgrade_is_surfaced_in_recent_llm_answers(test_client):
+    session_id, answer_id = _stage_downgraded_answer("LLM-RESPONSE-FORMAT-RECENT")
+
+    rows = [
+        row
+        for row in db.list_recent_llm_answers_for_session(session_id)
+        if row["answer_id"] == answer_id
+    ]
+    assert len(rows) == 1
+    assert rows[0]["response_format_requested"] == "json_schema"
+    assert rows[0]["response_format_used"] == "json_object"
+    assert rows[0]["response_format_downgraded"] is True
+
+
+async def _run_and_flush_fire_and_forget_tasks(fn) -> None:
+    fn()
+    pending = [task for task in asyncio.all_tasks() if task is not asyncio.current_task()]
+    if pending:
+        await asyncio.gather(*pending)
+
+
+def test_downgrade_is_surfaced_in_apply_succeeded_event(test_client):
+    app_session_id = "LLM-RESPONSE-FORMAT-APPLY"
+    session_id, answer_id = _stage_downgraded_answer(app_session_id)
+
+    asyncio.run(
+        _run_and_flush_fire_and_forget_tasks(
+            lambda: mark_llm_answer_applied(
+                answer_id=answer_id,
+                session_id=session_id,
+                prompt_id=PromptId.CASES_CALCULATION,
+            )
+        )
+    )
+
+    events = asyncio.run(llm_monitor.get_recent_events(app_session_id, limit=50))
+    apply_events = [
+        event
+        for event in events
+        if event["event_type"] == "llm_apply_succeeded" and event["answer_id"] == answer_id
+    ]
+    assert len(apply_events) == 1
+    assert apply_events[0]["response_format_requested"] == "json_schema"
+    assert apply_events[0]["response_format_used"] == "json_object"
+    assert apply_events[0]["response_format_downgraded"] is True
+
+
+def test_downgrade_is_surfaced_in_apply_failed_event(test_client):
+    app_session_id = "LLM-RESPONSE-FORMAT-APPLY-FAIL"
+    _session_id, answer_id = _stage_downgraded_answer(app_session_id)
+
+    asyncio.run(
+        _run_and_flush_fire_and_forget_tasks(
+            lambda: mark_llm_answer_apply_failed(answer_id=answer_id, exc=RuntimeError("boom"))
+        )
+    )
+
+    events = asyncio.run(llm_monitor.get_recent_events(app_session_id, limit=50))
+    apply_events = [
+        event
+        for event in events
+        if event["event_type"] == "llm_apply_failed" and event["answer_id"] == answer_id
+    ]
+    assert len(apply_events) == 1
+    assert apply_events[0]["response_format_requested"] == "json_schema"
+    assert apply_events[0]["response_format_used"] == "json_object"
+    assert apply_events[0]["response_format_downgraded"] is True

--- a/tests/test_llm_response_format_observability.py
+++ b/tests/test_llm_response_format_observability.py
@@ -1,0 +1,264 @@
+import asyncio
+
+import pytest
+
+from backend.core import db, llm_service
+from backend.core.auth import ApiKeys
+from backend.core.llm_attempts import query_and_stage_llm_answer
+from backend.core.llm_service import LlmQueryError, LlmResult, query_llm
+from backend.core.prompts import PromptId
+
+JSON_MODE = {"type": "json_object"}
+
+
+def _json_schema_mode() -> dict:
+    return {
+        "type": "json_schema",
+        "name": "cases_calculation",
+        "schema": {
+            "type": "object",
+            "properties": {"normadressat": {"type": "string"}},
+            "required": ["normadressat"],
+            "additionalProperties": False,
+        },
+        "strict": True,
+    }
+
+
+def _keys() -> ApiKeys:
+    return ApiKeys(
+        openai_api_key="sk-test",
+        gemini_api_key="g-test",
+        deepinfra_api_key="d-test",
+    )
+
+
+def _bad_request(model: str, provider: str = "openai") -> LlmQueryError:
+    return LlmQueryError(
+        provider=provider,
+        model=model,
+        reason="provider_http_error",
+        status_code=400,
+        message="unsupported",
+    )
+
+
+# --- Erfolgsfall: kein Downgrade wird auch als solcher gemeldet ---
+
+
+def test_json_schema_accepted_reports_no_downgrade(monkeypatch):
+    async def fake_query_openai(
+        prompt, api_key, model, *, stream=False, on_event=None, response_format=None
+    ):
+        return LlmResult(text="{}")
+
+    monkeypatch.setattr(llm_service, "query_openai", fake_query_openai)
+
+    result = asyncio.run(
+        query_llm(
+            "p", _keys(), "gpt-4o", provider="openai", response_format=_json_schema_mode()
+        )
+    )
+
+    assert result.response_format_requested == "json_schema"
+    assert result.response_format_used == "json_schema"
+    assert result.response_format_downgraded is False
+
+
+def test_no_response_format_reports_none(monkeypatch):
+    async def fake_query_openai(
+        prompt, api_key, model, *, stream=False, on_event=None, response_format=None
+    ):
+        return LlmResult(text="{}")
+
+    monkeypatch.setattr(llm_service, "query_openai", fake_query_openai)
+
+    result = asyncio.run(
+        query_llm("p", _keys(), "gpt-4o", provider="openai", response_format=None)
+    )
+
+    assert result.response_format_requested == "none"
+    assert result.response_format_used == "none"
+    assert result.response_format_downgraded is False
+
+
+# --- Downgrade wird als Daten gemeldet und geloggt ---
+
+
+def test_downgrade_to_json_object_is_reported(monkeypatch):
+    async def fake_query_openai(
+        prompt, api_key, model, *, stream=False, on_event=None, response_format=None
+    ):
+        if response_format is not None and response_format.get("type") == "json_schema":
+            raise _bad_request(model)
+        return LlmResult(text="{}")
+
+    monkeypatch.setattr(llm_service, "query_openai", fake_query_openai)
+
+    result = asyncio.run(
+        query_llm(
+            "p", _keys(), "gpt-4o", provider="openai", response_format=_json_schema_mode()
+        )
+    )
+
+    assert result.response_format_requested == "json_schema"
+    assert result.response_format_used == "json_object"
+    assert result.response_format_downgraded is True
+
+
+def test_downgrade_to_none_is_reported(monkeypatch):
+    async def fake_query_openai(
+        prompt, api_key, model, *, stream=False, on_event=None, response_format=None
+    ):
+        if response_format is not None:
+            raise _bad_request(model)
+        return LlmResult(text="{}")
+
+    monkeypatch.setattr(llm_service, "query_openai", fake_query_openai)
+
+    result = asyncio.run(
+        query_llm(
+            "p", _keys(), "gpt-4o", provider="openai", response_format=_json_schema_mode()
+        )
+    )
+
+    assert result.response_format_used == "none"
+    assert result.response_format_downgraded is True
+
+
+def test_downgrade_emits_warning_log(monkeypatch, caplog):
+    async def fake_query_openai(
+        prompt, api_key, model, *, stream=False, on_event=None, response_format=None
+    ):
+        if response_format is not None and response_format.get("type") == "json_schema":
+            raise _bad_request(model)
+        return LlmResult(text="{}")
+
+    monkeypatch.setattr(llm_service, "query_openai", fake_query_openai)
+
+    with caplog.at_level("WARNING", logger="uvicorn.error"):
+        asyncio.run(
+            query_llm(
+                "p",
+                _keys(),
+                "gpt-4o",
+                provider="openai",
+                response_format=_json_schema_mode(),
+            )
+        )
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("response_format downgrade" in message for message in messages)
+    assert any("from=json_schema to=json_object" in message for message in messages)
+
+
+# --- Testluecke geschlossen: Kette galt bisher nur fuer OpenAI ---
+
+
+def test_gemini_downgrade_is_reported(monkeypatch):
+    calls: list = []
+
+    async def fake_query_gemini(
+        prompt, api_key, model, *, stream=False, on_event=None, response_format=None
+    ):
+        calls.append(response_format)
+        if response_format is not None and response_format.get("type") == "json_schema":
+            raise _bad_request(model, provider="gemini")
+        return LlmResult(text="{}")
+
+    monkeypatch.setattr(llm_service, "query_gemini_openai", fake_query_gemini)
+
+    schema = _json_schema_mode()
+    result = asyncio.run(
+        query_llm("p", _keys(), "gemini-3.5-flash", provider="gemini", response_format=schema)
+    )
+
+    assert calls == [schema, JSON_MODE]
+    assert result.response_format_used == "json_object"
+    assert result.response_format_downgraded is True
+
+
+def test_deepinfra_downgrade_is_reported(monkeypatch):
+    calls: list = []
+
+    async def fake_query_deepinfra(
+        prompt, api_key, model, *, stream=False, on_event=None, response_format=None
+    ):
+        calls.append(response_format)
+        if response_format is not None:
+            raise _bad_request(model, provider="deepinfra")
+        return LlmResult(text="{}")
+
+    monkeypatch.setattr(llm_service, "query_deepinfra", fake_query_deepinfra)
+
+    schema = _json_schema_mode()
+    result = asyncio.run(
+        query_llm(
+            "p",
+            _keys(),
+            "deepseek-ai/DeepSeek-V3.2",
+            provider="deepinfra",
+            response_format=schema,
+        )
+    )
+
+    assert calls == [schema, JSON_MODE, None]
+    assert result.response_format_used == "none"
+    assert result.response_format_downgraded is True
+
+
+def test_bad_request_on_last_chain_link_raises(monkeypatch):
+    calls: list = []
+
+    async def fake_query_openai(
+        prompt, api_key, model, *, stream=False, on_event=None, response_format=None
+    ):
+        calls.append(response_format)
+        raise _bad_request(model)
+
+    monkeypatch.setattr(llm_service, "query_openai", fake_query_openai)
+
+    with pytest.raises(LlmQueryError):
+        asyncio.run(
+            query_llm(
+                "p",
+                _keys(),
+                "gpt-4o",
+                provider="openai",
+                response_format=_json_schema_mode(),
+            )
+        )
+
+    assert calls == [_json_schema_mode(), JSON_MODE, None]
+
+
+# --- Persistenz: das Ergebnis landet in den Answer-Metadaten ---
+
+
+def test_downgrade_is_persisted_in_answer_metadata(test_client):
+    session_id, _ = db.upsert_session("LLM-RESPONSE-FORMAT-OBS", "test-model")
+
+    async def fake_query_fn(prompt, api_keys, model, provider, **kwargs):
+        return LlmResult(
+            text="Antworttext",
+            response_format_requested="json_schema",
+            response_format_used="json_object",
+            response_format_downgraded=True,
+        )
+
+    answer_id, _ = asyncio.run(
+        query_and_stage_llm_answer(
+            session_id=session_id,
+            prompt_id=PromptId.CASES_CALCULATION,
+            prompt="p",
+            api_keys=_keys(),
+            model="test-model",
+            provider="openai",
+            query_fn=fake_query_fn,
+        )
+    )
+
+    metadata = db.get_llm_answer_by_id(answer_id)["metadata"]
+    assert metadata["response_format_requested"] == "json_schema"
+    assert metadata["response_format_used"] == "json_object"
+    assert metadata["response_format_downgraded"] is True

--- a/tests/test_llm_structured_output.py
+++ b/tests/test_llm_structured_output.py
@@ -398,8 +398,20 @@ def test_query_and_stage_uses_effort_citizens_schema_variant(test_client):
     }
 
 
-def test_query_and_stage_keeps_json_object_for_other_structured_prompt(test_client):
-    session_id, _ = db.upsert_session("LLM-JSON-OBJECT-OTHER", "test-model")
+@pytest.mark.parametrize(
+    "prompt_id",
+    [
+        "process_compilation",
+        "case_group_development",
+        "process_step_analysis",
+        "cases_calculation",
+        "effort_calculation",
+    ],
+)
+def test_query_and_stage_uses_json_schema_for_every_structured_prompt(
+    test_client, prompt_id
+):
+    session_id, _ = db.upsert_session(f"LLM-JSON-SCHEMA-{prompt_id}", "test-model")
     captured: dict = {}
 
     async def fake_query_fn(prompt, api_keys, model, provider, **kwargs):
@@ -409,7 +421,7 @@ def test_query_and_stage_keeps_json_object_for_other_structured_prompt(test_clie
     asyncio.run(
         query_and_stage_llm_answer(
             session_id=session_id,
-            prompt_id="process_compilation",
+            prompt_id=prompt_id,
             prompt="Frage",
             api_keys=ApiKeys(openai_api_key="sk-test"),
             model="test-model",
@@ -419,7 +431,11 @@ def test_query_and_stage_keeps_json_object_for_other_structured_prompt(test_clie
         )
     )
 
-    assert captured.get("response_format") == {"type": "json_object"}
+    response_format = captured.get("response_format")
+    assert response_format["type"] == "json_schema"
+    assert response_format["name"] == prompt_id
+    assert response_format["strict"] is True
+    assert response_format["schema"]["properties"]["normadressat"]["enum"] == [BUSINESS]
 
 
 def test_query_and_stage_cases_degrades_to_json_object_without_addressee(test_client):

--- a/tests/test_llm_structured_output.py
+++ b/tests/test_llm_structured_output.py
@@ -6,8 +6,23 @@ from backend.core import db, llm_service
 from backend.core.auth import ApiKeys
 from backend.core.llm_attempts import query_and_stage_llm_answer
 from backend.core.llm_service import LlmQueryError, LlmResult, query_llm
+from backend.core.norm_addressees import BUSINESS, CITIZENS
 
 JSON_MODE = {"type": "json_object"}
+
+
+def _json_schema_mode() -> dict:
+    return {
+        "type": "json_schema",
+        "name": "cases_calculation",
+        "schema": {
+            "type": "object",
+            "properties": {"normadressat": {"type": "string"}},
+            "required": ["normadressat"],
+            "additionalProperties": False,
+        },
+        "strict": True,
+    }
 
 
 def _keys() -> ApiKeys:
@@ -168,11 +183,247 @@ def test_query_deepinfra_passes_response_format(monkeypatch):
     assert captured["response_format"] == JSON_MODE
 
 
-# --- Opt-in: nur die Workflow-Prompts aktivieren den JSON-Modus ---
+# --- API-spezifisches Wrapping des json_schema-Formats ---
 
 
-def test_query_and_stage_enables_json_mode_for_workflow_prompt(test_client):
-    session_id, _ = db.upsert_session("LLM-JSON-MODE", "test-model")
+def test_query_openai_chat_wraps_json_schema(monkeypatch):
+    captured: dict = {}
+
+    async def fake_once(*, provider, client, payload, model):
+        captured["payload"] = payload
+        return LlmResult(text="{}")
+
+    monkeypatch.setattr(llm_service, "_query_chat_completions_once", fake_once)
+
+    schema = _json_schema_mode()
+    asyncio.run(
+        llm_service.query_openai("p", "sk-test", "gpt-4o", response_format=schema)
+    )
+
+    assert captured["payload"]["response_format"] == {
+        "type": "json_schema",
+        "json_schema": {
+            "name": "cases_calculation",
+            "strict": True,
+            "schema": schema["schema"],
+        },
+    }
+
+
+def test_query_gemini_chat_wraps_json_schema(monkeypatch):
+    captured: dict = {}
+
+    async def fake_once(*, provider, client, payload, model):
+        captured["payload"] = payload
+        return LlmResult(text="{}")
+
+    monkeypatch.setattr(llm_service, "_query_chat_completions_once", fake_once)
+
+    schema = _json_schema_mode()
+    asyncio.run(
+        llm_service.query_gemini_openai(
+            "p", "g-test", "gemini-2.5-flash", response_format=schema
+        )
+    )
+
+    assert captured["payload"]["response_format"] == {
+        "type": "json_schema",
+        "json_schema": {
+            "name": "cases_calculation",
+            "strict": True,
+            "schema": schema["schema"],
+        },
+    }
+
+
+def test_query_openai_responses_wraps_json_schema(monkeypatch):
+    captured: dict = {}
+
+    class _FakeResponses:
+        async def create(self, **payload):
+            captured["payload"] = payload
+            raise RuntimeError("stop after payload capture")
+
+    class _FakeClient:
+        responses = _FakeResponses()
+
+    schema = _json_schema_mode()
+    with pytest.raises(Exception):
+        asyncio.run(
+            llm_service._query_openai_responses(
+                _FakeClient(), "p", "gpt-5-mini", response_format=schema
+            )
+        )
+
+    assert captured["payload"]["text"] == {
+        "format": {
+            "type": "json_schema",
+            "name": "cases_calculation",
+            "schema": schema["schema"],
+            "strict": True,
+        }
+    }
+
+
+def test_response_format_wrappers_pass_json_object_through():
+    assert llm_service._response_format_for_chat(JSON_MODE) == JSON_MODE
+    assert llm_service._response_format_for_responses(JSON_MODE) == JSON_MODE
+    assert llm_service._response_format_for_chat(None) is None
+    assert llm_service._response_format_for_responses(None) is None
+
+
+# --- Gestaffelte Fallback-Kette json_schema -> json_object -> None ---
+
+
+def test_query_llm_staged_fallback_json_schema_to_json_object_to_none(monkeypatch):
+    calls: list = []
+
+    async def fake_query_openai(
+        prompt, api_key, model, *, stream=False, on_event=None, response_format=None
+    ):
+        calls.append(response_format)
+        if response_format is not None:
+            raise LlmQueryError(
+                provider="openai",
+                model=model,
+                reason="provider_http_error",
+                status_code=400,
+                message="unsupported",
+            )
+        return LlmResult(text="{}")
+
+    monkeypatch.setattr(llm_service, "query_openai", fake_query_openai)
+
+    schema = _json_schema_mode()
+    result = asyncio.run(
+        query_llm("p", _keys(), "gpt-4o", provider="openai", response_format=schema)
+    )
+
+    assert result.text == "{}"
+    assert calls == [schema, JSON_MODE, None]
+
+
+def test_query_llm_json_schema_falls_back_to_json_object(monkeypatch):
+    calls: list = []
+
+    async def fake_query_openai(
+        prompt, api_key, model, *, stream=False, on_event=None, response_format=None
+    ):
+        calls.append(response_format)
+        if response_format is not None and response_format.get("type") == "json_schema":
+            raise LlmQueryError(
+                provider="openai",
+                model=model,
+                reason="provider_http_error",
+                status_code=400,
+                message="strict schema unsupported",
+            )
+        return LlmResult(text="{}")
+
+    monkeypatch.setattr(llm_service, "query_openai", fake_query_openai)
+
+    schema = _json_schema_mode()
+    result = asyncio.run(
+        query_llm("p", _keys(), "gpt-4o", provider="openai", response_format=schema)
+    )
+
+    assert result.text == "{}"
+    assert calls == [schema, JSON_MODE]
+
+
+# --- Opt-in: cases/effort erzwingen json_schema, andere json_object ---
+
+
+def test_query_and_stage_uses_json_schema_for_cases(test_client):
+    session_id, _ = db.upsert_session("LLM-JSON-SCHEMA-CASES", "test-model")
+    captured: dict = {}
+
+    async def fake_query_fn(prompt, api_keys, model, provider, **kwargs):
+        captured.update(kwargs)
+        return "Antworttext"
+
+    asyncio.run(
+        query_and_stage_llm_answer(
+            session_id=session_id,
+            prompt_id="cases_calculation",
+            prompt="Frage",
+            api_keys=ApiKeys(openai_api_key="sk-test"),
+            model="test-model",
+            provider="openai",
+            query_fn=fake_query_fn,
+            norm_addressee=BUSINESS,
+        )
+    )
+
+    response_format = captured.get("response_format")
+    assert response_format["type"] == "json_schema"
+    assert response_format["name"] == "cases_calculation"
+    assert response_format["strict"] is True
+    assert response_format["schema"]["properties"]["normadressat"]["enum"] == [BUSINESS]
+
+
+def test_query_and_stage_uses_effort_citizens_schema_variant(test_client):
+    session_id, _ = db.upsert_session("LLM-JSON-SCHEMA-EFFORT", "test-model")
+    captured: dict = {}
+
+    async def fake_query_fn(prompt, api_keys, model, provider, **kwargs):
+        captured.update(kwargs)
+        return "Antworttext"
+
+    asyncio.run(
+        query_and_stage_llm_answer(
+            session_id=session_id,
+            prompt_id="effort_calculation",
+            prompt="Frage",
+            api_keys=ApiKeys(openai_api_key="sk-test"),
+            model="test-model",
+            provider="openai",
+            query_fn=fake_query_fn,
+            norm_addressee=CITIZENS,
+        )
+    )
+
+    response_format = captured.get("response_format")
+    assert response_format["type"] == "json_schema"
+    assert response_format["name"] == "effort_calculation"
+    taetigkeit = response_format["schema"]["properties"]["fallgruppen"]["items"][
+        "properties"
+    ]["taetigkeiten"]["items"]
+    assert set(taetigkeit["properties"].keys()) == {
+        "taetigkeiten_id",
+        "zeitaufwand_in_min_gueltig",
+        "sachaufwand_gueltig",
+        "zeitaufwand_in_min_vorschlag",
+        "sachaufwand_vorschlag",
+    }
+
+
+def test_query_and_stage_keeps_json_object_for_other_structured_prompt(test_client):
+    session_id, _ = db.upsert_session("LLM-JSON-OBJECT-OTHER", "test-model")
+    captured: dict = {}
+
+    async def fake_query_fn(prompt, api_keys, model, provider, **kwargs):
+        captured.update(kwargs)
+        return "Antworttext"
+
+    asyncio.run(
+        query_and_stage_llm_answer(
+            session_id=session_id,
+            prompt_id="process_compilation",
+            prompt="Frage",
+            api_keys=ApiKeys(openai_api_key="sk-test"),
+            model="test-model",
+            provider="openai",
+            query_fn=fake_query_fn,
+            norm_addressee=BUSINESS,
+        )
+    )
+
+    assert captured.get("response_format") == {"type": "json_object"}
+
+
+def test_query_and_stage_cases_degrades_to_json_object_without_addressee(test_client):
+    session_id, _ = db.upsert_session("LLM-JSON-DEGRADE", "test-model")
     captured: dict = {}
 
     async def fake_query_fn(prompt, api_keys, model, provider, **kwargs):

--- a/tests/test_norm_addressee_echo.py
+++ b/tests/test_norm_addressee_echo.py
@@ -206,15 +206,11 @@ def test_parse_cases_payload_rejects_mismatch():
     payload = """
     {
       "normadressat": "administration",
-      "prozesse": [
+      "fallgruppen": [
         {
-          "fallgruppen": [
-            {
-              "fallgruppen_id": 42,
-              "anzahl_betroffene_vorschlag": "10",
-              "haeufigkeit_pro_jahr_vorschlag": "1"
-            }
-          ]
+          "fallgruppen_id": 42,
+          "anzahl_betroffene_vorschlag": "10",
+          "haeufigkeit_pro_jahr_vorschlag": "1"
         }
       ]
     }
@@ -228,15 +224,11 @@ def test_parse_cases_payload_rejects_mismatch():
 def test_parse_cases_payload_flags_missing():
     payload = """
     {
-      "prozesse": [
+      "fallgruppen": [
         {
-          "fallgruppen": [
-            {
-              "fallgruppen_id": 42,
-              "anzahl_betroffene_vorschlag": "10",
-              "haeufigkeit_pro_jahr_vorschlag": "1"
-            }
-          ]
+          "fallgruppen_id": 42,
+          "anzahl_betroffene_vorschlag": "10",
+          "haeufigkeit_pro_jahr_vorschlag": "1"
         }
       ]
     }
@@ -255,21 +247,17 @@ def test_parse_effort_payload_rejects_mismatch():
     payload = """
     {
       "normadressat": "citizens",
-      "prozesse": [
+      "fallgruppen": [
         {
-          "fallgruppen": [
+          "fallgruppen_id": 10,
+          "taetigkeiten": [
             {
-              "fallgruppen_id": 10,
-              "taetigkeiten": [
-                {
-                  "taetigkeiten_id": 100,
-                  "personalaufwand_vorschlag": [
-                    {"qualifikation": "einfacher_und_mittlerer_dienst",
-                     "lohnquelle": "bund", "zeitaufwand_in_min": "6"}
-                  ],
-                  "sachaufwand_vorschlag": "2"
-                }
-              ]
+              "taetigkeiten_id": 100,
+              "personalaufwand_vorschlag": [
+                {"qualifikation": "einfacher_und_mittlerer_dienst",
+                 "lohnquelle": "bund", "zeitaufwand_in_min": "6"}
+              ],
+              "sachaufwand_vorschlag": "2"
             }
           ]
         }
@@ -285,18 +273,14 @@ def test_parse_effort_payload_rejects_mismatch():
 def test_parse_effort_payload_flags_missing():
     payload = """
     {
-      "prozesse": [
+      "fallgruppen": [
         {
-          "fallgruppen": [
+          "fallgruppen_id": 10,
+          "taetigkeiten": [
             {
-              "fallgruppen_id": 10,
-              "taetigkeiten": [
-                {
-                  "taetigkeiten_id": 100,
-                  "zeitaufwand_in_min_vorschlag": "6",
-                  "sachaufwand_vorschlag": "2"
-                }
-              ]
+              "taetigkeiten_id": 100,
+              "zeitaufwand_in_min_vorschlag": "6",
+              "sachaufwand_vorschlag": "2"
             }
           ]
         }
@@ -312,18 +296,14 @@ def test_parse_effort_payload_no_fallback_on_match():
     payload = """
     {
       "normadressat": "citizens",
-      "prozesse": [
+      "fallgruppen": [
         {
-          "fallgruppen": [
+          "fallgruppen_id": 10,
+          "taetigkeiten": [
             {
-              "fallgruppen_id": 10,
-              "taetigkeiten": [
-                {
-                  "taetigkeiten_id": 100,
-                  "zeitaufwand_in_min_vorschlag": "6",
-                  "sachaufwand_vorschlag": "2"
-                }
-              ]
+              "taetigkeiten_id": 100,
+              "zeitaufwand_in_min_vorschlag": "6",
+              "sachaufwand_vorschlag": "2"
             }
           ]
         }

--- a/tests/test_norm_addressee_echo.py
+++ b/tests/test_norm_addressee_echo.py
@@ -163,16 +163,11 @@ def test_parse_process_steps_rejects_mismatch():
     payload = """
     {
       "normadressat": "business",
-      "prozesse": [
+      "fallgruppen": [
         {
-          "prozess_id": 1,
-          "fallgruppen": [
-            {
-              "fallgruppen_id": 10,
-              "taetigkeiten": [
-                {"taetigkeit": "T", "beschreibung": "B"}
-              ]
-            }
+          "fallgruppen_id": 10,
+          "taetigkeiten": [
+            {"taetigkeit": "T", "beschreibung": "B"}
           ]
         }
       ]
@@ -187,16 +182,11 @@ def test_parse_process_steps_rejects_mismatch():
 def test_parse_process_steps_flags_missing():
     payload = """
     {
-      "prozesse": [
+      "fallgruppen": [
         {
-          "prozess_id": 1,
-          "fallgruppen": [
-            {
-              "fallgruppen_id": 10,
-              "taetigkeiten": [
-                {"taetigkeit": "T", "beschreibung": "B"}
-              ]
-            }
+          "fallgruppen_id": 10,
+          "taetigkeiten": [
+            {"taetigkeit": "T", "beschreibung": "B"}
           ]
         }
       ]

--- a/tests/test_payload_builders.py
+++ b/tests/test_payload_builders.py
@@ -1,6 +1,7 @@
 from backend.core.payload_builders import (
     build_case_groups_payload,
     build_processes_payload_with_regulations,
+    build_step_analysis_output_skeleton,
     build_step_analysis_payload,
     build_vorgaben_payload,
 )
@@ -574,3 +575,38 @@ def test_build_step_analysis_payload_keeps_all_steps_with_multiple_roots():
     taetigkeiten = payload[0]["fallgruppen"][0]["taetigkeiten"]
     step_ids = [taetigkeit["taetigkeiten_id"] for taetigkeit in taetigkeiten]
     assert step_ids == [40, 41, 42]
+
+
+def test_build_step_analysis_output_skeleton_is_flat_ids_only():
+    # #64 (Option 4): flaches Skelett - alle Fallgruppen zweier Prozesse liegen
+    # ohne Prozess-Ebene flach nebeneinander; vorbefuellt nur die IDs, laesst
+    # `taetigkeiten` leer; kein deskriptives Feld darf durchsickern.
+    processes = [
+        {"process_id": 312, "process": "Prozess 312", "description": "d", "change_status": "geaendert"},
+        {"process_id": 313, "process": "Prozess 313", "description": "d", "change_status": "geaendert"},
+    ]
+    case_groups = [
+        {"case_group_id": 491, "process_id": 312, "case_group": "F491", "description": "d", "change_status": "geaendert"},
+        {"case_group_id": 492, "process_id": 313, "case_group": "F492", "description": "d", "change_status": "geaendert"},
+    ]
+    payload_groups = build_case_groups_payload(
+        processes=processes,
+        case_groups=case_groups,
+        norm_addressee="business",
+    )
+
+    skeleton = build_step_analysis_output_skeleton(payload_groups, norm_addressee="business")
+
+    assert skeleton == {
+        "normadressat": "business",
+        "fallgruppen": [
+            {"fallgruppen_id": 491, "taetigkeiten": []},
+            {"fallgruppen_id": 492, "taetigkeiten": []},
+        ],
+    }
+    assert set(skeleton.keys()) == {"normadressat", "fallgruppen"}
+    fallgruppen_ids = [group["fallgruppen_id"] for group in skeleton["fallgruppen"]]
+    assert fallgruppen_ids == [491, 492]
+    assert len(fallgruppen_ids) == len(set(fallgruppen_ids))
+    for group in skeleton["fallgruppen"]:
+        assert set(group.keys()) == {"fallgruppen_id", "taetigkeiten"}

--- a/tests/test_payload_builders.py
+++ b/tests/test_payload_builders.py
@@ -1,5 +1,7 @@
 from backend.core.payload_builders import (
     build_case_groups_payload,
+    build_cases_calculation_output_skeleton,
+    build_effort_calculation_output_skeleton,
     build_processes_payload_with_regulations,
     build_step_analysis_output_skeleton,
     build_step_analysis_payload,
@@ -610,3 +612,109 @@ def test_build_step_analysis_output_skeleton_is_flat_ids_only():
     assert len(fallgruppen_ids) == len(set(fallgruppen_ids))
     for group in skeleton["fallgruppen"]:
         assert set(group.keys()) == {"fallgruppen_id", "taetigkeiten"}
+
+
+def test_build_cases_calculation_output_skeleton_is_flat_prefilled():
+    # #64 (Option 4, Schritt 6): flaches Skelett - alle Fallgruppen zweier Prozesse
+    # flach nebeneinander, vorbefuellt mit `fallgruppen_id` + leeren Kennzahlen-Slots
+    # (inkl. erklaerungen/confidence); das Modell fuellt nur Werte.
+    processes = [
+        {"process_id": 312, "process": "Prozess 312", "description": "d", "change_status": "geaendert"},
+        {"process_id": 313, "process": "Prozess 313", "description": "d", "change_status": "geaendert"},
+    ]
+    case_groups = [
+        {"case_group_id": 491, "process_id": 312, "case_group": "F491", "description": "d", "change_status": "geaendert"},
+        {"case_group_id": 492, "process_id": 313, "case_group": "F492", "description": "d", "change_status": "geaendert"},
+    ]
+    payload_groups = build_case_groups_payload(
+        processes=processes,
+        case_groups=case_groups,
+        norm_addressee="business",
+    )
+
+    skeleton = build_cases_calculation_output_skeleton(payload_groups, norm_addressee="business")
+
+    assert set(skeleton.keys()) == {"normadressat", "fallgruppen"}
+    assert skeleton["normadressat"] == "business"
+    fallgruppen_ids = [group["fallgruppen_id"] for group in skeleton["fallgruppen"]]
+    assert fallgruppen_ids == [491, 492]
+    metric_keys = (
+        "anzahl_betroffene_gueltig",
+        "haeufigkeit_pro_jahr_gueltig",
+        "anzahl_betroffene_vorschlag",
+        "haeufigkeit_pro_jahr_vorschlag",
+    )
+    for group in skeleton["fallgruppen"]:
+        assert set(group.keys()) == {
+            "fallgruppen_id",
+            *metric_keys,
+            "erklaerungen",
+            "confidence",
+        }
+        for key in metric_keys:
+            assert group[key] == ""
+        assert set(group["erklaerungen"].keys()) == set(metric_keys)
+        assert set(group["confidence"].keys()) == set(metric_keys)
+
+
+def _effort_skeleton_input():
+    processes = [
+        {"process_id": 10, "process": "Prozess 10", "description": "d", "change_status": "geaendert"},
+    ]
+    case_groups = [
+        {"case_group_id": 20, "process_id": 10, "case_group": "F20", "description": "d", "change_status": "geaendert"},
+    ]
+    steps = [
+        {"step_id": 40, "case_group_id": 20, "step": "Schritt 1", "description": "", "change_status": "geaendert", "previous_id": None, "next_id": 41},
+        {"step_id": 41, "case_group_id": 20, "step": "Schritt 2", "description": "", "change_status": "geaendert", "previous_id": 40, "next_id": None},
+    ]
+    return build_step_analysis_payload(
+        processes=processes,
+        case_groups=case_groups,
+        steps=steps,
+        regulations=[],
+    )
+
+
+def test_build_effort_calculation_output_skeleton_org_is_flat_prefilled():
+    payload = _effort_skeleton_input()
+
+    skeleton = build_effort_calculation_output_skeleton(payload, norm_addressee="administration")
+
+    assert set(skeleton.keys()) == {"normadressat", "fallgruppen"}
+    assert skeleton["normadressat"] == "administration"
+    assert [group["fallgruppen_id"] for group in skeleton["fallgruppen"]] == [20]
+    taetigkeiten = skeleton["fallgruppen"][0]["taetigkeiten"]
+    assert [t["taetigkeiten_id"] for t in taetigkeiten] == [40, 41]
+    for taetigkeit in taetigkeiten:
+        assert set(taetigkeit.keys()) == {
+            "taetigkeiten_id",
+            "personalaufwand_gueltig",
+            "sachaufwand_gueltig",
+            "personalaufwand_vorschlag",
+            "sachaufwand_vorschlag",
+        }
+        assert taetigkeit["personalaufwand_gueltig"] == [
+            {"qualifikation": "", "lohnquelle": "", "zeitaufwand_in_min": ""}
+        ]
+        assert taetigkeit["personalaufwand_vorschlag"] == [
+            {"qualifikation": "", "lohnquelle": "", "zeitaufwand_in_min": ""}
+        ]
+
+
+def test_build_effort_calculation_output_skeleton_citizens_omits_wages():
+    payload = _effort_skeleton_input()
+
+    skeleton = build_effort_calculation_output_skeleton(payload, norm_addressee="citizens")
+
+    taetigkeiten = skeleton["fallgruppen"][0]["taetigkeiten"]
+    assert [t["taetigkeiten_id"] for t in taetigkeiten] == [40, 41]
+    for taetigkeit in taetigkeiten:
+        assert set(taetigkeit.keys()) == {
+            "taetigkeiten_id",
+            "zeitaufwand_in_min_gueltig",
+            "sachaufwand_gueltig",
+            "zeitaufwand_in_min_vorschlag",
+            "sachaufwand_vorschlag",
+        }
+        assert "personalaufwand_gueltig" not in taetigkeit

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -128,14 +128,16 @@ def test_effort_prompt_schema_uses_single_json_braces(norm_addressee):
     assert "}}" not in prompt
 
 
-def test_render_prompt_ignores_contract_field_overrides():
+def test_render_prompt_effort_default_skeleton_echoes_run_addressee():
+    # #64 (Schritt 6): ohne Router-Skelett faellt render_prompt auf ein leeres
+    # Default-Skelett zurueck, das den Lauf-Normadressaten fest echot; ein
+    # Kontext-Override (norm_addressee_prompt_opening) wird weiterhin ignoriert.
     prompt = render_prompt(
         PromptId.EFFORT_CALCULATION,
         law_summary="Kurzfassung",
         step_analysis_json="[]",
         norm_addressee=BUSINESS,
         norm_addressee_prompt_opening="BROKEN CONTEXT",
-        effort_json_schema='{"normadressat": "citizens"}',
     )
 
     assert "BROKEN CONTEXT" not in prompt
@@ -432,7 +434,7 @@ def test_norm_addressee_prompts_end_with_final_json_instruction(prompt_id, norm_
 def test_norm_addressee_prompts_integrate_guidance_before_schema(prompt_id, norm_addressee):
     prompt = _render_prompt_for_contract(prompt_id, norm_addressee)
     context_marker = "Dieser Lauf betrifft nur den Normadressaten"
-    schema_marker = "Geben Sie nur und ausschliesslich JSON im folgenden Format zurueck:"
+    schema_marker = "Geben Sie nur und ausschliesslich JSON"
 
     assert context_marker in prompt
     assert prompt.index(context_marker) < prompt.index(schema_marker)

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -4,7 +4,10 @@ from backend.core.norm_addressees import ADMINISTRATION, BUSINESS, CITIZENS
 from backend.core import prompts
 from backend.core.payload_builders import (
     build_case_groups_payload,
+    build_cases_calculation_output_skeleton,
+    build_effort_calculation_output_skeleton,
     build_step_analysis_output_skeleton,
+    build_step_analysis_payload,
     dump_prompt_json,
 )
 from backend.core.prompts import NORM_ADDRESSEE_PROMPT_OPENINGS, PromptId, render_prompt
@@ -778,3 +781,80 @@ def test_effort_prompt_business_guidance_names_wirtschaftsabschnitt():
 
     assert "wirtschaftsabschnitt" in prompt.lower() or "lohnquelle" in prompt.lower()
     assert "gesamtwirtschaft" in prompt.lower()
+
+
+def _step6_processes_and_case_groups():
+    processes = [
+        {"process_id": 312, "process": "Prozess 312", "description": "d", "change_status": "geaendert"},
+        {"process_id": 313, "process": "Prozess 313", "description": "d", "change_status": "geaendert"},
+    ]
+    case_groups = [
+        {"case_group_id": 491, "process_id": 312, "case_group": "F491", "description": "d", "change_status": "geaendert"},
+        {"case_group_id": 492, "process_id": 313, "case_group": "F492", "description": "d", "change_status": "geaendert"},
+    ]
+    return processes, case_groups
+
+
+@pytest.mark.parametrize("norm_addressee", [ADMINISTRATION, BUSINESS, CITIZENS])
+def test_cases_calculation_prompt_injects_prefilled_skeleton_ids(norm_addressee):
+    processes, case_groups = _step6_processes_and_case_groups()
+    case_groups_payload = build_case_groups_payload(
+        processes=processes,
+        case_groups=case_groups,
+        norm_addressee=norm_addressee,
+    )
+
+    prompt = render_prompt(
+        PromptId.CASES_CALCULATION,
+        law_summary="Kurzfassung",
+        case_groups_json=dump_prompt_json(case_groups_payload),
+        output_skeleton_json=dump_prompt_json(
+            build_cases_calculation_output_skeleton(
+                case_groups_payload,
+                norm_addressee=norm_addressee,
+            )
+        ),
+        norm_addressee=norm_addressee,
+    )
+
+    assert '"fallgruppen_id": 491' in prompt
+    assert '"fallgruppen_id": 492' in prompt
+    assert f'"normadressat": "{norm_addressee}"' in prompt
+    assert '"fallgruppen": []' not in prompt
+
+
+@pytest.mark.parametrize("norm_addressee", [ADMINISTRATION, BUSINESS, CITIZENS])
+def test_effort_calculation_prompt_injects_prefilled_skeleton_ids(norm_addressee):
+    processes, case_groups = _step6_processes_and_case_groups()
+    steps = [
+        {"step_id": 40, "case_group_id": 491, "step": "Schritt 1", "description": "", "change_status": "geaendert", "previous_id": None, "next_id": 41},
+        {"step_id": 41, "case_group_id": 491, "step": "Schritt 2", "description": "", "change_status": "geaendert", "previous_id": 40, "next_id": None},
+        {"step_id": 42, "case_group_id": 492, "step": "Schritt 3", "description": "", "change_status": "geaendert", "previous_id": None, "next_id": None},
+    ]
+    steps_payload = build_step_analysis_payload(
+        processes=processes,
+        case_groups=case_groups,
+        steps=steps,
+        norm_addressee=norm_addressee,
+    )
+
+    prompt = render_prompt(
+        PromptId.EFFORT_CALCULATION,
+        law_summary="Kurzfassung",
+        step_analysis_json=dump_prompt_json(steps_payload),
+        output_skeleton_json=dump_prompt_json(
+            build_effort_calculation_output_skeleton(
+                steps_payload,
+                norm_addressee=norm_addressee,
+            )
+        ),
+        norm_addressee=norm_addressee,
+    )
+
+    assert '"fallgruppen_id": 491' in prompt
+    assert '"fallgruppen_id": 492' in prompt
+    assert '"taetigkeiten_id": 40' in prompt
+    assert '"taetigkeiten_id": 41' in prompt
+    assert '"taetigkeiten_id": 42' in prompt
+    assert f'"normadressat": "{norm_addressee}"' in prompt
+    assert '"fallgruppen": []' not in prompt

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -2,6 +2,11 @@ import re
 
 from backend.core.norm_addressees import ADMINISTRATION, BUSINESS, CITIZENS
 from backend.core import prompts
+from backend.core.payload_builders import (
+    build_case_groups_payload,
+    build_step_analysis_output_skeleton,
+    dump_prompt_json,
+)
 from backend.core.prompts import NORM_ADDRESSEE_PROMPT_OPENINGS, PromptId, render_prompt
 import pytest
 
@@ -534,10 +539,9 @@ def test_process_step_analysis_prompt_frames_checklist_recurring_only(norm_addre
 
 
 @pytest.mark.parametrize("norm_addressee", [ADMINISTRATION, BUSINESS, CITIZENS])
-def test_process_step_analysis_prompt_demands_unique_fallgruppen_per_process(norm_addressee):
-    # #13/#25: Step 5 muss die uebergebene Prozess-/Fallgruppen-Struktur
-    # erhalten - jede fallgruppen_id genau einmal, unter ihrem Prozess
-    # (verhindert doppelte Step-Ketten fuer dieselbe Fallgruppe).
+def test_process_step_analysis_prompt_demands_unique_fallgruppen(norm_addressee):
+    # #64 (Option 4): flaches Schema - jede fallgruppen_id genau einmal, kein
+    # Zusammenfuehren/Aufteilen (der fruehere Prozess-Bezug entfaellt flach).
     prompt = render_prompt(
         PromptId.PROCESS_STEP_ANALYSIS,
         law_summary="Kurzfassung",
@@ -545,10 +549,52 @@ def test_process_step_analysis_prompt_demands_unique_fallgruppen_per_process(nor
         norm_addressee=norm_addressee,
     )
 
-    assert "jede vorgegebene `fallgruppen_id` unter ihrem vorgegebenen Prozess" in prompt
-    assert "geben Sie sie genau einmal aus" in prompt
-    assert "unter einem fremden Prozess" in prompt
+    assert "Geben Sie jede vorgegebene `fallgruppen_id` genau einmal aus" in prompt
+    assert "keine `fallgruppen_id` mehrfach vorkommt" in prompt
     assert "Fuehren Sie Fallgruppen nicht zusammen, teilen Sie sie nicht auf" in prompt
+    assert "unter ihrem vorgegebenen Prozess" not in prompt
+    assert "unter einem fremden Prozess" not in prompt
+
+
+@pytest.mark.parametrize("norm_addressee", [ADMINISTRATION, BUSINESS, CITIZENS])
+def test_process_step_analysis_prompt_injects_flat_output_skeleton(norm_addressee):
+    # #64 (Option 4): Statt eines nested Schemas zeigt der Prompt ein aus
+    # case_groups_json vorbefuelltes FLACHES Skelett (nur fallgruppen_id,
+    # taetigkeiten leer, keine Prozess-Ebene); das Modell fuellt nur taetigkeiten.
+    processes = [
+        {"process_id": 312, "process": "Prozess 312", "description": "d", "change_status": "geaendert"},
+        {"process_id": 313, "process": "Prozess 313", "description": "d", "change_status": "geaendert"},
+    ]
+    case_groups = [
+        {"case_group_id": 491, "process_id": 312, "case_group": "F491", "description": "d", "change_status": "geaendert"},
+        {"case_group_id": 492, "process_id": 313, "case_group": "F492", "description": "d", "change_status": "geaendert"},
+    ]
+    payload_groups = build_case_groups_payload(
+        processes=processes,
+        case_groups=case_groups,
+        norm_addressee=norm_addressee,
+    )
+    prompt = render_prompt(
+        PromptId.PROCESS_STEP_ANALYSIS,
+        law_summary="Kurzfassung",
+        case_groups_json=dump_prompt_json(payload_groups),
+        output_skeleton_json=dump_prompt_json(
+            build_step_analysis_output_skeleton(payload_groups, norm_addressee=norm_addressee)
+        ),
+        norm_addressee=norm_addressee,
+    )
+
+    output_section = prompt.split("vorbefuellten Skelett", 1)[1]
+    assert "Fuellen Sie ausschliesslich das Feld `taetigkeiten`" in prompt
+    assert (
+        "Fuegen Sie keine Fallgruppen-Objekte hinzu, entfernen, "
+        "verschieben oder duplizieren Sie keine" in prompt
+    )
+    assert '"fallgruppen_id": 491' in prompt
+    assert '"fallgruppen_id": 492' in prompt
+    assert '"taetigkeiten": []' in prompt
+    assert '"fallgruppen_id": ""' not in prompt
+    assert '"prozess_id"' not in output_section
 
 
 @pytest.mark.parametrize("norm_addressee", [ADMINISTRATION, BUSINESS, CITIZENS])

--- a/tests/test_sessions_contract.py
+++ b/tests/test_sessions_contract.py
@@ -407,6 +407,39 @@ def test_sessions_llm_monitor_snapshot_contract(test_client):
     assert first["norm_addressee"] == "business"
 
 
+def test_sessions_llm_monitor_snapshot_surfaces_response_format_downgrade(test_client):
+    app_session_id = "CONTRACT-LLM-MONITOR-RESPONSE-FORMAT"
+    session_id, _ = db.upsert_session(app_session_id, "gpt-5")
+    db.insert_llm_answer(
+        session_id=session_id,
+        prompt_id="cases_calculation",
+        model="gpt-5",
+        answer_text='{"ok": true}',
+        metadata={
+            "provider": "openai",
+            "response_format_requested": "json_schema",
+            "response_format_used": "json_object",
+            "response_format_downgraded": True,
+        },
+        answer_state=db.LLM_ANSWER_STATE_ACTIVE,
+        state_reason="session_updated",
+        norm_addressee="business",
+    )
+
+    resp = test_client.get(
+        "/sessions/llm-monitor",
+        params={"app_session_id": app_session_id},
+    )
+    assert resp.status_code == 200
+    payload = resp.json()
+    parsed = _parse_contract(sessions_router.SessionLlmMonitorSnapshotResponse, payload)
+    assert len(parsed.recent) >= 1
+    first = parsed.recent[0]
+    assert first["response_format_requested"] == "json_schema"
+    assert first["response_format_used"] == "json_object"
+    assert first["response_format_downgraded"] is True
+
+
 def test_sessions_llm_monitor_snapshot_includes_deep_research_recent(test_client):
     app_session_id = "CONTRACT-LLM-MONITOR-DR"
     session_id, _ = db.upsert_session(app_session_id, "gpt-5")

--- a/tests/test_sessions_run_all.py
+++ b/tests/test_sessions_run_all.py
@@ -17,6 +17,7 @@ from backend.routers import (
     sessions as sessions_router,
 )
 from backend.core.norm_addressees import ADMINISTRATION, BUSINESS, CITIZENS
+from backend.routers.sessions import _ATOMIC_STEP_MAX_ATTEMPTS
 
 
 def _is_effort_prompt(prompt: str) -> bool:
@@ -1203,7 +1204,7 @@ def test_processes_step_partial_failure_keeps_valid_sibling_pending_and_applies_
     assert retry_start.status_code == 200
     retry_done = _wait_for_run_completion(test_client, retry_start.json()["run_id"])
     assert retry_done["status"] == "completed"
-    assert calls == {ADMINISTRATION: 1, BUSINESS: 3}
+    assert calls == {ADMINISTRATION: 1, BUSINESS: _ATOMIC_STEP_MAX_ATTEMPTS + 1}
     assert len(db.list_processes_for_session_and_addressee(session_id, ADMINISTRATION)) == 1
     assert len(db.list_processes_for_session_and_addressee(session_id, BUSINESS)) == 1
 
@@ -3412,7 +3413,7 @@ def test_process_step_exhausts_retry_and_keeps_partial_failure_state(
 
     assert payload["status"] == "failed"
     assert "Die Antwort für Wirtschaft konnte nicht verarbeitet werden" in payload["last_error"]
-    assert calls == {ADMINISTRATION: 1, BUSINESS: 2}
+    assert calls == {ADMINISTRATION: 1, BUSINESS: _ATOMIC_STEP_MAX_ATTEMPTS}
     assert db.list_process_steps_for_session(session_id) == []
     rows = [
         row

--- a/tests/test_sessions_run_all.py
+++ b/tests/test_sessions_run_all.py
@@ -297,26 +297,16 @@ def _patch_run_all_llms(monkeypatch, app_session_id: str) -> None:
             return _json_for_prompt(
                 prompt,
                 {
-                    "prozesse": [
+                    "fallgruppen": [
                         {
-                            "prozess_id": str(processes[0]["process_id"]),
-                            "fallgruppen": [
-                                {
-                                    "fallgruppen_id": str(case_groups[0]["case_group_id"]),
-                                    "anzahl_betroffene_vorschlag": "10",
-                                    "haeufigkeit_pro_jahr_vorschlag": "2",
-                                }
-                            ],
+                            "fallgruppen_id": str(case_groups[0]["case_group_id"]),
+                            "anzahl_betroffene_vorschlag": "10",
+                            "haeufigkeit_pro_jahr_vorschlag": "2",
                         },
                         {
-                            "prozess_id": str(processes[1]["process_id"]),
-                            "fallgruppen": [
-                                {
-                                    "fallgruppen_id": str(case_groups[1]["case_group_id"]),
-                                    "anzahl_betroffene_vorschlag": "5",
-                                    "haeufigkeit_pro_jahr_vorschlag": "1",
-                                }
-                            ],
+                            "fallgruppen_id": str(case_groups[1]["case_group_id"]),
+                            "anzahl_betroffene_vorschlag": "5",
+                            "haeufigkeit_pro_jahr_vorschlag": "1",
                         },
                     ]
                 }
@@ -347,18 +337,7 @@ def _patch_run_all_llms(monkeypatch, app_session_id: str) -> None:
             )
         return _json_for_prompt(
             prompt,
-            {
-                "prozesse": [
-                    {
-                        "prozess_id": str(processes[0]["process_id"]),
-                        "fallgruppen": [effort_fallgruppen[0]],
-                    },
-                    {
-                        "prozess_id": str(processes[1]["process_id"]),
-                        "fallgruppen": [effort_fallgruppen[1]],
-                    },
-                ]
-            }
+            {"fallgruppen": effort_fallgruppen}
         )
 
     monkeypatch.setattr(regulations_router, "query_llm", fake_regulations_llm)
@@ -486,16 +465,11 @@ def _patch_run_all_llms_for_all_addressees(monkeypatch, app_session_id: str) -> 
             return _json_for_prompt(
                 prompt,
                 {
-                    "prozesse": [
+                    "fallgruppen": [
                         {
-                            "prozess_id": str(processes[0]["process_id"]),
-                            "fallgruppen": [
-                                {
-                                    "fallgruppen_id": str(case_groups[0]["case_group_id"]),
-                                    "anzahl_betroffene_vorschlag": "10",
-                                    "haeufigkeit_pro_jahr_vorschlag": "2",
-                                }
-                            ],
+                            "fallgruppen_id": str(case_groups[0]["case_group_id"]),
+                            "anzahl_betroffene_vorschlag": "10",
+                            "haeufigkeit_pro_jahr_vorschlag": "2",
                         }
                     ]
                 }
@@ -521,15 +495,10 @@ def _patch_run_all_llms_for_all_addressees(monkeypatch, app_session_id: str) -> 
         return _json_for_prompt(
             prompt,
             {
-                "prozesse": [
+                "fallgruppen": [
                     {
-                        "prozess_id": str(processes[0]["process_id"]),
-                        "fallgruppen": [
-                            {
-                                "fallgruppen_id": str(case_groups[0]["case_group_id"]),
-                                "taetigkeiten": [effort_entry],
-                            }
-                        ],
+                        "fallgruppen_id": str(case_groups[0]["case_group_id"]),
+                        "taetigkeiten": [effort_entry],
                     }
                 ]
             }
@@ -650,16 +619,11 @@ def _patch_run_all_llms_for_business_only(monkeypatch, app_session_id: str) -> N
             return _json_for_prompt(
                 prompt,
                 {
-                    "prozesse": [
+                    "fallgruppen": [
                         {
-                            "prozess_id": str(processes[0]["process_id"]),
-                            "fallgruppen": [
-                                {
-                                    "fallgruppen_id": str(case_groups[0]["case_group_id"]),
-                                    "anzahl_betroffene_vorschlag": "10",
-                                    "haeufigkeit_pro_jahr_vorschlag": "2",
-                                }
-                            ],
+                            "fallgruppen_id": str(case_groups[0]["case_group_id"]),
+                            "anzahl_betroffene_vorschlag": "10",
+                            "haeufigkeit_pro_jahr_vorschlag": "2",
                         }
                     ]
                 }
@@ -667,23 +631,18 @@ def _patch_run_all_llms_for_business_only(monkeypatch, app_session_id: str) -> N
         return _json_for_prompt(
             prompt,
             {
-                "prozesse": [
+                "fallgruppen": [
                     {
-                        "prozess_id": str(processes[0]["process_id"]),
-                        "fallgruppen": [
+                        "fallgruppen_id": str(case_groups[0]["case_group_id"]),
+                        "taetigkeiten": [
                             {
-                                "fallgruppen_id": str(case_groups[0]["case_group_id"]),
-                                "taetigkeiten": [
-                                    {
-                                        "taetigkeiten_id": str(steps[0]["step_id"]),
-                                        "taetigkeit": steps[0]["step"],
-                                        "beschreibung": steps[0]["description"],
-                                        "personalaufwand_vorschlag": [
-                                            _personalaufwand_row(addressee, "30")
-                                        ],
-                                        "sachaufwand_vorschlag": "10",
-                                    }
+                                "taetigkeiten_id": str(steps[0]["step_id"]),
+                                "taetigkeit": steps[0]["step"],
+                                "beschreibung": steps[0]["description"],
+                                "personalaufwand_vorschlag": [
+                                    _personalaufwand_row(addressee, "30")
                                 ],
+                                "sachaufwand_vorschlag": "10",
                             }
                         ],
                     }
@@ -908,18 +867,13 @@ def test_run_all_uses_deep_research_for_case_group_metrics(test_client, monkeypa
             }
         return json.dumps(
             {
-                "prozesse": [
+                "normadressat": addressee,
+                "fallgruppen": [
                     {
-                        "prozess_id": str(processes[0]["process_id"]),
-                        "normadressat": addressee,
-                        "fallgruppen": [
-                            {
-                                "fallgruppen_id": str(case_groups[0]["case_group_id"]),
-                                "taetigkeiten": [effort_entry],
-                            }
-                        ],
+                        "fallgruppen_id": str(case_groups[0]["case_group_id"]),
+                        "taetigkeiten": [effort_entry],
                     }
-                ]
+                ],
             }
         )
 
@@ -1983,16 +1937,11 @@ def test_effort_step_stages_all_normal_prompts_concurrently(test_client, monkeyp
         if prompt_kind == "cases":
             return json.dumps(
                 {
-                    "prozesse": [
+                    "fallgruppen": [
                         {
-                            "prozess_id": str(processes[0]["process_id"]),
-                            "fallgruppen": [
-                                {
-                                    "fallgruppen_id": str(case_groups[0]["case_group_id"]),
-                                    "anzahl_betroffene_vorschlag": "10",
-                                    "haeufigkeit_pro_jahr_vorschlag": "2",
-                                }
-                            ],
+                            "fallgruppen_id": str(case_groups[0]["case_group_id"]),
+                            "anzahl_betroffene_vorschlag": "10",
+                            "haeufigkeit_pro_jahr_vorschlag": "2",
                         }
                     ]
                 }
@@ -2013,15 +1962,10 @@ def test_effort_step_stages_all_normal_prompts_concurrently(test_client, monkeyp
             }
         return json.dumps(
             {
-                "prozesse": [
+                "fallgruppen": [
                     {
-                        "prozess_id": str(processes[0]["process_id"]),
-                        "fallgruppen": [
-                            {
-                                "fallgruppen_id": str(case_groups[0]["case_group_id"]),
-                                "taetigkeiten": [effort_entry],
-                            }
-                        ],
+                        "fallgruppen_id": str(case_groups[0]["case_group_id"]),
+                        "taetigkeiten": [effort_entry],
                     }
                 ]
             }
@@ -2069,16 +2013,11 @@ def test_effort_step_parse_failure_applies_no_sibling_metrics_and_keeps_valid_pe
         if not _is_effort_prompt(prompt):
             return json.dumps(
                 {
-                    "prozesse": [
+                    "fallgruppen": [
                         {
-                            "prozess_id": str(processes[0]["process_id"]),
-                            "fallgruppen": [
-                                {
-                                    "fallgruppen_id": str(case_groups[0]["case_group_id"]),
-                                    "anzahl_betroffene_vorschlag": "10",
-                                    "haeufigkeit_pro_jahr_vorschlag": "2",
-                                }
-                            ],
+                            "fallgruppen_id": str(case_groups[0]["case_group_id"]),
+                            "anzahl_betroffene_vorschlag": "10",
+                            "haeufigkeit_pro_jahr_vorschlag": "2",
                         }
                     ]
                 }
@@ -2104,15 +2043,10 @@ def test_effort_step_parse_failure_applies_no_sibling_metrics_and_keeps_valid_pe
             }
         return json.dumps(
             {
-                "prozesse": [
+                "fallgruppen": [
                     {
-                        "prozess_id": str(processes[0]["process_id"]),
-                        "fallgruppen": [
-                            {
-                                "fallgruppen_id": str(case_groups[0]["case_group_id"]),
-                                "taetigkeiten": [effort_entry],
-                            }
-                        ],
+                        "fallgruppen_id": str(case_groups[0]["case_group_id"]),
+                        "taetigkeiten": [effort_entry],
                     }
                 ]
             }
@@ -2170,16 +2104,11 @@ def test_effort_step_tile_refresh_failure_rolls_back_metrics_and_answers(
         if not _is_effort_prompt(prompt):
             return json.dumps(
                 {
-                    "prozesse": [
+                    "fallgruppen": [
                         {
-                            "prozess_id": str(processes[0]["process_id"]),
-                            "fallgruppen": [
-                                {
-                                    "fallgruppen_id": str(case_groups[0]["case_group_id"]),
-                                    "anzahl_betroffene_vorschlag": "10",
-                                    "haeufigkeit_pro_jahr_vorschlag": "2",
-                                }
-                            ],
+                            "fallgruppen_id": str(case_groups[0]["case_group_id"]),
+                            "anzahl_betroffene_vorschlag": "10",
+                            "haeufigkeit_pro_jahr_vorschlag": "2",
                         }
                     ]
                 }
@@ -2198,15 +2127,10 @@ def test_effort_step_tile_refresh_failure_rolls_back_metrics_and_answers(
             }
         return json.dumps(
             {
-                "prozesse": [
+                "fallgruppen": [
                     {
-                        "prozess_id": str(processes[0]["process_id"]),
-                        "fallgruppen": [
-                            {
-                                "fallgruppen_id": str(case_groups[0]["case_group_id"]),
-                                "taetigkeiten": [effort_entry],
-                            }
-                        ],
+                        "fallgruppen_id": str(case_groups[0]["case_group_id"]),
+                        "taetigkeiten": [effort_entry],
                     }
                 ]
             }
@@ -2604,18 +2528,13 @@ def test_single_step_run_effort_uses_deep_research_when_enabled(
             }
         return json.dumps(
             {
-                "prozesse": [
+                "normadressat": addressee,
+                "fallgruppen": [
                     {
-                        "prozess_id": str(processes[0]["process_id"]),
-                        "normadressat": addressee,
-                        "fallgruppen": [
-                            {
-                                "fallgruppen_id": str(case_groups[0]["case_group_id"]),
-                                "taetigkeiten": [effort_entry],
-                            }
-                        ],
+                        "fallgruppen_id": str(case_groups[0]["case_group_id"]),
+                        "taetigkeiten": [effort_entry],
                     }
-                ]
+                ],
             }
         )
 
@@ -2714,18 +2633,13 @@ def test_single_step_run_effort_reuses_waiting_effort_after_completed_deep_resea
             }
         response = json.dumps(
             {
-                "prozesse": [
+                "normadressat": addressee,
+                "fallgruppen": [
                     {
-                        "prozess_id": str(processes[0]["process_id"]),
-                        "normadressat": addressee,
-                        "fallgruppen": [
-                            {
-                                "fallgruppen_id": str(case_groups[0]["case_group_id"]),
-                                "taetigkeiten": [effort_entry],
-                            }
-                        ],
+                        "fallgruppen_id": str(case_groups[0]["case_group_id"]),
+                        "taetigkeiten": [effort_entry],
                     }
-                ]
+                ],
             }
         )
         effort_payloads[addressee] = response
@@ -2938,7 +2852,7 @@ def test_single_step_run_effort_cancel_promotes_staged_effort_for_retry(
         return json.dumps(
             {
                 "normadressat": addressee,
-                "prozesse": [],
+                "fallgruppen": [],
             }
         )
 
@@ -3001,16 +2915,11 @@ def test_single_step_run_effort_cancel_preserves_completed_normal_answer_for_ret
         case_groups = db.list_case_groups_for_session_and_addressee(session_id, addressee)
         return json.dumps(
             {
-                "prozesse": [
+                "fallgruppen": [
                     {
-                        "prozess_id": str(processes[0]["process_id"]),
-                        "fallgruppen": [
-                            {
-                                "fallgruppen_id": str(case_groups[0]["case_group_id"]),
-                                "anzahl_betroffene_vorschlag": "10",
-                                "haeufigkeit_pro_jahr_vorschlag": "1",
-                            }
-                        ],
+                        "fallgruppen_id": str(case_groups[0]["case_group_id"]),
+                        "anzahl_betroffene_vorschlag": "10",
+                        "haeufigkeit_pro_jahr_vorschlag": "1",
                     }
                 ]
             }
@@ -3034,15 +2943,10 @@ def test_single_step_run_effort_cancel_preserves_completed_normal_answer_for_ret
             }
         return json.dumps(
             {
-                "prozesse": [
+                "fallgruppen": [
                     {
-                        "prozess_id": str(processes[0]["process_id"]),
-                        "fallgruppen": [
-                            {
-                                "fallgruppen_id": str(case_groups[0]["case_group_id"]),
-                                "taetigkeiten": [effort_entry],
-                            }
-                        ],
+                        "fallgruppen_id": str(case_groups[0]["case_group_id"]),
+                        "taetigkeiten": [effort_entry],
                     }
                 ]
             }

--- a/tests/test_sessions_run_all.py
+++ b/tests/test_sessions_run_all.py
@@ -17,7 +17,20 @@ from backend.routers import (
     sessions as sessions_router,
 )
 from backend.core.norm_addressees import ADMINISTRATION, BUSINESS, CITIZENS
-from backend.routers.sessions import _ATOMIC_STEP_MAX_ATTEMPTS
+from backend.routers.sessions import (
+    _ATOMIC_STEP_DEFAULT_MAX_ATTEMPTS,
+    _max_attempts_for_model,
+)
+
+
+def test_max_attempts_for_model_high_retry_models():
+    for model in ("gemini-3.5-flash", "gemini-3-flash-preview", "gpt-5.4-mini"):
+        assert _max_attempts_for_model(model) == 4
+
+
+def test_max_attempts_for_model_default_for_strong_model():
+    assert _max_attempts_for_model("gpt-5.4") == _ATOMIC_STEP_DEFAULT_MAX_ATTEMPTS
+    assert _ATOMIC_STEP_DEFAULT_MAX_ATTEMPTS == 2
 
 
 def _is_effort_prompt(prompt: str) -> bool:
@@ -1204,7 +1217,7 @@ def test_processes_step_partial_failure_keeps_valid_sibling_pending_and_applies_
     assert retry_start.status_code == 200
     retry_done = _wait_for_run_completion(test_client, retry_start.json()["run_id"])
     assert retry_done["status"] == "completed"
-    assert calls == {ADMINISTRATION: 1, BUSINESS: _ATOMIC_STEP_MAX_ATTEMPTS + 1}
+    assert calls == {ADMINISTRATION: 1, BUSINESS: _ATOMIC_STEP_DEFAULT_MAX_ATTEMPTS + 1}
     assert len(db.list_processes_for_session_and_addressee(session_id, ADMINISTRATION)) == 1
     assert len(db.list_processes_for_session_and_addressee(session_id, BUSINESS)) == 1
 
@@ -3413,7 +3426,7 @@ def test_process_step_exhausts_retry_and_keeps_partial_failure_state(
 
     assert payload["status"] == "failed"
     assert "Die Antwort für Wirtschaft konnte nicht verarbeitet werden" in payload["last_error"]
-    assert calls == {ADMINISTRATION: 1, BUSINESS: _ATOMIC_STEP_MAX_ATTEMPTS}
+    assert calls == {ADMINISTRATION: 1, BUSINESS: _ATOMIC_STEP_DEFAULT_MAX_ATTEMPTS}
     assert db.list_process_steps_for_session(session_id) == []
     rows = [
         row

--- a/tests/test_sessions_run_all.py
+++ b/tests/test_sessions_run_all.py
@@ -253,41 +253,30 @@ def _patch_run_all_llms(monkeypatch, app_session_id: str) -> None:
     async def fake_steps_llm(prompt, *_args, **_kwargs):
         session_id = db.get_session_id_by_app_id(app_session_id)
         assert session_id is not None
-        processes = db.list_processes_for_session(session_id)
         case_groups = db.list_case_groups_for_session(session_id)
         return _json_for_prompt(
             prompt,
             {
-                "prozesse": [
+                "fallgruppen": [
                     {
-                        "prozess_id": str(processes[0]["process_id"]),
-                        "fallgruppen": [
+                        "fallgruppen_id": str(case_groups[0]["case_group_id"]),
+                        "taetigkeiten": [
                             {
-                                "fallgruppen_id": str(case_groups[0]["case_group_id"]),
-                                "taetigkeiten": [
-                                    {
-                                        "taetigkeit": "Schritt A1",
-                                        "beschreibung": "Beschreibung A1",
-                                    },
-                                    {
-                                        "taetigkeit": "Schritt A2",
-                                        "beschreibung": "Beschreibung A2",
-                                    },
-                                ],
-                            }
+                                "taetigkeit": "Schritt A1",
+                                "beschreibung": "Beschreibung A1",
+                            },
+                            {
+                                "taetigkeit": "Schritt A2",
+                                "beschreibung": "Beschreibung A2",
+                            },
                         ],
                     },
                     {
-                        "prozess_id": str(processes[1]["process_id"]),
-                        "fallgruppen": [
+                        "fallgruppen_id": str(case_groups[1]["case_group_id"]),
+                        "taetigkeiten": [
                             {
-                                "fallgruppen_id": str(case_groups[1]["case_group_id"]),
-                                "taetigkeiten": [
-                                    {
-                                        "taetigkeit": "Schritt B1",
-                                        "beschreibung": "Beschreibung B1",
-                                    }
-                                ],
+                                "taetigkeit": "Schritt B1",
+                                "beschreibung": "Beschreibung B1",
                             }
                         ],
                     },
@@ -469,18 +458,13 @@ def _patch_run_all_llms_for_all_addressees(monkeypatch, app_session_id: str) -> 
         return _json_for_prompt(
             prompt,
             {
-                "prozesse": [
+                "fallgruppen": [
                     {
-                        "prozess_id": str(processes[0]["process_id"]),
-                        "fallgruppen": [
+                        "fallgruppen_id": str(case_groups[0]["case_group_id"]),
+                        "taetigkeiten": [
                             {
-                                "fallgruppen_id": str(case_groups[0]["case_group_id"]),
-                                "taetigkeiten": [
-                                    {
-                                        "taetigkeit": f"Schritt {addressee}",
-                                        "beschreibung": f"Beschreibung Schritt {addressee}",
-                                    }
-                                ],
+                                "taetigkeit": f"Schritt {addressee}",
+                                "beschreibung": f"Beschreibung Schritt {addressee}",
                             }
                         ],
                     }
@@ -638,18 +622,13 @@ def _patch_run_all_llms_for_business_only(monkeypatch, app_session_id: str) -> N
         return _json_for_prompt(
             prompt,
             {
-                "prozesse": [
+                "fallgruppen": [
                     {
-                        "prozess_id": str(processes[0]["process_id"]),
-                        "fallgruppen": [
+                        "fallgruppen_id": str(case_groups[0]["case_group_id"]),
+                        "taetigkeiten": [
                             {
-                                "fallgruppen_id": str(case_groups[0]["case_group_id"]),
-                                "taetigkeiten": [
-                                    {
-                                        "taetigkeit": f"Schritt {addressee}",
-                                        "beschreibung": f"Beschreibung Schritt {addressee}",
-                                    }
-                                ],
+                                "taetigkeit": f"Schritt {addressee}",
+                                "beschreibung": f"Beschreibung Schritt {addressee}",
                             }
                         ],
                     }
@@ -1494,20 +1473,13 @@ def test_process_step_step_partial_failure_applies_nothing(test_client, monkeypa
         case_group_id = admin_case_group if addressee == ADMINISTRATION else 999999
         return json.dumps(
             {
-                "prozesse": [
+                "fallgruppen": [
                     {
-                        "prozess_id": str(
-                            admin_process if addressee == ADMINISTRATION else business_process
-                        ),
-                        "fallgruppen": [
+                        "fallgruppen_id": str(case_group_id),
+                        "taetigkeiten": [
                             {
-                                "fallgruppen_id": str(case_group_id),
-                                "taetigkeiten": [
-                                    {
-                                        "taetigkeit": f"Schritt {addressee}",
-                                        "beschreibung": "Beschreibung",
-                                    }
-                                ],
+                                "taetigkeit": f"Schritt {addressee}",
+                                "beschreibung": "Beschreibung",
                             }
                         ],
                     }
@@ -1637,19 +1609,14 @@ def test_single_step_success_normalizes_change_status_for_processes_case_groups_
         assert _detect_addressee_from_prompt(prompt) == ADMINISTRATION
         return json.dumps(
             {
-                "prozesse": [
+                "fallgruppen": [
                     {
-                        "prozess_id": str(process["process_id"]),
-                        "fallgruppen": [
+                        "fallgruppen_id": str(case_group["case_group_id"]),
+                        "taetigkeiten": [
                             {
-                                "fallgruppen_id": str(case_group["case_group_id"]),
-                                "taetigkeiten": [
-                                    {
-                                        "taetigkeit": "Schritt Verwaltung",
-                                        "beschreibung": "Beschreibung",
-                                        "status_change": "unchanged",
-                                    }
-                                ],
+                                "taetigkeit": "Schritt Verwaltung",
+                                "beschreibung": "Beschreibung",
+                                "status_change": "unchanged",
                             }
                         ],
                     }
@@ -1850,24 +1817,18 @@ def test_process_step_apply_failure_rolls_back_rows_tiles_links_and_answers(
 
     async def valid_process_steps_llm(prompt, *_args, **_kwargs):
         addressee = _detect_addressee_from_prompt(prompt)
-        process_id = admin_process if addressee == ADMINISTRATION else business_process
         case_group_id = (
             admin_case_group if addressee == ADMINISTRATION else business_case_group
         )
         return json.dumps(
             {
-                "prozesse": [
+                "fallgruppen": [
                     {
-                        "prozess_id": str(process_id),
-                        "fallgruppen": [
+                        "fallgruppen_id": str(case_group_id),
+                        "taetigkeiten": [
                             {
-                                "fallgruppen_id": str(case_group_id),
-                                "taetigkeiten": [
-                                    {
-                                        "taetigkeit": f"Schritt {addressee}",
-                                        "beschreibung": "Beschreibung",
-                                    }
-                                ],
+                                "taetigkeit": f"Schritt {addressee}",
+                                "beschreibung": "Beschreibung",
                             }
                         ],
                     }

--- a/tests/test_sessions_run_all.py
+++ b/tests/test_sessions_run_all.py
@@ -1203,7 +1203,7 @@ def test_processes_step_partial_failure_keeps_valid_sibling_pending_and_applies_
     assert retry_start.status_code == 200
     retry_done = _wait_for_run_completion(test_client, retry_start.json()["run_id"])
     assert retry_done["status"] == "completed"
-    assert calls == {ADMINISTRATION: 1, BUSINESS: 2}
+    assert calls == {ADMINISTRATION: 1, BUSINESS: 3}
     assert len(db.list_processes_for_session_and_addressee(session_id, ADMINISTRATION)) == 1
     assert len(db.list_processes_for_session_and_addressee(session_id, BUSINESS)) == 1
 
@@ -3223,3 +3223,294 @@ def test_run_all_successful_restart_clears_transient_status_fields(test_client, 
     assert restart_done["current_step"] is None
     assert restart_done["current_label"] is None
     assert restart_done["current_norm_addressee"] is None
+
+
+def test_is_retryable_atomic_step_error_only_matches_422():
+    from fastapi import HTTPException
+
+    assert (
+        sessions_router._is_retryable_atomic_step_error(
+            HTTPException(status_code=422, detail="No process steps parsed")
+        )
+        is True
+    )
+    for code in (400, 404, 409, 500, 502):
+        assert (
+            sessions_router._is_retryable_atomic_step_error(
+                HTTPException(status_code=code, detail="x")
+            )
+            is False
+        )
+    assert sessions_router._is_retryable_atomic_step_error(RuntimeError("x")) is False
+    assert sessions_router._is_retryable_atomic_step_error(ValueError("x")) is False
+
+
+def test_process_step_retries_once_when_first_output_violates_skeleton(
+    test_client,
+    monkeypatch,
+):
+    app_session_id = "STEP-PROCESS-STEPS-RETRY-SUCCESS"
+    session_id, _ = db.upsert_session(app_session_id, "test-model")
+    db.insert_regulation(
+        session_id,
+        "§ B",
+        "Vorgabe Wirtschaft",
+        applies_to_administration=False,
+        applies_to_business=True,
+        applies_to_citizens=False,
+        is_business_information_obligation=True,
+    )
+    business_process = db.insert_process(
+        session_id,
+        "Prozess Wirtschaft",
+        "Beschreibung",
+        norm_addressee=BUSINESS,
+    )
+    case_group_1 = db.insert_case_group(
+        session_id,
+        business_process,
+        "Fallgruppe 1",
+        "Beschreibung",
+        norm_addressee=BUSINESS,
+    )
+    case_group_2 = db.insert_case_group(
+        session_id,
+        business_process,
+        "Fallgruppe 2",
+        "Beschreibung",
+        norm_addressee=BUSINESS,
+    )
+    _upsert_process_tile(session_id, business_process, BUSINESS, row=1)
+    _upsert_case_group_tile(session_id, case_group_1, business_process, BUSINESS, row=1)
+    _upsert_case_group_tile(session_id, case_group_2, business_process, BUSINESS, row=2)
+    calls = {BUSINESS: 0}
+
+    async def flaky_steps_llm(prompt, *_args, **_kwargs):
+        addressee = _detect_addressee_from_prompt(prompt)
+        assert addressee == BUSINESS
+        calls[addressee] += 1
+        fallgruppen = [
+            {
+                "fallgruppen_id": str(case_group_1),
+                "taetigkeiten": [
+                    {"taetigkeit": "Schritt 1", "beschreibung": "Beschreibung 1"}
+                ],
+            }
+        ]
+        if calls[addressee] >= 2:
+            fallgruppen.append(
+                {
+                    "fallgruppen_id": str(case_group_2),
+                    "taetigkeiten": [
+                        {"taetigkeit": "Schritt 2", "beschreibung": "Beschreibung 2"}
+                    ],
+                }
+            )
+        return _json_for_prompt(prompt, {"fallgruppen": fallgruppen})
+
+    monkeypatch.setattr(process_steps_router, "query_llm", flaky_steps_llm)
+    start_response = test_client.post(
+        "/sessions/step-runs/start",
+        json={
+            "app_session_id": app_session_id,
+            "step_key": "process_steps",
+            "model": "test-model",
+            "provider": "openai",
+        },
+    )
+    assert start_response.status_code == 200
+    payload = _wait_for_run_completion(test_client, start_response.json()["run_id"])
+
+    assert payload["status"] == "completed"
+    assert calls == {BUSINESS: 2}
+    steps = db.list_process_steps_for_session_and_addressee(session_id, BUSINESS)
+    covered = {int(step["case_group_id"]) for step in steps}
+    assert covered == {case_group_1, case_group_2}
+
+
+def test_process_step_exhausts_retry_and_keeps_partial_failure_state(
+    test_client,
+    monkeypatch,
+):
+    app_session_id = "STEP-PROCESS-STEPS-RETRY-EXHAUSTED"
+    session_id, _ = db.upsert_session(app_session_id, "test-model")
+    db.insert_regulation(
+        session_id,
+        "§ A",
+        "Vorgabe Verwaltung",
+        applies_to_administration=True,
+        applies_to_business=False,
+        applies_to_citizens=False,
+    )
+    db.insert_regulation(
+        session_id,
+        "§ B",
+        "Vorgabe Wirtschaft",
+        applies_to_administration=False,
+        applies_to_business=True,
+        applies_to_citizens=False,
+        is_business_information_obligation=True,
+    )
+    admin_process = db.insert_process(
+        session_id,
+        "Prozess Verwaltung",
+        "Beschreibung",
+        norm_addressee=ADMINISTRATION,
+    )
+    business_process = db.insert_process(
+        session_id,
+        "Prozess Wirtschaft",
+        "Beschreibung",
+        norm_addressee=BUSINESS,
+    )
+    admin_case_group = db.insert_case_group(
+        session_id,
+        admin_process,
+        "Fallgruppe Verwaltung",
+        "Beschreibung",
+        norm_addressee=ADMINISTRATION,
+    )
+    db.insert_case_group(
+        session_id,
+        business_process,
+        "Fallgruppe Wirtschaft",
+        "Beschreibung",
+        norm_addressee=BUSINESS,
+    )
+    calls = {ADMINISTRATION: 0, BUSINESS: 0}
+
+    async def steps_llm(prompt, *_args, **_kwargs):
+        addressee = _detect_addressee_from_prompt(prompt)
+        calls[addressee] += 1
+        case_group_id = admin_case_group if addressee == ADMINISTRATION else 999999
+        return _json_for_prompt(
+            prompt,
+            {
+                "fallgruppen": [
+                    {
+                        "fallgruppen_id": str(case_group_id),
+                        "taetigkeiten": [
+                            {"taetigkeit": f"Schritt {addressee}", "beschreibung": "B"}
+                        ],
+                    }
+                ]
+            },
+        )
+
+    monkeypatch.setattr(process_steps_router, "query_llm", steps_llm)
+    start_response = test_client.post(
+        "/sessions/step-runs/start",
+        json={
+            "app_session_id": app_session_id,
+            "step_key": "process_steps",
+            "model": "test-model",
+            "provider": "openai",
+        },
+    )
+    assert start_response.status_code == 200
+    payload = _wait_for_run_completion(test_client, start_response.json()["run_id"])
+
+    assert payload["status"] == "failed"
+    assert "Die Antwort für Wirtschaft konnte nicht verarbeitet werden" in payload["last_error"]
+    assert calls == {ADMINISTRATION: 1, BUSINESS: 2}
+    assert db.list_process_steps_for_session(session_id) == []
+    rows = [
+        row
+        for row in db.list_recent_llm_answers_for_session(session_id)
+        if row["prompt_id"] == PromptId.PROCESS_STEP_ANALYSIS
+    ]
+    admin_rows = [row for row in rows if row["norm_addressee"] == ADMINISTRATION]
+    business_rows = [row for row in rows if row["norm_addressee"] == BUSINESS]
+    assert len(admin_rows) == 1
+    assert admin_rows[0]["answer_state"] == "pending"
+    assert admin_rows[0]["state_reason"] == "waiting_for_paired_retry"
+    assert business_rows
+    assert all(row["answer_state"] == "invalid" for row in business_rows)
+    assert any(
+        str(row["state_reason"]).startswith("session_update_failed")
+        for row in business_rows
+    )
+
+
+def test_effort_step_retries_failed_page_and_reuses_successful_pages(
+    test_client,
+    monkeypatch,
+):
+    app_session_id = "STEP-EFFORT-RETRY-SUCCESS"
+    session_id = _seed_step6_prerequisites(app_session_id)
+    calls: dict[tuple[str, str], int] = {}
+
+    async def flaky_effort_llm(prompt, *_args, **_kwargs):
+        addressee = _detect_addressee_from_prompt(prompt)
+        prompt_kind = "effort" if _is_effort_prompt(prompt) else "cases"
+        calls[(prompt_kind, addressee)] = calls.get((prompt_kind, addressee), 0) + 1
+        case_groups = db.list_case_groups_for_session_and_addressee(session_id, addressee)
+        steps = db.list_process_steps_for_session_and_addressee(session_id, addressee)
+        if prompt_kind == "cases":
+            return json.dumps(
+                {
+                    "fallgruppen": [
+                        {
+                            "fallgruppen_id": str(case_groups[0]["case_group_id"]),
+                            "anzahl_betroffene_vorschlag": "10",
+                            "haeufigkeit_pro_jahr_vorschlag": "2",
+                        }
+                    ]
+                }
+            )
+        if addressee == BUSINESS and calls[(prompt_kind, addressee)] == 1:
+            return json.dumps(
+                {
+                    "fallgruppen": [
+                        {
+                            "fallgruppen_id": str(case_groups[0]["case_group_id"]),
+                            "taetigkeiten": [],
+                        }
+                    ]
+                }
+            )
+        if addressee == CITIZENS:
+            effort_entry = {
+                "taetigkeiten_id": str(steps[0]["step_id"]),
+                "zeitaufwand_in_min_vorschlag": "30",
+                "sachaufwand_vorschlag": "10",
+            }
+        else:
+            effort_entry = {
+                "taetigkeiten_id": str(steps[0]["step_id"]),
+                "personalaufwand_vorschlag": [_personalaufwand_row(addressee, "30")],
+                "sachaufwand_vorschlag": "10",
+            }
+        return json.dumps(
+            {
+                "fallgruppen": [
+                    {
+                        "fallgruppen_id": str(case_groups[0]["case_group_id"]),
+                        "taetigkeiten": [effort_entry],
+                    }
+                ]
+            }
+        )
+
+    monkeypatch.setattr(effort_router, "query_llm", flaky_effort_llm)
+    start_response = test_client.post(
+        "/sessions/step-runs/start",
+        json={
+            "app_session_id": app_session_id,
+            "step_key": "effort",
+            "model": "test-model",
+            "provider": "openai",
+        },
+    )
+    assert start_response.status_code == 200
+    payload = _wait_for_run_completion(test_client, start_response.json()["run_id"])
+
+    assert payload["status"] == "completed"
+    assert calls[("effort", BUSINESS)] == 2
+    assert calls[("cases", BUSINESS)] == 2
+    assert calls[("effort", ADMINISTRATION)] == 1
+    assert calls[("cases", ADMINISTRATION)] == 1
+    assert calls[("effort", CITIZENS)] == 1
+    assert calls[("cases", CITIZENS)] == 1
+    for addressee in (ADMINISTRATION, BUSINESS, CITIZENS):
+        assert db.has_effort_metrics(session_id, addressee)

--- a/tests/test_structured_output_schema.py
+++ b/tests/test_structured_output_schema.py
@@ -1,0 +1,215 @@
+import json
+
+from backend.core.norm_addressees import ADMINISTRATION, BUSINESS, CITIZENS
+from backend.core.payload_builders import (
+    _CASES_METRIC_KEYS,
+    build_cases_calculation_output_schema,
+    build_cases_calculation_output_skeleton,
+    build_effort_calculation_output_schema,
+    build_effort_calculation_output_skeleton,
+)
+from backend.routers.effort import _parse_cases_payload, _parse_effort_payload
+
+_FORBIDDEN_KEYWORDS = {
+    "minItems",
+    "maxItems",
+    "minimum",
+    "maximum",
+    "exclusiveMinimum",
+    "exclusiveMaximum",
+    "pattern",
+    "format",
+    "minLength",
+    "maxLength",
+    "minProperties",
+    "maxProperties",
+    "patternProperties",
+    "oneOf",
+    "allOf",
+}
+
+
+def _node_type(node: dict) -> object:
+    return node.get("type")
+
+
+def _is_object(node: dict) -> bool:
+    node_type = _node_type(node)
+    return node_type == "object" or (
+        isinstance(node_type, list) and "object" in node_type
+    )
+
+
+def _is_array(node: dict) -> bool:
+    node_type = _node_type(node)
+    return node_type == "array" or (isinstance(node_type, list) and "array" in node_type)
+
+
+def _assert_strict_subset(node: dict, object_depth: int = 0) -> None:
+    assert isinstance(node, dict)
+    for keyword in _FORBIDDEN_KEYWORDS:
+        assert keyword not in node, keyword
+    if _is_object(node):
+        current_depth = object_depth + 1
+        assert current_depth <= 5
+        assert node.get("additionalProperties") is False
+        properties = node.get("properties", {})
+        assert set(node.get("required", [])) == set(properties.keys())
+        for child in properties.values():
+            _assert_strict_subset(child, current_depth)
+    elif _is_array(node):
+        items = node.get("items")
+        assert isinstance(items, dict)
+        _assert_strict_subset(items, object_depth)
+
+
+def test_cases_schema_is_strict_subset_compliant_for_all_addressees():
+    for addressee in (ADMINISTRATION, BUSINESS, CITIZENS):
+        _assert_strict_subset(build_cases_calculation_output_schema(addressee))
+
+
+def test_effort_schema_is_strict_subset_compliant_for_all_addressees():
+    for addressee in (ADMINISTRATION, BUSINESS, CITIZENS):
+        _assert_strict_subset(build_effort_calculation_output_schema(addressee))
+
+
+def test_cases_schema_matches_skeleton_keys():
+    skeleton = build_cases_calculation_output_skeleton(
+        [{"fallgruppen": [{"fallgruppen_id": 1}]}],
+        norm_addressee=ADMINISTRATION,
+    )
+    skeleton_fallgruppe = skeleton["fallgruppen"][0]
+    schema = build_cases_calculation_output_schema(ADMINISTRATION)
+    schema_fallgruppe = schema["properties"]["fallgruppen"]["items"]["properties"]
+
+    assert set(schema_fallgruppe.keys()) == set(skeleton_fallgruppe.keys())
+    assert set(schema_fallgruppe["erklaerungen"]["properties"].keys()) == set(
+        skeleton_fallgruppe["erklaerungen"].keys()
+    )
+    assert set(schema_fallgruppe["confidence"]["properties"].keys()) == set(
+        skeleton_fallgruppe["confidence"].keys()
+    )
+    for metric_key in _CASES_METRIC_KEYS:
+        assert schema_fallgruppe["confidence"]["properties"][metric_key]["enum"] == [
+            "high",
+            "medium",
+            "low",
+        ]
+
+
+def test_effort_citizens_schema_matches_skeleton_keys():
+    skeleton = build_effort_calculation_output_skeleton(
+        [{"fallgruppen": [{"fallgruppen_id": 1, "taetigkeiten": [{"taetigkeiten_id": 9}]}]}],
+        norm_addressee=CITIZENS,
+    )
+    skeleton_taetigkeit = skeleton["fallgruppen"][0]["taetigkeiten"][0]
+    schema = build_effort_calculation_output_schema(CITIZENS)
+    schema_taetigkeit = schema["properties"]["fallgruppen"]["items"]["properties"][
+        "taetigkeiten"
+    ]["items"]["properties"]
+
+    assert set(schema_taetigkeit.keys()) == set(skeleton_taetigkeit.keys())
+    assert "personalaufwand_gueltig" not in schema_taetigkeit
+
+
+def test_effort_org_schema_matches_skeleton_keys():
+    skeleton = build_effort_calculation_output_skeleton(
+        [{"fallgruppen": [{"fallgruppen_id": 1, "taetigkeiten": [{"taetigkeiten_id": 9}]}]}],
+        norm_addressee=BUSINESS,
+    )
+    skeleton_taetigkeit = skeleton["fallgruppen"][0]["taetigkeiten"][0]
+    schema = build_effort_calculation_output_schema(BUSINESS)
+    schema_taetigkeit = schema["properties"]["fallgruppen"]["items"]["properties"][
+        "taetigkeiten"
+    ]["items"]["properties"]
+
+    assert set(schema_taetigkeit.keys()) == set(skeleton_taetigkeit.keys())
+
+    skeleton_item = skeleton_taetigkeit["personalaufwand_gueltig"][0]
+    schema_item = schema_taetigkeit["personalaufwand_gueltig"]["items"]["properties"]
+    assert set(schema_item.keys()) == set(skeleton_item.keys())
+
+
+def test_normadressat_enum_is_pinned_to_run_addressee():
+    schema = build_cases_calculation_output_schema(BUSINESS)
+    assert schema["properties"]["normadressat"]["enum"] == [BUSINESS]
+
+
+def test_schema_conformant_cases_example_parses():
+    example = {
+        "normadressat": ADMINISTRATION,
+        "fallgruppen": [
+            {
+                "fallgruppen_id": 501,
+                "anzahl_betroffene_gueltig": 100,
+                "haeufigkeit_pro_jahr_gueltig": 1,
+                "anzahl_betroffene_vorschlag": 120,
+                "haeufigkeit_pro_jahr_vorschlag": 1,
+                "erklaerungen": {key: "Herleitung" for key in _CASES_METRIC_KEYS},
+                "confidence": {key: "high" for key in _CASES_METRIC_KEYS},
+            }
+        ],
+    }
+
+    parsed, fallback_kinds = _parse_cases_payload(json.dumps(example), ADMINISTRATION)
+
+    assert fallback_kinds == set()
+    assert len(parsed) == 1
+    assert parsed[0]["case_group_id"] == 501
+    assert parsed[0]["addressees_current"] == 100.0
+    assert parsed[0]["addressees_proposed"] == 120.0
+    assert parsed[0]["case_metric_research_json"]["confidence"][
+        "anzahl_betroffene_gueltig"
+    ] == "high"
+
+
+def test_schema_conformant_cases_example_allows_null_side():
+    example = {
+        "normadressat": ADMINISTRATION,
+        "fallgruppen": [
+            {
+                "fallgruppen_id": 501,
+                "anzahl_betroffene_gueltig": None,
+                "haeufigkeit_pro_jahr_gueltig": None,
+                "anzahl_betroffene_vorschlag": 120,
+                "haeufigkeit_pro_jahr_vorschlag": 1,
+                "erklaerungen": {key: "Herleitung" for key in _CASES_METRIC_KEYS},
+                "confidence": {key: "medium" for key in _CASES_METRIC_KEYS},
+            }
+        ],
+    }
+
+    parsed, fallback_kinds = _parse_cases_payload(json.dumps(example), ADMINISTRATION)
+
+    assert fallback_kinds == set()
+    assert parsed[0]["addressees_current"] is None
+    assert parsed[0]["addressees_proposed"] == 120.0
+
+
+def test_schema_conformant_effort_citizens_example_parses():
+    example = {
+        "normadressat": CITIZENS,
+        "fallgruppen": [
+            {
+                "fallgruppen_id": 501,
+                "taetigkeiten": [
+                    {
+                        "taetigkeiten_id": 9001,
+                        "zeitaufwand_in_min_gueltig": 30,
+                        "sachaufwand_gueltig": 0,
+                        "zeitaufwand_in_min_vorschlag": 45,
+                        "sachaufwand_vorschlag": 5,
+                    }
+                ],
+            }
+        ],
+    }
+
+    parsed, fallback_kinds = _parse_effort_payload(json.dumps(example), CITIZENS)
+
+    assert fallback_kinds == set()
+    assert len(parsed) == 1
+    assert parsed[0]["step_id"] == 9001
+    assert parsed[0]["time_required_current"]["a"] == 30.0
+    assert parsed[0]["time_required_proposed"]["a"] == 45.0
+    assert parsed[0]["expenses_proposed"] == 5.0

--- a/tests/test_structured_output_schema.py
+++ b/tests/test_structured_output_schema.py
@@ -1,14 +1,24 @@
 import json
 
 from backend.core.norm_addressees import ADMINISTRATION, BUSINESS, CITIZENS
+import pytest
+
 from backend.core.payload_builders import (
     _CASES_METRIC_KEYS,
+    build_case_group_development_output_schema,
     build_cases_calculation_output_schema,
     build_cases_calculation_output_skeleton,
     build_effort_calculation_output_schema,
     build_effort_calculation_output_skeleton,
+    build_process_compilation_output_schema,
+    build_step_analysis_output_schema,
+    build_step_analysis_output_skeleton,
 )
+from backend.core.prompts import PromptId, render_prompt
+from backend.routers.case_groups import _parse_case_groups
 from backend.routers.effort import _parse_cases_payload, _parse_effort_payload
+from backend.routers.process_steps import _parse_process_steps
+from backend.routers.processes import _parse_processes
 
 _FORBIDDEN_KEYWORDS = {
     "minItems",
@@ -213,3 +223,126 @@ def test_schema_conformant_effort_citizens_example_parses():
     assert parsed[0]["time_required_current"]["a"] == 30.0
     assert parsed[0]["time_required_proposed"]["a"] == 45.0
     assert parsed[0]["expenses_proposed"] == 5.0
+
+
+# --- Drift-Schutz: Prompt-Beispielblock <-> generiertes Schema ---
+#
+# Die Prompt-Texte sind handgetippt, die Schemata werden generiert. Damit die
+# beiden Seiten nicht auseinanderlaufen, wird der JSON-Beispielblock aus dem
+# gerenderten Prompt extrahiert und gegen das Schema geprueft: gleiche
+# Feldnamen auf jeder Ebene, gleiche Verschachtelung.
+
+_RENDER_KWARGS = {
+    PromptId.PROCESS_COMPILATION: {"vorgaben_json": "[]"},
+    PromptId.CASE_GROUP_DEVELOPMENT: {"prozesse_json": "[]"},
+    PromptId.PROCESS_STEP_ANALYSIS: {"case_groups_json": "[]"},
+    PromptId.CASES_CALCULATION: {"case_groups_json": "[]"},
+    PromptId.EFFORT_CALCULATION: {"step_analysis_json": "[]"},
+}
+
+_FORM_ANCHORS = {
+    PromptId.PROCESS_COMPILATION: "Geben Sie nur und ausschliesslich JSON im folgenden Format zurueck:",
+    PromptId.CASE_GROUP_DEVELOPMENT: "Geben Sie nur und ausschliesslich JSON im folgenden Format zurueck:",
+    PromptId.PROCESS_STEP_ANALYSIS: "Jedes Element von `taetigkeiten` hat folgende Form:",
+    PromptId.CASES_CALCULATION: "Jede Fallgruppe hat folgende Kennzahlenform:",
+    PromptId.EFFORT_CALCULATION: "Jede Taetigkeit hat folgende Aufwandsform:",
+}
+
+# Wo im Schema die extrahierte Beispielform haengt.
+_SCHEMA_SUBTREE = {
+    PromptId.PROCESS_COMPILATION: (),
+    PromptId.CASE_GROUP_DEVELOPMENT: (),
+    PromptId.PROCESS_STEP_ANALYSIS: ("fallgruppen", "taetigkeiten"),
+    PromptId.CASES_CALCULATION: ("fallgruppen",),
+    PromptId.EFFORT_CALCULATION: ("fallgruppen", "taetigkeiten"),
+}
+
+_SCHEMA_BUILDERS = {
+    PromptId.PROCESS_COMPILATION: build_process_compilation_output_schema,
+    PromptId.CASE_GROUP_DEVELOPMENT: build_case_group_development_output_schema,
+    PromptId.PROCESS_STEP_ANALYSIS: build_step_analysis_output_schema,
+    PromptId.CASES_CALCULATION: build_cases_calculation_output_schema,
+    PromptId.EFFORT_CALCULATION: build_effort_calculation_output_schema,
+}
+
+_STRUCTURED_PROMPT_IDS = list(_SCHEMA_BUILDERS)
+
+
+def _json_block_after(text: str, anchor: str) -> dict:
+    start = text.index(anchor) + len(anchor)
+    start = text.index("{", start)
+    depth = 0
+    for index in range(start, len(text)):
+        if text[index] == "{":
+            depth += 1
+        elif text[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return json.loads(text[start : index + 1])
+    raise AssertionError(f"no balanced JSON block after anchor: {anchor}")
+
+
+def _example_form(prompt_id: str, norm_addressee: str) -> dict:
+    prompt = render_prompt(
+        prompt_id,
+        norm_addressee=norm_addressee,
+        law_summary="x",
+        **_RENDER_KWARGS[prompt_id],
+    )
+    return _json_block_after(prompt, _FORM_ANCHORS[prompt_id])
+
+
+def _schema_form(prompt_id: str, norm_addressee: str) -> dict:
+    node = _SCHEMA_BUILDERS[prompt_id](norm_addressee)
+    for key in _SCHEMA_SUBTREE[prompt_id]:
+        node = node["properties"][key]["items"]
+    return node
+
+
+def _example_paths(value, prefix: str = "") -> set[str]:
+    paths: set[str] = set()
+    if isinstance(value, dict):
+        for key, child in value.items():
+            path = f"{prefix}.{key}" if prefix else key
+            paths.add(path)
+            paths |= _example_paths(child, path)
+    elif isinstance(value, list):
+        for child in value:
+            paths |= _example_paths(child, f"{prefix}[]")
+    return paths
+
+
+def _schema_paths(node: dict, prefix: str = "") -> set[str]:
+    paths: set[str] = set()
+    if _is_object(node):
+        for key, child in node.get("properties", {}).items():
+            path = f"{prefix}.{key}" if prefix else key
+            paths.add(path)
+            paths |= _schema_paths(child, path)
+    elif _is_array(node):
+        paths |= _schema_paths(node["items"], f"{prefix}[]")
+    return paths
+
+
+@pytest.mark.parametrize("prompt_id", _STRUCTURED_PROMPT_IDS)
+@pytest.mark.parametrize("norm_addressee", [ADMINISTRATION, BUSINESS, CITIZENS])
+def test_prompt_example_and_schema_have_identical_field_tree(prompt_id, norm_addressee):
+    example = _example_paths(_example_form(prompt_id, norm_addressee))
+    schema = _schema_paths(_schema_form(prompt_id, norm_addressee))
+
+    assert example == schema, (
+        f"{prompt_id}/{norm_addressee}: "
+        f"nur im Prompt={sorted(example - schema)}, nur im Schema={sorted(schema - example)}"
+    )
+
+
+@pytest.mark.parametrize("prompt_id", _STRUCTURED_PROMPT_IDS)
+def test_all_structured_schemas_are_strict_subset_compliant(prompt_id):
+    for addressee in (ADMINISTRATION, BUSINESS, CITIZENS):
+        _assert_strict_subset(_SCHEMA_BUILDERS[prompt_id](addressee))
+
+
+@pytest.mark.parametrize("prompt_id", _STRUCTURED_PROMPT_IDS)
+def test_all_structured_schemas_pin_normadressat(prompt_id):
+    schema = _SCHEMA_BUILDERS[prompt_id](BUSINESS)
+    assert schema["properties"]["normadressat"]["enum"] == [BUSINESS]

--- a/tests/test_workflow_parser_edges.py
+++ b/tests/test_workflow_parser_edges.py
@@ -107,15 +107,11 @@ def _seed_effort_context(
 def _cases_payload(case_group_id: int) -> str:
     return f"""
     {{
-      "prozesse": [
+      "fallgruppen": [
         {{
-          "fallgruppen": [
-            {{
-              "fallgruppen_id": "{case_group_id}",
-              "anzahl_betroffene_vorschlag": "10",
-              "haeufigkeit_pro_jahr_vorschlag": "2"
-            }}
-          ]
+          "fallgruppen_id": "{case_group_id}",
+          "anzahl_betroffene_vorschlag": "10",
+          "haeufigkeit_pro_jahr_vorschlag": "2"
         }}
       ]
     }}
@@ -130,19 +126,15 @@ def _org_effort_payload(
 ) -> str:
     return f"""
     {{
-      "prozesse": [
+      "fallgruppen": [
         {{
-          "fallgruppen": [
+          "fallgruppen_id": "{case_group_id}",
+          "anzahl_betroffene_vorschlag": "10",
+          "haeufigkeit_pro_jahr_vorschlag": "2",
+          "taetigkeiten": [
             {{
-              "fallgruppen_id": "{case_group_id}",
-              "anzahl_betroffene_vorschlag": "10",
-              "haeufigkeit_pro_jahr_vorschlag": "2",
-              "taetigkeiten": [
-                {{
-                  "taetigkeiten_id": "{step_id}",
-                  {entry_fields}
-                }}
-              ]
+              "taetigkeiten_id": "{step_id}",
+              {entry_fields}
             }}
           ]
         }}
@@ -410,17 +402,13 @@ def test_effort_parser_logs_alias_fallbacks(monkeypatch):
     )
     cases_text = f"""
     {{
-      "prozesse": [
+      "fallgruppen": [
         {{
-          "fallgruppen": [
-            {{
-              "fallgruppen_id": "{case_group_id}",
-              "anzahl_betroffene_current": "10",
-              "haeufigkeit_pro_jahr_current": "3",
-              "anzahl_betroffene_proposed": "12",
-              "haeufigkeit_pro_jahr_proposed": "4"
-            }}
-          ]
+          "fallgruppen_id": "{case_group_id}",
+          "anzahl_betroffene_current": "10",
+          "haeufigkeit_pro_jahr_current": "3",
+          "anzahl_betroffene_proposed": "12",
+          "haeufigkeit_pro_jahr_proposed": "4"
         }}
       ]
     }}
@@ -459,6 +447,95 @@ def test_effort_parser_logs_alias_fallbacks(monkeypatch):
 
     assert "cases_legacy_english_alias" in fallback_kinds
     assert "effort_legacy_english_alias" in fallback_kinds
+
+
+def test_cases_parser_rejects_nested_without_top_level_fallgruppen():
+    # #64 (Option 4, Schritt 6): cases ist strikt flach. Eine verschachtelte Form
+    # (oberstes `prozesse`, kein top-level `fallgruppen`) wird jetzt als 422
+    # abgelehnt.
+    session_id, case_group_id, step_id, context = _seed_effort_context(
+        "PARSER-CASES-NESTED"
+    )
+    cases_text = f"""
+    {{
+      "prozesse": [
+        {{
+          "fallgruppen": [
+            {{
+              "fallgruppen_id": "{case_group_id}",
+              "anzahl_betroffene_vorschlag": "10",
+              "haeufigkeit_pro_jahr_vorschlag": "2"
+            }}
+          ]
+        }}
+      ]
+    }}
+    """
+    effort_text = _org_effort_payload(
+        case_group_id,
+        step_id,
+        entry_fields="""
+        "personalaufwand_vorschlag": [
+          {"qualifikation": "einfacher_und_mittlerer_dienst", "lohnquelle": "bund", "zeitaufwand_in_min": "10"}
+        ]
+        """,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        _parse_effort(
+            session_id=session_id,
+            context=context,
+            cases_text=cases_text,
+            effort_text=effort_text,
+        )
+
+    assert exc_info.value.status_code == 422
+    assert exc_info.value.detail == (
+        "Invalid cases_calculation payload: expected top-level key "
+        "'fallgruppen' in LLM response"
+    )
+
+
+def test_effort_parser_rejects_nested_without_top_level_fallgruppen():
+    # #64 (Option 4, Schritt 6): effort ist strikt flach - nested-only 422.
+    session_id, case_group_id, step_id, context = _seed_effort_context(
+        "PARSER-EFFORT-NESTED"
+    )
+    effort_text = f"""
+    {{
+      "prozesse": [
+        {{
+          "fallgruppen": [
+            {{
+              "fallgruppen_id": "{case_group_id}",
+              "taetigkeiten": [
+                {{
+                  "taetigkeiten_id": "{step_id}",
+                  "personalaufwand_vorschlag": [
+                    {{"qualifikation": "einfacher_und_mittlerer_dienst", "lohnquelle": "bund", "zeitaufwand_in_min": "10"}}
+                  ]
+                }}
+              ]
+            }}
+          ]
+        }}
+      ]
+    }}
+    """
+
+    with pytest.raises(HTTPException) as exc_info:
+        _parse_effort(
+            session_id=session_id,
+            context=context,
+            cases_text=_cases_payload(case_group_id),
+            effort_text=effort_text,
+        )
+
+    assert exc_info.value.status_code == 422
+    assert exc_info.value.detail == (
+        "Invalid effort_calculation payload for administration: expected "
+        "top-level key 'fallgruppen' in LLM response"
+    )
 
 
 def test_effort_parser_rejects_invalid_cases_json_payload():
@@ -559,26 +636,22 @@ def test_effort_parser_rejects_missing_step_id_after_empty_effort_entry():
     )
     effort_text = f"""
     {{
-      "prozesse": [
+      "fallgruppen": [
         {{
-          "fallgruppen": [
+          "fallgruppen_id": "{case_group_id}",
+          "taetigkeiten": [
             {{
-              "fallgruppen_id": "{case_group_id}",
-              "taetigkeiten": [
-                {{
-                  "taetigkeiten_id": "{step_id}",
-                  "personalaufwand_vorschlag": [
-                    {{"qualifikation": "einfacher_und_mittlerer_dienst", "lohnquelle": "bund", "zeitaufwand_in_min": "10"}}
-                  ]
-                }},
-                {{
-                  "taetigkeiten_id": "{missing_step_id}",
-                  "personalaufwand_gueltig": [],
-                  "personalaufwand_vorschlag": [],
-                  "sachaufwand_gueltig": "",
-                  "sachaufwand_vorschlag": ""
-                }}
+              "taetigkeiten_id": "{step_id}",
+              "personalaufwand_vorschlag": [
+                {{"qualifikation": "einfacher_und_mittlerer_dienst", "lohnquelle": "bund", "zeitaufwand_in_min": "10"}}
               ]
+            }},
+            {{
+              "taetigkeiten_id": "{missing_step_id}",
+              "personalaufwand_gueltig": [],
+              "personalaufwand_vorschlag": [],
+              "sachaufwand_gueltig": "",
+              "sachaufwand_vorschlag": ""
             }}
           ]
         }}
@@ -976,20 +1049,16 @@ def test_effort_parser_rejects_duplicate_case_group_id():
     )
     cases_text = f"""
     {{
-      "prozesse": [
+      "fallgruppen": [
         {{
-          "fallgruppen": [
-            {{
-              "fallgruppen_id": "{case_group_id}",
-              "anzahl_betroffene_vorschlag": "10",
-              "haeufigkeit_pro_jahr_vorschlag": "2"
-            }},
-            {{
-              "fallgruppen_id": "{case_group_id}",
-              "anzahl_betroffene_vorschlag": "12",
-              "haeufigkeit_pro_jahr_vorschlag": "2"
-            }}
-          ]
+          "fallgruppen_id": "{case_group_id}",
+          "anzahl_betroffene_vorschlag": "10",
+          "haeufigkeit_pro_jahr_vorschlag": "2"
+        }},
+        {{
+          "fallgruppen_id": "{case_group_id}",
+          "anzahl_betroffene_vorschlag": "12",
+          "haeufigkeit_pro_jahr_vorschlag": "2"
         }}
       ]
     }}
@@ -1071,26 +1140,22 @@ def test_effort_parser_rejects_duplicate_step_id():
     )
     effort_text = f"""
     {{
-      "prozesse": [
+      "fallgruppen": [
         {{
-          "fallgruppen": [
+          "fallgruppen_id": "{case_group_id}",
+          "anzahl_betroffene_vorschlag": "10",
+          "haeufigkeit_pro_jahr_vorschlag": "2",
+          "taetigkeiten": [
             {{
-              "fallgruppen_id": "{case_group_id}",
-              "anzahl_betroffene_vorschlag": "10",
-              "haeufigkeit_pro_jahr_vorschlag": "2",
-              "taetigkeiten": [
-                {{
-                  "taetigkeiten_id": "{step_id}",
-                  "personalaufwand_vorschlag": [
-                    {{"qualifikation": "einfacher_und_mittlerer_dienst", "lohnquelle": "bund", "zeitaufwand_in_min": "10"}}
-                  ]
-                }},
-                {{
-                  "taetigkeiten_id": "{step_id}",
-                  "personalaufwand_vorschlag": [
-                    {{"qualifikation": "gehobener_dienst", "lohnquelle": "laender", "zeitaufwand_in_min": "12"}}
-                  ]
-                }}
+              "taetigkeiten_id": "{step_id}",
+              "personalaufwand_vorschlag": [
+                {{"qualifikation": "einfacher_und_mittlerer_dienst", "lohnquelle": "bund", "zeitaufwand_in_min": "10"}}
+              ]
+            }},
+            {{
+              "taetigkeiten_id": "{step_id}",
+              "personalaufwand_vorschlag": [
+                {{"qualifikation": "gehobener_dienst", "lohnquelle": "laender", "zeitaufwand_in_min": "12"}}
               ]
             }}
           ]

--- a/tests/test_workflow_parser_edges.py
+++ b/tests/test_workflow_parser_edges.py
@@ -312,15 +312,11 @@ def test_process_step_parser_rejects_unknown_case_group_id():
     )
     payload = """
     {
-      "prozesse": [
+      "fallgruppen": [
         {
-          "fallgruppen": [
-            {
-              "fallgruppen_id": "999",
-              "taetigkeiten": [
-                {"taetigkeit": "Schritt X", "beschreibung": "Beschreibung"}
-              ]
-            }
+          "fallgruppen_id": "999",
+          "taetigkeiten": [
+            {"taetigkeit": "Schritt X", "beschreibung": "Beschreibung"}
           ]
         }
       ]
@@ -344,18 +340,14 @@ def test_process_step_parser_rejects_unknown_regulation_links():
     )
     payload = f"""
     {{
-      "prozesse": [
+      "fallgruppen": [
         {{
-          "fallgruppen": [
+          "fallgruppen_id": "{case_group_id}",
+          "taetigkeiten": [
             {{
-              "fallgruppen_id": "{case_group_id}",
-              "taetigkeiten": [
-                {{
-                  "taetigkeit": "Schritt X",
-                  "beschreibung": "Beschreibung",
-                  "vorgaben_ids": [999]
-                }}
-              ]
+              "taetigkeit": "Schritt X",
+              "beschreibung": "Beschreibung",
+              "vorgaben_ids": [999]
             }}
           ]
         }}
@@ -374,20 +366,24 @@ def test_process_step_parser_rejects_unknown_regulation_links():
     assert "Unknown vorgaben_ids in process steps" in exc_info.value.detail
 
 
-def test_process_step_parser_rejects_flattened_fallgruppen_without_prozesse():
-    # #13/#25: Abgeflachte Form (oberstes `fallgruppen`, kein `prozesse`) wird
-    # mit der Envelope-Pflicht bewusst als 422 abgelehnt - einheitlich mit den
-    # uebrigen Parsern, die durchgaengig top-level `prozesse` verlangen.
+def test_process_step_parser_rejects_nested_without_top_level_fallgruppen():
+    # #64 (Option 4): Step 5 ist strikt flach. Eine verschachtelte Form (oberstes
+    # `prozesse`, kein top-level `fallgruppen`) wird jetzt bewusst als 422
+    # abgelehnt - die Envelope-Pflicht verlangt durchgaengig top-level `fallgruppen`.
     _session_id, _process_id, _regulation_id, case_group_id, context = (
-        _seed_process_step_context("PARSER-STEPS-FALLBACK")
+        _seed_process_step_context("PARSER-STEPS-NESTED")
     )
     payload = f"""
     {{
-      "fallgruppen": [
+      "prozesse": [
         {{
-          "fallgruppen_id": "{case_group_id}",
-          "taetigkeiten": [
-            {{"taetigkeit": "Schritt X", "beschreibung": "Aus fallback parser"}}
+          "fallgruppen": [
+            {{
+              "fallgruppen_id": "{case_group_id}",
+              "taetigkeiten": [
+                {{"taetigkeit": "Schritt X", "beschreibung": "Nested nicht mehr erlaubt"}}
+              ]
+            }}
           ]
         }}
       ]
@@ -404,7 +400,7 @@ def test_process_step_parser_rejects_flattened_fallgruppen_without_prozesse():
     assert exc_info.value.status_code == 422
     assert exc_info.value.detail == (
         "Invalid process_step_analysis payload: expected top-level key "
-        "'prozesse' in LLM response"
+        "'fallgruppen' in LLM response"
     )
 
 
@@ -795,25 +791,17 @@ def test_process_step_parser_rejects_duplicate_case_group_id():
     )
     payload = f"""
     {{
-      "prozesse": [
+      "fallgruppen": [
         {{
-          "fallgruppen": [
-            {{
-              "fallgruppen_id": "{case_group_id}",
-              "taetigkeiten": [
-                {{"taetigkeit": "Schritt A", "beschreibung": "Erste Kette"}}
-              ]
-            }}
+          "fallgruppen_id": "{case_group_id}",
+          "taetigkeiten": [
+            {{"taetigkeit": "Schritt A", "beschreibung": "Erste Kette"}}
           ]
         }},
         {{
-          "fallgruppen": [
-            {{
-              "fallgruppen_id": "{case_group_id}",
-              "taetigkeiten": [
-                {{"taetigkeit": "Schritt B", "beschreibung": "Zweite Kette"}}
-              ]
-            }}
+          "fallgruppen_id": "{case_group_id}",
+          "taetigkeiten": [
+            {{"taetigkeit": "Schritt B", "beschreibung": "Zweite Kette"}}
           ]
         }}
       ]
@@ -934,39 +922,34 @@ def test_process_step_persist_guard_allows_single_chain_per_case_group():
     )
 
 
-def test_process_step_parser_rejects_duplicate_case_group_id_same_process():
-    # #64: Reproduziert die gemeldete O9EBJR-Form: dieselbe fallgruppen_id
-    # taucht ZWEIMAL im SELBEN Prozessblock auf, mit identischen Wrapper-Metadaten
-    # (Bezeichnung/Beschreibung/aenderungsstatus), aber unterschiedlichen
-    # Taetigkeiten. Der Parser appended je Fallgruppe -> der Duplikat-Guard muss
-    # auch diese Same-Process-Form vor der Persistenz mit 422 abweisen.
-    _session_id, process_id, _regulation_id, case_group_id, context = (
-        _seed_process_step_context("PARSER-STEPS-DUP-SAME-PROCESS")
+def test_process_step_parser_rejects_duplicate_case_group_id_identical_metadata():
+    # #64 (AC6): Reproduziert die gemeldete O9EBJR-Form flach - dieselbe
+    # fallgruppen_id taucht ZWEIMAL im top-level `fallgruppen`-Array auf, mit
+    # identischen Wrapper-Metadaten (Bezeichnung/Beschreibung/aenderungsstatus),
+    # aber unterschiedlichen Taetigkeiten. Der Parser appended je Fallgruppe ->
+    # der Duplikat-Guard muss diese Form vor der Persistenz mit 422 abweisen.
+    _session_id, _process_id, _regulation_id, case_group_id, context = (
+        _seed_process_step_context("PARSER-STEPS-DUP-METADATA")
     )
     payload = f"""
     {{
-      "prozesse": [
+      "fallgruppen": [
         {{
-          "prozess_id": {process_id},
-          "fallgruppen": [
-            {{
-              "fallgruppen_id": "{case_group_id}",
-              "fallgruppe_bezeichnung": "Identische Fallgruppe",
-              "fallgruppe_beschreibung": "Gleiche Metadaten",
-              "aenderungsstatus": "eingefuehrt",
-              "taetigkeiten": [
-                {{"taetigkeit": "Block 1 - Schritt A", "beschreibung": "Erste Kette"}}
-              ]
-            }},
-            {{
-              "fallgruppen_id": "{case_group_id}",
-              "fallgruppe_bezeichnung": "Identische Fallgruppe",
-              "fallgruppe_beschreibung": "Gleiche Metadaten",
-              "aenderungsstatus": "eingefuehrt",
-              "taetigkeiten": [
-                {{"taetigkeit": "Block 2 - Schritt X", "beschreibung": "Zweite Kette"}}
-              ]
-            }}
+          "fallgruppen_id": "{case_group_id}",
+          "fallgruppe_bezeichnung": "Identische Fallgruppe",
+          "fallgruppe_beschreibung": "Gleiche Metadaten",
+          "aenderungsstatus": "eingefuehrt",
+          "taetigkeiten": [
+            {{"taetigkeit": "Block 1 - Schritt A", "beschreibung": "Erste Kette"}}
+          ]
+        }},
+        {{
+          "fallgruppen_id": "{case_group_id}",
+          "fallgruppe_bezeichnung": "Identische Fallgruppe",
+          "fallgruppe_beschreibung": "Gleiche Metadaten",
+          "aenderungsstatus": "eingefuehrt",
+          "taetigkeiten": [
+            {{"taetigkeit": "Block 2 - Schritt X", "beschreibung": "Zweite Kette"}}
           ]
         }}
       ]
@@ -1197,15 +1180,11 @@ def test_process_step_parser_rejects_missing_case_group():
     )
     payload = f"""
     {{
-      "prozesse": [
+      "fallgruppen": [
         {{
-          "fallgruppen": [
-            {{
-              "fallgruppen_id": "{case_group_id}",
-              "taetigkeiten": [
-                {{"taetigkeit": "Schritt A", "beschreibung": "Nur erste Fallgruppe"}}
-              ]
-            }}
+          "fallgruppen_id": "{case_group_id}",
+          "taetigkeiten": [
+            {{"taetigkeit": "Schritt A", "beschreibung": "Nur erste Fallgruppe"}}
           ]
         }}
       ]

--- a/tests_review/contracts/test_prompt_template_anchors.py
+++ b/tests_review/contracts/test_prompt_template_anchors.py
@@ -14,8 +14,8 @@ Kernaussage anschlaegt.
 import pytest
 
 from backend.core.prompts import (
-    EFFORT_JSON_SCHEMA_BY_ADDRESSEE,
-    EFFORT_JSON_SCHEMA_DEFAULT,
+    EFFORT_TAETIGKEIT_FORM_BY_ADDRESSEE,
+    EFFORT_TAETIGKEIT_FORM_DEFAULT,
     NORM_ADDRESSEE_PROMPT_OPENINGS,
     NORM_ADDRESSEE_RULES_ADMINISTRATION,
     NORM_ADDRESSEE_RULES_BUSINESS,
@@ -181,8 +181,8 @@ class TestRecurringOnlyContract:
                 assert "einmalig" not in text.lower()
 
     def test_effort_schema_has_no_per_case_execution_field(self):
-        assert "ausfuehrung_pro_einzelfall" not in EFFORT_JSON_SCHEMA_DEFAULT
-        for schema in EFFORT_JSON_SCHEMA_BY_ADDRESSEE.values():
+        assert "ausfuehrung_pro_einzelfall" not in EFFORT_TAETIGKEIT_FORM_DEFAULT
+        for schema in EFFORT_TAETIGKEIT_FORM_BY_ADDRESSEE.values():
             assert "ausfuehrung_pro_einzelfall" not in schema
 
     def test_one_off_lists_avoid_status_ambiguous_einfuehrung(self):


### PR DESCRIPTION
Follow-up to #72, split out per review verdict.

Branch note: this branch is the full pre-split snapshot, so it still contains
its own copies of the schema/skeleton commits that now live on #72 (content
identical, verified by diff). Needs a rebase onto develop after #72 merges
to drop the redundant commits before this PR merges.

Julia asked in the #72 review thread whether commit 66afeeb (truncated-stream
detection) is still needed, since truncated streams did not occur in her
sample with strict json_schema active (0/58 vs 18/254 without schema).
Resolved: keeping it. Truncation is a transport-layer issue, not a schema
issue, and the case that matters is the response_format downgrade fallback
path (json_schema -> json_object -> None), where the schema constraint is
gone and the original truncation risk returns. The fix does not change retry
behavior (still 422, retry proceeds), it only reports the error correctly
instead of the misleading "missing key".

Contains, unchanged from the pre-split state of #72:
- Model-dependent atomic-step retry on retryable (422) model-output errors
- response_format observability: LlmResult carries requested/used/downgraded,
  llm_service logs every downgrade, persisted to answer metadata, live
  monitor state whitelists the same keys
- Truncated-stream detection, relevant for the downgrade fallback path (see
  note above)

Added on this branch, closes the item Julia flagged as still open in the
#72 review:
- response_format surfaced in the LLM monitor UI: recent-call API, frontend
  types, LlmMonitorConsole badge (Schema / JSON / No format, warning on
  downgrade)
- query_llm docstring wording fix, ported from #72
