### PR TITLE
Follow-up fixes after merging the containerisation/auth branch into `develop`.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -35,6 +35,7 @@ prompt_audits
 
 # Docs (not needed in the runtime image)
 *.md
+!resources/**/*.md
 
 # Env files and tooling
 .env

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ pnpm-debug.log*
 
 # Notes
 open_issues.md
+code_analysis/
 
 # Local legacy code (kept on disk, not tracked)
 backend/legacy/

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -27,8 +27,9 @@ RUN apt-get update \
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Copy the backend package.
+# Copy runtime source and bundled example resources.
 COPY backend/ ./backend/
+COPY resources/ ./resources/
 
 # Create a non-root user and a persistent data directory it owns.
 RUN useradd --create-home --uid 10001 appuser \

--- a/backend/core/db.py
+++ b/backend/core/db.py
@@ -962,6 +962,46 @@ def _seed_compliance_text_examples(cur: sqlite3.Cursor) -> None:
         )
 
 
+def _seed_builtin_laws(cur: sqlite3.Cursor) -> None:
+    builtins_dir = Path(__file__).resolve().parents[2] / "resources" / "built_in_laws"
+    if not builtins_dir.exists():
+        return
+    law_files = sorted(path for path in builtins_dir.iterdir() if path.suffix.lower() == ".txt")
+    for path in law_files:
+        law_text = path.read_text(encoding="utf-8").strip()
+        if not law_text:
+            continue
+        file_name = path.name
+        cur.execute(
+            """
+            SELECT document_id
+            FROM laws
+            WHERE file_name = ? AND owner_user_id IS NULL
+            ORDER BY is_builtin DESC, document_id ASC
+            LIMIT 1
+            """,
+            (file_name,),
+        )
+        row = cur.fetchone()
+        if row:
+            cur.execute(
+                """
+                UPDATE laws
+                SET law_text = ?, text_length = ?, is_builtin = 1
+                WHERE document_id = ?
+                """,
+                (law_text, len(law_text), int(row["document_id"])),
+            )
+        else:
+            cur.execute(
+                """
+                INSERT INTO laws (file_name, law_text, text_length, owner_user_id, is_builtin)
+                VALUES (?, ?, ?, NULL, 1)
+                """,
+                (file_name, law_text, len(law_text)),
+            )
+
+
 def _create_session_pay_rate_overrides_by_addressee_table(
     cur: sqlite3.Cursor,
     table_name: str = "session_pay_rate_overrides_by_addressee",
@@ -1663,7 +1703,7 @@ def init_db() -> None:
             text_length     INTEGER NOT NULL,
             uploaded_at     TEXT NOT NULL DEFAULT current_timestamp,
             owner_user_id   INTEGER REFERENCES users(user_id),
-            is_builtin      INTEGER NOT NULL DEFAULT 1
+            is_builtin      INTEGER NOT NULL DEFAULT 0
         )
         """
     )
@@ -1711,8 +1751,8 @@ def init_db() -> None:
     )
     _create_users_table(cur)
     _ensure_column(cur, "laws", "owner_user_id", "INTEGER REFERENCES users(user_id)")
-    _ensure_column(cur, "laws", "is_builtin", "INTEGER NOT NULL DEFAULT 1")
-    cur.execute("UPDATE laws SET is_builtin = 1 WHERE is_builtin IS NULL")
+    _ensure_column(cur, "laws", "is_builtin", "INTEGER NOT NULL DEFAULT 0")
+    cur.execute("UPDATE laws SET is_builtin = 0 WHERE owner_user_id IS NULL")
     cur.execute(
         "CREATE INDEX IF NOT EXISTS idx_laws_owner_file ON laws(owner_user_id, file_name)"
     )
@@ -1730,6 +1770,7 @@ def init_db() -> None:
     _create_compliance_text_examples_table(cur)
     _create_compliance_text_exports_table(cur)
     _seed_compliance_text_examples(cur)
+    _seed_builtin_laws(cur)
     _create_deep_research_runs_table(cur)
     _create_session_scoped_tile_tables(cur)
     cur.execute(
@@ -2080,15 +2121,25 @@ def list_law_file_names(owner_user_id: int | None = None) -> List[str]:
     cur = conn.cursor()
     if owner_user_id is None:
         cur.execute(
-            "SELECT file_name FROM laws ORDER BY uploaded_at DESC, document_id DESC"
+            """
+            SELECT file_name, MAX(uploaded_at) AS uploaded_at, MAX(document_id) AS document_id
+            FROM laws
+            GROUP BY file_name
+            ORDER BY uploaded_at DESC, document_id DESC
+            """
         )
     else:
         cur.execute(
             """
-            SELECT file_name
+            SELECT
+                file_name,
+                MAX(is_builtin) AS builtin_rank,
+                MAX(uploaded_at) AS uploaded_at,
+                MAX(document_id) AS document_id
             FROM laws
             WHERE is_builtin = 1 OR owner_user_id = ?
-            ORDER BY is_builtin DESC, uploaded_at DESC, document_id DESC
+            GROUP BY file_name
+            ORDER BY builtin_rank DESC, uploaded_at DESC, document_id DESC
             """,
             (int(owner_user_id),),
         )
@@ -2159,7 +2210,7 @@ def insert_law(
     file_name: str,
     law_text: str,
     owner_user_id: int | None = None,
-    is_builtin: bool = True,
+    is_builtin: bool = False,
 ) -> int:
     conn = get_conn()
     cur = conn.cursor()

--- a/backend/routers/sessions.py
+++ b/backend/routers/sessions.py
@@ -594,15 +594,17 @@ def _get_latest_failed_step_status(
     session_id = db.get_session_id_by_app_id(app_session_id)
     if session_id is None:
         return None
-    seen_prompts: set[str] = set()
+    seen_prompt_addressees: set[tuple[str, str]] = set()
     for row in db.list_recent_llm_answers_for_session(session_id, limit=50):
         prompt_id = str(row.get("prompt_id") or "")
         mapping = _FAILED_PROMPT_STEP.get(prompt_id)
         if mapping is None:
             continue
-        if prompt_id in seen_prompts:
+        norm_addressee = str(row.get("norm_addressee") or "").strip()
+        seen_key = (prompt_id, norm_addressee)
+        if seen_key in seen_prompt_addressees:
             continue
-        seen_prompts.add(prompt_id)
+        seen_prompt_addressees.add(seen_key)
         if row.get("answer_state") != "invalid":
             continue
         step_key, label, ready_flag = mapping

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,7 +11,7 @@
         "@fontsource/jetbrains-mono": "^5.2.8",
         "@fontsource/space-grotesk": "^5.2.10",
         "@xyflow/react": "^12.4.4",
-        "next": "15.5.12",
+        "next": "15.5.20",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       },
@@ -26,7 +26,7 @@
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "eslint": "^9",
-        "eslint-config-next": "15.5.12",
+        "eslint-config-next": "15.5.20",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "tailwindcss": "^4",
@@ -54,13 +54,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -69,9 +69,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -79,21 +79,22 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -133,14 +134,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.0.tgz",
-      "integrity": "sha512-vSH118/wwM/pLR38g/Sgk05sNtro6TlTJKuiMXDaZqPUfjTFcudpCOt00IhOfj+1BFAX+UFAlzCU+6WXr3GLFQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -150,14 +151,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -177,9 +178,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -187,29 +188,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -229,9 +230,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -239,9 +240,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -249,9 +250,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -259,27 +260,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -538,33 +539,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -572,14 +573,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1347,9 +1348,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1859,15 +1860,15 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.12.tgz",
-      "integrity": "sha512-pUvdJN1on574wQHjaBfNGDt9Mz5utDSZFsIIQkMzPgNS8ZvT4H2mwOrOIClwsQOb6EGx5M76/CZr6G8i6pSpLg==",
+      "version": "15.5.20",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.20.tgz",
+      "integrity": "sha512-dXh51Wvddf8daEyBXryZZEe1FdVxEWx9lgaTseLZUtC1XP/W8Wri+Z+VPOElHlByk23CyqHdc2oVByX7wsTWsw==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.5.12.tgz",
-      "integrity": "sha512-+ZRSDFTv4aC96aMb5E41rMjysx8ApkryevnvEYZvPZO52KvkqP5rNExLUXJFr9P4s0f3oqNQR6vopCZsPWKDcQ==",
+      "version": "15.5.20",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.5.20.tgz",
+      "integrity": "sha512-MZUgFpVd9rGSZpb8bNceUWvkAZe6aQw/6h2SSqHQuYzKfaiEUEVPIO6mXqaBmiBEBSN1f1sOc1uV8GCM90oegg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1875,9 +1876,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.12.tgz",
-      "integrity": "sha512-RnRjBtH8S8eXCpUNkQ+543DUc7ys8y15VxmFU9HRqlo9BG3CcBUiwNtF8SNoi2xvGCVJq1vl2yYq+3oISBS0Zg==",
+      "version": "15.5.20",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.20.tgz",
+      "integrity": "sha512-in0yXG7/pRBVjWeEl7f7ZZETpletSMFKXVS4GJgHENTPVrJFNJKPrYewa9rpZcvdjwFece5fZP0CK34G4PxowA==",
       "cpu": [
         "arm64"
       ],
@@ -1891,9 +1892,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.12.tgz",
-      "integrity": "sha512-nqa9/7iQlboF1EFtNhWxQA0rQstmYRSBGxSM6g3GxvxHxcoeqVXfGNr9stJOme674m2V7r4E3+jEhhGvSQhJRA==",
+      "version": "15.5.20",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.20.tgz",
+      "integrity": "sha512-0hsFshdPnTzGJdDTHeHJ+XPUShOpnyp9pUFDwDhqctsA0Cd8NcIVGRPtptYhgYY9DjkKgCDRkXxmgRc+CgT5Wg==",
       "cpu": [
         "x64"
       ],
@@ -1907,9 +1908,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.12.tgz",
-      "integrity": "sha512-dCzAjqhDHwmoB2M4eYfVKqXs99QdQxNQVpftvP1eGVppamXh/OkDAwV737Zr0KPXEqRUMN4uCjh6mjO+XtF3Mw==",
+      "version": "15.5.20",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.20.tgz",
+      "integrity": "sha512-DMvkoBtAABOzE6pMZRW/xNm7sKqql3wzzzZJ1R/d/rp4BCxv6LykouD3tHjGY8WdQqGpZs11t+R9AtjPxvvljw==",
       "cpu": [
         "arm64"
       ],
@@ -1923,9 +1924,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.12.tgz",
-      "integrity": "sha512-+fpGWvQiITgf7PUtbWY1H7qUSnBZsPPLyyq03QuAKpVoTy/QUx1JptEDTQMVvQhvizCEuNLEeghrQUyXQOekuw==",
+      "version": "15.5.20",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.20.tgz",
+      "integrity": "sha512-RQmDfeYBtXV2FSId7dfA1hE6M/T6+g7wdbYnFQ47tw/gUBwV+CccLVejNmCGa9yLDitk83foeg8hl/3DjfYQ5g==",
       "cpu": [
         "arm64"
       ],
@@ -1939,9 +1940,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.12.tgz",
-      "integrity": "sha512-jSLvgdRRL/hrFAPqEjJf1fFguC719kmcptjNVDJl26BnJIpjL3KH5h6mzR4mAweociLQaqvt4UyzfbFjgAdDcw==",
+      "version": "15.5.20",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.20.tgz",
+      "integrity": "sha512-DkWLEdKajJwdGt27M3i1VEO2kelTvZrK6Pcb7JvW2BY+nofWm7FBsBNDj7g7Pr1NuQ5PLJvqEqYa20GTsBDnKQ==",
       "cpu": [
         "x64"
       ],
@@ -1955,9 +1956,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.12.tgz",
-      "integrity": "sha512-/uaF0WfmYqQgLfPmN6BvULwxY0dufI2mlN2JbOKqqceZh1G4hjREyi7pg03zjfyS6eqNemHAZPSoP84x17vo6w==",
+      "version": "15.5.20",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.20.tgz",
+      "integrity": "sha512-rAO5b7pKHvX+ExdmJskusDXTNbiNZfptifIPZItbUx+AOXxxTydVBsPt7Oz84DRd5mY8e0DcE8kvLj3AIfjE6w==",
       "cpu": [
         "x64"
       ],
@@ -1971,9 +1972,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.12.tgz",
-      "integrity": "sha512-xhsL1OvQSfGmlL5RbOmU+FV120urrgFpYLq+6U8C6KIym32gZT6XF/SDE92jKzzlPWskkbjOKCpqk5m4i8PEfg==",
+      "version": "15.5.20",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.20.tgz",
+      "integrity": "sha512-Hp3zFsN8N8Kj9+vY6L4vnZ9EtA9eXyATu0q4EfGbZTiocgPUNSfz8NWhym6xvaOmHpJ8EuoypuU1WejCPsTFtg==",
       "cpu": [
         "arm64"
       ],
@@ -1987,9 +1988,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.12.tgz",
-      "integrity": "sha512-Z1Dh6lhFkxvBDH1FoW6OU/L6prYwPSlwjLiZkExIAh8fbP6iI/M7iGTQAJPYJ9YFlWobCZ1PHbchFhFYb2ADkw==",
+      "version": "15.5.20",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.20.tgz",
+      "integrity": "sha512-T/L7CXpR1M0wij/xbF3rT1+7KvSkfOLr7C+ToHHWZTG2eKmb52C5WvsyGCBNtkVvDEUESWkRUbbqSH4rSbOCYQ==",
       "cpu": [
         "x64"
       ],
@@ -2398,7 +2399,6 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -2473,9 +2473,9 @@
       }
     },
     "node_modules/@tootallnate/once": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+      "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2498,8 +2498,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2727,6 +2726,7 @@
       "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2737,6 +2737,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2817,6 +2818,7 @@
       "integrity": "sha512-npiaib8XzbjtzS2N4HlqPvlpxpmZ14FjSJrteZpPxGUaYPlvhzlzUZ4mZyABo0EFrOWnvyd0Xxroq//hKhtAWg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.0",
         "@typescript-eslint/types": "8.53.0",
@@ -2961,9 +2963,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2971,13 +2973,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -3343,6 +3345,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3398,9 +3401,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3841,19 +3844,22 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.9.19",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
-      "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
+      "version": "2.10.43",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
+      "integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3875,9 +3881,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.6.tgz",
+      "integrity": "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==",
       "dev": true,
       "funding": [
         {
@@ -3894,12 +3900,13 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.42",
+        "caniuse-lite": "^1.0.30001803",
+        "electron-to-chromium": "^1.5.389",
+        "node-releases": "^2.0.51",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -3996,9 +4003,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001764",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001764.tgz",
-      "integrity": "sha512-9JGuzl2M+vPL+pz70gtMF9sHdMFbY9FJaQBi186cHKH3pSzDvzoUJUPV6fqiKIMyXbud9ZLg4F3Yza1vJ1+93g==",
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
       "funding": [
         {
           "type": "opencollective",
@@ -4373,6 +4380,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4606,7 +4614,6 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4659,8 +4666,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/domexception": {
       "version": "4.0.0",
@@ -4692,9 +4698,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.286",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
-      "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
+      "version": "1.5.393",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.393.tgz",
+      "integrity": "sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg==",
       "dev": true,
       "license": "ISC"
     },
@@ -4983,6 +4989,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5038,13 +5045,13 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.5.12.tgz",
-      "integrity": "sha512-ktW3XLfd+ztEltY5scJNjxjHwtKWk6vU2iwzZqSN09UsbBmMeE/cVlJ1yESg6Yx5LW7p/Z8WzUAgYXGLEmGIpg==",
+      "version": "15.5.20",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.5.20.tgz",
+      "integrity": "sha512-Pl/I5544gmkcVVWcnaOMfhJSBK8lZ1NCJ+mGBkd2qvbGt2Gi7sEpgHF06OR13a2p6THODlncpvGsZzY2vUqwxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "15.5.12",
+        "@next/eslint-plugin-next": "15.5.20",
         "@rushstack/eslint-patch": "^1.10.3",
         "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
@@ -5156,6 +5163,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5595,9 +5603,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -5618,17 +5626,17 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -5987,9 +5995,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7678,10 +7686,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -8190,7 +8208,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -8316,9 +8333,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -8346,9 +8363,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -8387,12 +8404,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "15.5.12",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.5.12.tgz",
-      "integrity": "sha512-Fi/wQ4Etlrn60rz78bebG1i1SR20QxvV8tVp6iJspjLUSHcZoeUXCt+vmWoEcza85ElZzExK/jJ/F6SvtGktjA==",
+      "version": "15.5.20",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.20.tgz",
+      "integrity": "sha512-cvyS3/geydan1xLtE3FA8VCgdoQ/Gg/dlOldFkFCbB5VcVYJV7090hQLBnvTW2PwT76Z/dHdzDZCsVhZpoOlUA==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.5.12",
+        "@next/env": "15.5.20",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
@@ -8405,14 +8422,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.5.12",
-        "@next/swc-darwin-x64": "15.5.12",
-        "@next/swc-linux-arm64-gnu": "15.5.12",
-        "@next/swc-linux-arm64-musl": "15.5.12",
-        "@next/swc-linux-x64-gnu": "15.5.12",
-        "@next/swc-linux-x64-musl": "15.5.12",
-        "@next/swc-win32-arm64-msvc": "15.5.12",
-        "@next/swc-win32-x64-msvc": "15.5.12",
+        "@next/swc-darwin-arm64": "15.5.20",
+        "@next/swc-darwin-x64": "15.5.20",
+        "@next/swc-linux-arm64-gnu": "15.5.20",
+        "@next/swc-linux-arm64-musl": "15.5.20",
+        "@next/swc-linux-x64-gnu": "15.5.20",
+        "@next/swc-linux-x64-musl": "15.5.20",
+        "@next/swc-win32-arm64-msvc": "15.5.20",
+        "@next/swc-win32-x64-msvc": "15.5.20",
         "sharp": "^0.34.3"
       },
       "peerDependencies": {
@@ -8474,11 +8491,14 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -8826,9 +8846,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8928,9 +8948,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.20",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
+      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
       "dev": true,
       "funding": [
         {
@@ -8948,7 +8968,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -8972,7 +8992,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -8988,7 +9007,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -9001,8 +9019,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/prompts": {
       "version": "2.4.2",
@@ -9103,6 +9120,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9112,6 +9130,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10038,11 +10057,12 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10251,6 +10271,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10632,9 +10653,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
     "@fontsource/jetbrains-mono": "^5.2.8",
     "@fontsource/space-grotesk": "^5.2.10",
     "@xyflow/react": "^12.4.4",
-    "next": "15.5.12",
+    "next": "15.5.20",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
@@ -28,7 +28,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
-    "eslint-config-next": "15.5.12",
+    "eslint-config-next": "15.5.20",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "tailwindcss": "^4",

--- a/frontend/src/components/CaseGroupsPanel.tsx
+++ b/frontend/src/components/CaseGroupsPanel.tsx
@@ -22,7 +22,6 @@ export default function CaseGroupsPanel() {
   } = useApp();
   const [status, setStatus] = useState<string | null>(null);
   const runAllCancel = useRunAllStepCancel({
-    stepKey: "case_groups",
     appSessionId: state.appSessionId,
     setStatus,
     logScope: "CaseGroupsPanel.cancelRunAll",

--- a/frontend/src/components/EffortPanel.tsx
+++ b/frontend/src/components/EffortPanel.tsx
@@ -24,7 +24,6 @@ export default function EffortPanel() {
   } = useApp();
   const [status, setStatus] = useState<string | null>(null);
   const runAllCancel = useRunAllStepCancel({
-    stepKey: "effort",
     appSessionId: state.appSessionId,
     setStatus,
     logScope: "EffortPanel.cancelRunAll",

--- a/frontend/src/components/LlmMonitorConsole.tsx
+++ b/frontend/src/components/LlmMonitorConsole.tsx
@@ -5,8 +5,13 @@ import { createPortal } from "react-dom";
 
 import { useApp } from "@/contexts/AppContext";
 import { apiClient } from "@/lib/api";
+import { createAuthenticatedEventSource } from "@/lib/eventSource";
 import { logClientError } from "@/lib/errorFeedback";
-import { selectVisibleRecent } from "@/lib/llmMonitor";
+import {
+  formatMonitorClock,
+  selectVisibleRecent,
+  sortRecentCallsNewestFirst,
+} from "@/lib/llmMonitor";
 import {
   LlmMonitorEvent,
   LlmMonitorPendingCall,
@@ -37,21 +42,6 @@ function formatClockFromMs(value?: number | null): string {
     return "-";
   }
   return new Date(value).toLocaleTimeString("de-DE", {
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-  });
-}
-
-function formatClockFromIso(value?: string | null): string {
-  if (!value) {
-    return "-";
-  }
-  const parsed = new Date(value);
-  if (Number.isNaN(parsed.getTime())) {
-    return value;
-  }
-  return parsed.toLocaleTimeString("de-DE", {
     hour: "2-digit",
     minute: "2-digit",
     second: "2-digit",
@@ -178,7 +168,7 @@ function mergeRecentRows(
   previous: LlmMonitorRecentCall[],
   incoming: LlmMonitorRecentCall[]
 ): LlmMonitorRecentCall[] {
-  const merged = [...incoming, ...previous];
+  const merged = sortRecentCallsNewestFirst([...incoming, ...previous]);
   const seen = new Set<string>();
   const deduped: LlmMonitorRecentCall[] = [];
   for (const row of merged) {
@@ -301,7 +291,9 @@ export default function LlmMonitorConsole({ open, onClose }: LlmMonitorConsolePr
 
     const applySnapshot = (snapshot: LlmMonitorSnapshotResponse) => {
       setPending(snapshot.pending || []);
-      setRecent((snapshot.recent || []).slice(0, MAX_RECENT_ROWS));
+      setRecent(
+        sortRecentCallsNewestFirst(snapshot.recent || []).slice(0, MAX_RECENT_ROWS)
+      );
       setEvents((snapshot.events || []).slice(0, MAX_EVENT_ROWS));
       const streamRows = (snapshot.stream_attempts || []).slice(0, MAX_STREAM_ATTEMPTS);
       setStreamAttempts(streamRows);
@@ -336,7 +328,7 @@ export default function LlmMonitorConsole({ open, onClose }: LlmMonitorConsolePr
 
     loadSnapshot();
 
-    const source = new EventSource(
+    const source = createAuthenticatedEventSource(
       apiClient.getLlmMonitorEventsUrl({
         appSessionId: state.appSessionId,
         limit: MAX_RECENT_ROWS,
@@ -605,7 +597,7 @@ export default function LlmMonitorConsole({ open, onClose }: LlmMonitorConsolePr
                         </span>
                       </div>
                       <div className="mt-1 text-[11px] text-slate-600">
-                        {formatClockFromIso(row.created_at)} · {row.provider || "?"} ·{" "}
+                        {formatMonitorClock(row.created_at)} · {row.provider || "?"} ·{" "}
                         {row.model || "?"}
                       </div>
                       <div className="mt-1 font-mono text-[10px] text-slate-500">

--- a/frontend/src/components/ProcessStepsPanel.tsx
+++ b/frontend/src/components/ProcessStepsPanel.tsx
@@ -22,7 +22,6 @@ export default function ProcessStepsPanel() {
   } = useApp();
   const [status, setStatus] = useState<string | null>(null);
   const runAllCancel = useRunAllStepCancel({
-    stepKey: "process_steps",
     appSessionId: state.appSessionId,
     setStatus,
     logScope: "ProcessStepsPanel.cancelRunAll",

--- a/frontend/src/components/ProcessesPanel.tsx
+++ b/frontend/src/components/ProcessesPanel.tsx
@@ -22,7 +22,6 @@ export default function ProcessesPanel() {
   } = useApp();
   const [status, setStatus] = useState<string | null>(null);
   const runAllCancel = useRunAllStepCancel({
-    stepKey: "processes",
     appSessionId: state.appSessionId,
     setStatus,
     logScope: "ProcessesPanel.cancelRunAll",

--- a/frontend/src/components/RegulationsPanel.tsx
+++ b/frontend/src/components/RegulationsPanel.tsx
@@ -23,7 +23,6 @@ export default function RegulationsPanel() {
   } = useApp();
   const [status, setStatus] = useState<string | null>(null);
   const runAllCancel = useRunAllStepCancel({
-    stepKey: "regulations",
     appSessionId: state.appSessionId,
     setStatus,
     logScope: "RegulationsPanel.cancelRunAll",

--- a/frontend/src/components/SessionMenu.tsx
+++ b/frontend/src/components/SessionMenu.tsx
@@ -11,6 +11,7 @@ import {
   type ComplianceTextUserEditPolicy,
 } from "@/lib/api";
 import { logClientError } from "@/lib/errorFeedback";
+import { createAuthenticatedEventSource } from "@/lib/eventSource";
 import { useAnchoredPopoverPosition } from "@/lib/useAnchoredPopoverPosition";
 import {
   emitRunAllStepCleared,
@@ -31,7 +32,11 @@ type SessionMenuProps = {
 
 type SessionStepResult = { status: string; message?: string };
 type RunStepStartedEvent = { key?: string; label?: string };
-type RunStepStatusEvent = { session_status?: SessionStatus };
+type RunStepStatusEvent = {
+  session_status?: SessionStatus;
+  step?: SessionStepResult;
+  message?: string;
+};
 type RunCompletedEvent = { final_status?: SessionStatus; ok?: boolean };
 type RunFailedEvent = {
   final_status?: SessionStatus;
@@ -757,7 +762,7 @@ export default function SessionMenu({ variant = "default" }: SessionMenuProps) {
 
   const beginRunEventStream = (runId: string) => {
     stopRunMonitoring();
-    const source = new EventSource(apiClient.getRunAllEventsUrl(runId));
+    const source = createAuthenticatedEventSource(apiClient.getRunAllEventsUrl(runId));
     runEventSourceRef.current = source;
 
     source.addEventListener("snapshot", (event) => {
@@ -797,27 +802,50 @@ export default function SessionMenu({ variant = "default" }: SessionMenuProps) {
       }
     });
 
+    const applyStepSessionStatus = (payload: RunStepStatusEvent) => {
+      if (!payload.session_status) {
+        return;
+      }
+      applySessionMenuStatus(payload.session_status);
+      const inferredStep = deriveRunAllStepKeyFromStatus(payload.session_status);
+      if (inferredStep) {
+        const label = getRunAllStepLabel(inferredStep);
+        setCurrentRunLabel(label);
+        emitRunAllStepStarted(inferredStep, runId, "run_all", label);
+      }
+    };
+
     const applyEventStatus = (event: Event) => {
       try {
         const payload = JSON.parse((event as MessageEvent).data) as RunStepStatusEvent;
-        if (payload.session_status) {
-          applySessionMenuStatus(payload.session_status);
-          const inferredStep = deriveRunAllStepKeyFromStatus(payload.session_status);
-          if (inferredStep) {
-            const label = getRunAllStepLabel(inferredStep);
-            setCurrentRunLabel(label);
-            emitRunAllStepStarted(inferredStep, runId, "run_all", label);
-          }
-        }
+        applyStepSessionStatus(payload);
       } catch (error) {
         logClientError("SessionMenu.stepStatusEvent", error, { runId });
         // Ignore malformed status event.
       }
     };
 
+    const handleStepFailed = (event: Event) => {
+      try {
+        const payload = JSON.parse((event as MessageEvent).data) as RunStepStatusEvent;
+        applyStepSessionStatus(payload);
+        setStatus(
+          payload.step?.message ||
+            payload.message ||
+            "Schritte konnten nicht vollständig ausgeführt werden."
+        );
+      } catch (error) {
+        logClientError("SessionMenu.stepFailedEvent", error, { runId });
+        setStatus("Schritte konnten nicht vollständig ausgeführt werden.");
+      } finally {
+        resetRunUiState();
+        void refreshResearchSettings();
+      }
+    };
+
     source.addEventListener("step_completed", applyEventStatus);
     source.addEventListener("step_skipped", applyEventStatus);
-    source.addEventListener("step_failed", applyEventStatus);
+    source.addEventListener("step_failed", handleStepFailed);
     source.addEventListener("run_cancelling", () => {
       isCancellingRunRef.current = true;
       setIsCancellingRun(true);

--- a/frontend/src/components/TotalCostPanel.tsx
+++ b/frontend/src/components/TotalCostPanel.tsx
@@ -170,7 +170,6 @@ export default function TotalCostPanel() {
   const totalCostReadyRef = useRef(state.totalCostReady);
   const isComputingCostSummary = useRef(false);
   const runAllCancel = useRunAllStepCancel({
-    stepKey: "total_cost",
     appSessionId: state.appSessionId,
     setStatus,
     logScope: "TotalCostPanel.cancelRunAll",

--- a/frontend/src/components/UploadPanel.tsx
+++ b/frontend/src/components/UploadPanel.tsx
@@ -46,7 +46,6 @@ export default function UploadPanel() {
     proposed: false,
   });
   const runAllCancel = useRunAllStepCancel({
-    stepKey: "summary",
     appSessionId: state.appSessionId,
     setStatus,
     logScope: "UploadPanel.cancelRunAll",
@@ -153,11 +152,29 @@ export default function UploadPanel() {
     try {
       const response = await apiClient.fetchRegulations();
       setAvailableRegulations(response.files);
+      if (
+        state.selectedCurrentLaw &&
+        !response.files.includes(state.selectedCurrentLaw)
+      ) {
+        setSelectedCurrentLaw("");
+      }
+      if (
+        state.selectedRegulation &&
+        !response.files.includes(state.selectedRegulation)
+      ) {
+        setSelectedRegulation("");
+      }
     } catch (error) {
       logClientError("UploadPanel.loadRegulations", error);
       setStatus("Regelungen konnten nicht geladen werden.");
     }
-  }, [setAvailableRegulations]);
+  }, [
+    setAvailableRegulations,
+    setSelectedCurrentLaw,
+    setSelectedRegulation,
+    state.selectedCurrentLaw,
+    state.selectedRegulation,
+  ]);
 
   useEffect(() => {
     loadRegulations();
@@ -308,7 +325,12 @@ export default function UploadPanel() {
           </StepRunButton>
         </div>
 
-        <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <div
+          data-testid="law-selection-grid"
+          className={
+            isBusy ? "hidden" : "grid grid-cols-1 gap-4 lg:grid-cols-2"
+          }
+        >
           <div className="rounded-2xl border border-slate-200 bg-white px-4 py-4 shadow-sm">
             <h3 className="text-sm font-semibold text-slate-800">
               Gültiges Gesetz

--- a/frontend/src/components/__tests__/ProcessesPanel.test.tsx
+++ b/frontend/src/components/__tests__/ProcessesPanel.test.tsx
@@ -27,6 +27,7 @@ jest.mock("@/lib/api", () => ({
 const mockUseApp = useApp as jest.Mock;
 const mockStartStepRun = apiClient.startStepRun as jest.Mock;
 const mockGetStepRunStatus = apiClient.getStepRunStatus as jest.Mock;
+const mockCancelRunAll = apiClient.cancelRunAll as jest.Mock;
 
 describe("ProcessesPanel", () => {
   const baseContextActions = {
@@ -147,5 +148,47 @@ describe("ProcessesPanel", () => {
     expect(
       screen.getByRole("button", { name: /abbrechen/i })
     ).toBeInTheDocument();
+  });
+
+  it("shows run-all cancellation on the visible step even when run-all is executing another step", async () => {
+    mockUseApp.mockReturnValue({
+      state: {
+        appSessionId: "PRIDJF",
+        selectedNormAddressee: "administration",
+        selectedModel: "gemini-3.5-flash",
+        availableModels: [],
+        summaryReady: true,
+        regulationsReady: true,
+        processesReady: false,
+        caseGroupsReady: false,
+        processStepsReady: false,
+        effortReady: false,
+        totalCostReady: false,
+        lastFailedStep: null,
+        lastFailedLabel: null,
+        lastFailedMessage: null,
+      },
+      ...baseContextActions,
+    });
+    mockCancelRunAll.mockResolvedValue({ status: "cancelling" });
+    const user = userEvent.setup();
+    render(<ProcessesPanel />);
+
+    act(() => {
+      emitRunAllStepStarted(
+        "case_groups",
+        "run-all-1",
+        "run_all",
+        "Fallgruppen entwickeln"
+      );
+    });
+
+    const button = screen.getByRole("button", { name: /abbrechen/i });
+    expect(button).toBeInTheDocument();
+
+    await user.click(button);
+
+    expect(mockCancelRunAll).toHaveBeenCalledWith("run-all-1");
+    expect(screen.getByText(/abbruch angefordert/i)).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/__tests__/SessionMenu.test.tsx
+++ b/frontend/src/components/__tests__/SessionMenu.test.tsx
@@ -646,6 +646,69 @@ describe("SessionMenu", () => {
     ).toBeInTheDocument();
   });
 
+  it("shows step failure details even when the terminal run_failed event is missed", async () => {
+    const listeners: Record<string, EventListener> = {};
+    (global as typeof globalThis & { EventSource: jest.Mock }).EventSource = jest
+      .fn()
+      .mockImplementation(() => ({
+        addEventListener: jest.fn((eventName: string, listener: EventListener) => {
+          listeners[eventName] = listener;
+        }),
+        close: jest.fn(),
+      }));
+    const user = await openMenu();
+
+    await user.click(
+      screen.getByRole("button", { name: /verbleibende schritte ausführen/i })
+    );
+
+    await waitFor(() => expect(listeners.step_failed).toBeDefined());
+    act(() => {
+      listeners.step_failed(
+        new MessageEvent("step_failed", {
+          data: JSON.stringify({
+            key: "processes",
+            label: "Prozesse bündeln",
+            step: {
+              status: "failed",
+              message:
+                "Die Antwort für Wirtschaft konnte nicht verarbeitet werden.",
+            },
+            session_status: {
+              summary_ready: true,
+              regulations_ready: true,
+              processes_ready: false,
+              case_groups_ready: false,
+              process_steps_ready: false,
+              effort_ready: false,
+              total_cost_ready: false,
+              last_failed_step: "processes",
+              last_failed_label: "Prozesse bündeln",
+              last_failed_message:
+                "Die Antwort für Wirtschaft konnte nicht verarbeitet werden.",
+            },
+          }),
+        })
+      );
+    });
+
+    expect(
+      screen.getByText(/antwort für wirtschaft konnte nicht verarbeitet werden/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /verbleibende schritte ausführen/i })
+    ).not.toBeDisabled();
+
+    await user.click(
+      screen.getByRole("button", { name: /verbleibende schritte ausführen/i })
+    );
+
+    expect(
+      screen.queryByText(/antwort für wirtschaft konnte nicht verarbeitet werden/i)
+    ).not.toBeInTheDocument();
+    expect(mockStartRunAllSteps).toHaveBeenCalledTimes(2);
+  });
+
   it("downloads the compliance text export from the export section", async () => {
     mockUseApp.mockReturnValue({
       state: {

--- a/frontend/src/components/__tests__/UploadPanel.test.tsx
+++ b/frontend/src/components/__tests__/UploadPanel.test.tsx
@@ -5,6 +5,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import UploadPanel from "@/components/UploadPanel";
 import { useApp } from "@/contexts/AppContext";
 import { apiClient } from "@/lib/api";
+import { useActiveWorkflowRun } from "@/lib/runAllStepEvents";
 import { prepareSessionDocuments } from "@/lib/sessionStart";
 
 jest.mock("@/contexts/AppContext", () => ({
@@ -33,16 +34,19 @@ jest.mock("@/lib/sessionStart", () => ({
 }));
 
 jest.mock("@/lib/runAllStepEvents", () => ({
-  useRunAllStepRun: jest.fn(() => ({
-    isBusy: false,
+  useActiveWorkflowRun: jest.fn(() => ({
+    isActive: false,
+    stepKey: null,
     runId: null,
     runKind: null,
+    label: null,
   })),
 }));
 
 const mockUseApp = useApp as jest.Mock;
 const mockFetchRegulations = apiClient.fetchRegulations as jest.Mock;
 const mockPrepareSessionDocuments = prepareSessionDocuments as jest.Mock;
+const mockUseActiveWorkflowRun = useActiveWorkflowRun as jest.Mock;
 
 function createAppValue(overrides: Record<string, unknown> = {}) {
   return {
@@ -70,6 +74,9 @@ function createAppValue(overrides: Record<string, unknown> = {}) {
     setProcessesReady: jest.fn(),
     setRegulationsReady: jest.fn(),
     setSummaryReady: jest.fn(),
+    setLastFailedStep: jest.fn(),
+    setLastFailedLabel: jest.fn(),
+    setLastFailedMessage: jest.fn(),
   };
 }
 
@@ -80,6 +87,13 @@ describe("UploadPanel", () => {
     mockPrepareSessionDocuments.mockResolvedValue({
       proposedFilename: "proposed.txt",
       llm: { model: "gpt-5.4", provider: "openai", keys: {} },
+    });
+    mockUseActiveWorkflowRun.mockReturnValue({
+      isActive: false,
+      stepKey: null,
+      runId: null,
+      runKind: null,
+      label: null,
     });
     mockUseApp.mockReturnValue(createAppValue());
   });
@@ -129,6 +143,47 @@ describe("UploadPanel", () => {
 
     await waitFor(() => expect(mockFetchRegulations).toHaveBeenCalled());
     expect(screen.getByRole("button", { name: /ccc starten/i })).toBeEnabled();
+  });
+
+  it("hides upload controls while run-all is starting CCC", async () => {
+    mockUseApp.mockReturnValue(
+      createAppValue({
+        selectedCurrentLaw: "current.txt",
+        selectedRegulation: "proposed.txt",
+      })
+    );
+    mockUseActiveWorkflowRun.mockReturnValue({
+      isActive: true,
+      stepKey: "summary",
+      runId: "run-all-1",
+      runKind: "run_all",
+      label: "CCC starten",
+    });
+
+    render(<UploadPanel />);
+
+    await waitFor(() => expect(mockFetchRegulations).toHaveBeenCalled());
+    expect(screen.getByRole("button", { name: /abbrechen/i })).toBeEnabled();
+    const uploadGrid = screen.getByTestId("law-selection-grid");
+    expect(uploadGrid).toHaveClass("hidden");
+  });
+
+  it("clears selected laws that are no longer visible to the current user", async () => {
+    const app = createAppValue({
+      selectedCurrentLaw: "legacy-current.txt",
+      selectedRegulation: "legacy-proposed.txt",
+    });
+    mockUseApp.mockReturnValue(app);
+    mockFetchRegulations.mockResolvedValue({ files: ["shared-proposed.txt"] });
+
+    render(<UploadPanel />);
+
+    await waitFor(() => expect(mockFetchRegulations).toHaveBeenCalled());
+    expect(app.setAvailableRegulations).toHaveBeenCalledWith([
+      "shared-proposed.txt",
+    ]);
+    expect(app.setSelectedCurrentLaw).toHaveBeenCalledWith("");
+    expect(app.setSelectedRegulation).toHaveBeenCalledWith("");
   });
 
   it("disables CCC starten while a proposed upload conflict is unresolved", async () => {

--- a/frontend/src/contexts/AppContext.tsx
+++ b/frontend/src/contexts/AppContext.tsx
@@ -401,6 +401,24 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
         // A stored session id may no longer exist or may not be owned by the
         // current user (the backend returns 404 in that case).
         if (status === 404) {
+          setAppSessionIdState("");
+          sessionStorage.removeItem(APP_SESSION_STORAGE_KEY);
+          sessionStorage.removeItem(LEGACY_SESSION_STORAGE_KEY);
+          sessionStorage.removeItem(NORM_ADDRESSEE_READINESS_STORAGE_KEY);
+          setSummaryReady(false);
+          setRegulationsReady(false);
+          setProcessesReady(false);
+          setCaseGroupsReady(false);
+          setProcessStepsReady(false);
+          setEffortReady(false);
+          setTotalCostReady(false);
+          setAddresseeReadiness(createDefaultAddresseeReadiness());
+          setCurrentTab(0);
+          setLastCompletedStep(null);
+          setLastCompletedLabel(null);
+          setLastFailedStep(null);
+          setLastFailedLabel(null);
+          setLastFailedMessage(null);
           return;
         }
         logDebug("[AppContext] Failed to sync session status", {

--- a/frontend/src/contexts/__tests__/AppContext.test.tsx
+++ b/frontend/src/contexts/__tests__/AppContext.test.tsx
@@ -21,6 +21,7 @@ function ContextProbe() {
       data-effort={state.effortReady}
       data-total={state.totalCostReady}
       data-addressee={state.selectedNormAddressee}
+      data-session={state.appSessionId}
     />
   );
 }
@@ -28,6 +29,8 @@ function ContextProbe() {
 describe("AppContext session status sync", () => {
   beforeEach(() => {
     sessionStorage.clear();
+    localStorage.clear();
+    localStorage.setItem("selected_model", "gpt-5.4");
     (apiClient.createSession as jest.Mock).mockResolvedValue({
       app_session_id: "a".repeat(32),
       created: true,
@@ -165,6 +168,51 @@ describe("AppContext session status sync", () => {
       expect(node.getAttribute("data-total")).toBe("true");
       expect(node.getAttribute("data-tab")).toBe("6");
     });
+  });
+
+  it("replaces a stored session id that the backend no longer owns", async () => {
+    const freshSessionId = "FRESH1";
+    sessionStorage.setItem("app_session_id", "STALE1");
+    sessionStorage.setItem(
+      "norm_addressee_readiness",
+      JSON.stringify({
+        administration: { totalCostReady: true },
+        business: { totalCostReady: true },
+        citizens: { totalCostReady: true },
+      })
+    );
+    (apiClient.createSession as jest.Mock).mockResolvedValue({
+      app_session_id: freshSessionId,
+      created: true,
+    });
+    (apiClient.getSessionStatus as jest.Mock)
+      .mockRejectedValueOnce({ status: 404 })
+      .mockResolvedValue({
+        summary_ready: false,
+        regulations_ready: false,
+        processes_ready: false,
+        case_groups_ready: false,
+        process_steps_ready: false,
+        effort_ready: false,
+        total_cost_ready: false,
+      });
+
+    const { getByTestId } = render(
+      <AppProvider>
+        <ContextProbe />
+      </AppProvider>
+    );
+
+    await waitFor(() => {
+      expect(apiClient.createSession).toHaveBeenCalledWith("gpt-5.4");
+      expect(getByTestId("state").getAttribute("data-session")).toBe(
+        freshSessionId
+      );
+    });
+    expect(sessionStorage.getItem("app_session_id")).toBe(freshSessionId);
+    expect(sessionStorage.getItem("norm_addressee_readiness")).not.toContain(
+      "true"
+    );
   });
 
   it("restores the selected norm addressee from session storage", async () => {

--- a/frontend/src/lib/__tests__/eventSource.test.ts
+++ b/frontend/src/lib/__tests__/eventSource.test.ts
@@ -1,0 +1,21 @@
+import { createAuthenticatedEventSource } from "@/lib/eventSource";
+
+describe("createAuthenticatedEventSource", () => {
+  it("includes credentials for cookie-authenticated SSE endpoints", () => {
+    const eventSource = { close: jest.fn() };
+    const eventSourceConstructor = jest
+      .fn()
+      .mockImplementation(() => eventSource);
+    const originalEventSource = global.EventSource;
+    global.EventSource = eventSourceConstructor as unknown as typeof EventSource;
+
+    try {
+      expect(createAuthenticatedEventSource("/events")).toBe(eventSource);
+      expect(eventSourceConstructor).toHaveBeenCalledWith("/events", {
+        withCredentials: true,
+      });
+    } finally {
+      global.EventSource = originalEventSource;
+    }
+  });
+});

--- a/frontend/src/lib/__tests__/llmMonitor.test.ts
+++ b/frontend/src/lib/__tests__/llmMonitor.test.ts
@@ -1,4 +1,9 @@
-import { selectVisibleRecent } from "@/lib/llmMonitor";
+import {
+  formatMonitorClock,
+  parseMonitorTimestampMs,
+  selectVisibleRecent,
+  sortRecentCallsNewestFirst,
+} from "@/lib/llmMonitor";
 import { LlmMonitorRecentCall } from "@/types";
 
 function call(overrides: Partial<LlmMonitorRecentCall>): LlmMonitorRecentCall {
@@ -48,5 +53,49 @@ describe("selectVisibleRecent (#64 P7)", () => {
 
     expect(visibleRecent.map((row) => row.answer_id)).toEqual([3, 2]);
     expect(staleRecentCount).toBe(0);
+  });
+});
+
+describe("LLM monitor recent ordering", () => {
+  it("treats persisted SQLite timestamps as UTC like live ISO timestamps", () => {
+    expect(parseMonitorTimestampMs("2026-07-20 19:45:27")).toBe(
+      Date.parse("2026-07-20T19:45:27Z")
+    );
+    expect(parseMonitorTimestampMs("2026-07-20T19:45:27.000Z")).toBe(
+      Date.parse("2026-07-20T19:45:27.000Z")
+    );
+  });
+
+  it("sorts mixed persisted and live recent rows newest-first", () => {
+    const recent = [
+      call({
+        answer_id: 2,
+        prompt_id: "process_step_analysis",
+        created_at: "2026-07-20 19:45:56",
+      }),
+      call({
+        answer_id: 3,
+        prompt_id: "process_step_analysis",
+        created_at: "2026-07-20T19:45:30.000Z",
+      }),
+      call({
+        answer_id: 1,
+        prompt_id: "case_group_development",
+        created_at: "2026-07-20 19:45:14",
+      }),
+    ];
+
+    expect(sortRecentCallsNewestFirst(recent).map((row) => row.answer_id)).toEqual([
+      2,
+      3,
+      1,
+    ]);
+  });
+
+  it("formats persisted and live timestamps through the same clock path", () => {
+    const persisted = formatMonitorClock("2026-07-20 19:45:27");
+    const live = formatMonitorClock("2026-07-20T19:45:27.000Z");
+
+    expect(persisted).toBe(live);
   });
 });

--- a/frontend/src/lib/eventSource.ts
+++ b/frontend/src/lib/eventSource.ts
@@ -1,0 +1,5 @@
+"use client";
+
+export function createAuthenticatedEventSource(url: string): EventSource {
+  return new EventSource(url, { withCredentials: true });
+}

--- a/frontend/src/lib/llmMonitor.ts
+++ b/frontend/src/lib/llmMonitor.ts
@@ -1,5 +1,43 @@
 import { LlmMonitorRecentCall } from "@/types";
 
+const SQLITE_TIMESTAMP_PATTERN = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/;
+
+export function parseMonitorTimestampMs(value?: string | null): number {
+  if (!value) {
+    return 0;
+  }
+  const normalized = SQLITE_TIMESTAMP_PATTERN.test(value)
+    ? `${value.replace(" ", "T")}Z`
+    : value;
+  const parsed = Date.parse(normalized);
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+export function formatMonitorClock(value?: string | null): string {
+  const parsed = parseMonitorTimestampMs(value);
+  if (!parsed) {
+    return value || "-";
+  }
+  return new Date(parsed).toLocaleTimeString("de-DE", {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+}
+
+export function sortRecentCallsNewestFirst(
+  recent: LlmMonitorRecentCall[]
+): LlmMonitorRecentCall[] {
+  return [...recent].sort((a, b) => {
+    const timestampDelta =
+      parseMonitorTimestampMs(b.created_at) - parseMonitorTimestampMs(a.created_at);
+    if (timestampDelta !== 0) {
+      return timestampDelta;
+    }
+    return Number(b.answer_id || 0) - Number(a.answer_id || 0);
+  });
+}
+
 /**
  * #64 (P7): Ueberholte (superseded) Fehlversuche im Debug-Monitor herausfiltern.
  *

--- a/frontend/src/lib/useRunAllStepCancel.ts
+++ b/frontend/src/lib/useRunAllStepCancel.ts
@@ -4,10 +4,9 @@ import { Dispatch, SetStateAction, useEffect, useRef, useState } from "react";
 
 import { apiClient } from "@/lib/api";
 import { logClientError } from "@/lib/errorFeedback";
-import { RunAllStepKey, useRunAllStepRun } from "@/lib/runAllStepEvents";
+import { useActiveWorkflowRun } from "@/lib/runAllStepEvents";
 
 type UseRunAllStepCancelOptions = {
-  stepKey: RunAllStepKey;
   appSessionId: string;
   setStatus: Dispatch<SetStateAction<string | null>>;
   logScope: string;
@@ -16,13 +15,13 @@ type UseRunAllStepCancelOptions = {
 const CANCEL_REQUESTED_STATUS = "Abbruch angefordert...";
 
 export function useRunAllStepCancel({
-  stepKey,
   appSessionId,
   setStatus,
   logScope,
 }: UseRunAllStepCancelOptions) {
-  const runAllStep = useRunAllStepRun(stepKey);
-  const isRunAllBusy = runAllStep.isBusy && runAllStep.runKind === "run_all";
+  const activeWorkflowRun = useActiveWorkflowRun();
+  const isRunAllBusy =
+    activeWorkflowRun.isActive && activeWorkflowRun.runKind === "run_all";
   const [isCancellingRunAll, setIsCancellingRunAll] = useState(false);
   const isCancellingRunAllRef = useRef(false);
 
@@ -37,7 +36,7 @@ export function useRunAllStepCancel({
   }, [isRunAllBusy, setStatus]);
 
   const cancelRunAllForStep = async () => {
-    if (!runAllStep.runId) {
+    if (!activeWorkflowRun.runId) {
       setStatus("Lauf konnte nicht abgebrochen werden: Run-ID fehlt.");
       return;
     }
@@ -48,11 +47,11 @@ export function useRunAllStepCancel({
     setIsCancellingRunAll(true);
     setStatus(CANCEL_REQUESTED_STATUS);
     try {
-      await apiClient.cancelRunAll(runAllStep.runId);
+      await apiClient.cancelRunAll(activeWorkflowRun.runId);
     } catch (error) {
       logClientError(logScope, error, {
         appSessionId,
-        runId: runAllStep.runId,
+        runId: activeWorkflowRun.runId,
       });
       isCancellingRunAllRef.current = false;
       setIsCancellingRunAll(false);
@@ -63,7 +62,7 @@ export function useRunAllStepCancel({
   return {
     isRunAllBusy,
     isCancellingRunAll,
-    runAllRunId: runAllStep.runId,
+    runAllRunId: activeWorkflowRun.runId,
     cancelRunAllForStep,
   };
 }

--- a/resources/built_in_laws/arbeitstagepauschale_gueltig.txt
+++ b/resources/built_in_laws/arbeitstagepauschale_gueltig.txt
@@ -1,56 +1,77 @@
-### I. Gesetzlicher Status quo (Betrachtung nur für Arbeitnehmer)
+§ 9 Abs. 1 S. 3 Nr. 4 EStG
+Aktuelle Rechtslage
+Aufwendungen des Arbeitnehmers für die Wege zwischen Wohnung und erster Tätigkeitsstätte im Sinne des Absatzes 4. Zur Abgeltung dieser Aufwendungen ist für jeden Arbeitstag, an dem der Arbeitnehmer die erste Tätigkeitsstätte aufsucht eine Entfernungspauschale für jeden vollen Kilometer der Entfernung zwischen Wohnung und erster Tätigkeitsstätte von 0,30 Euro anzusetzen, höchstens jedoch 4 500 Euro im Kalenderjahr; ein höherer Betrag als 4 500 Euro ist anzusetzen, soweit der Arbeitnehmer einen eigenen oder ihm zur Nutzung überlassenen Kraftwagen benutzt. Die Entfernungspauschale gilt nicht für Flugstrecken und Strecken mit steuerfreier Sammelbeförderung nach § 3 Nummer 32. Für die Bestimmung der Entfernung ist die kürzeste Straßenverbindung zwischen Wohnung und erster Tätigkeitsstätte maßgebend; eine andere als die kürzeste Straßenverbindung kann zugrunde gelegt werden, wenn diese offensichtlich verkehrsgünstiger ist und vom Arbeitnehmer regelmäßig für die Wege zwischen Wohnung und erster Tätigkeitsstätte benutzt wird. Nach § 8 Absatz 2 Satz 11 oder Absatz 3 steuerfreie Sachbezüge für Fahrten zwischen Wohnung und erster Tätigkeitsstätte mindern den nach Satz 2 abziehbaren Betrag; ist der Arbeitgeber selbst der Verkehrsträger, ist der Preis anzusetzen, den ein dritter Arbeitgeber an den Verkehrsträger zu entrichten hätte. Hat ein Arbeitnehmer mehrere Wohnungen, so sind die Wege von einer Wohnung, die nicht der ersten Tätigkeitsstätte am nächsten liegt, nur zu berücksichtigen, wenn sie den Mittelpunkt der Lebensinteressen des Arbeitnehmers bildet und nicht nur gelegentlich aufgesucht wird. Nach § 3 Nummer 37 steuerfreie Sachbezüge mindern den nach Satz 2 abziehbaren Betrag nicht; § 3c Absatz 1 ist nicht anzuwenden. Zur Abgeltung der Aufwendungen im Sinne des Satzes 1 ist für die Veranlagungszeiträume 2021 bis 2026 abweichend von Satz 2 für jeden Arbeitstag, an dem der Arbeitnehmer die erste Tätigkeitsstätte aufsucht, eine Entfernungspauschale für jeden vollen Kilometer der ersten 20 Kilometer der Entfernung zwischen Wohnung und erster Tätigkeitsstätte von 0,30 Euro und für jeden weiteren vollen Kilometer
+a) von 0,35 Euro für 2021,
+b) von 0,38 Euro für 2022 bis 2026
+anzusetzen, höchstens 4 500 Euro im Kalenderjahr; ein höherer Betrag als 4 500 Euro ist anzusetzen, soweit der Arbeitnehmer einen eigenen oder ihm zur Nutzung überlassenen Kraftwagen benutzt.
 
-- Pendlerpauschale
-  - Voraussetzungen (tageweise Betrachtung):
-    - [Aufwendung für Weg zwischen Wohnung und erster Tätigkeitsstätte]
-    - Aufsuchen erster Tätigkeitsstätte ODER
-    - Arbeitnehmer hat keine erste Tätigkeitsstätte i.S.d. § 9 Abs. 4 und ist angewiesen dauerhaft denselben Ort oder dasselbe weiträumige Tätigkeitsgebiet typischerweise arbeitstäglich aufzusuchen (Siehe Verweis in § 9 Abs. 1 S. 3 Nr. 4a S. 3)
-  - Folge:
-    - Entfernungspauschale für jeden vollen Kilometer der Entfernung zwischen Wohnung und erster Tätigkeitsstätte i.H.v. 0,30 €
-      - Ausnahme: Gilt nicht für Flugstrecken und Strecken mit steuerfreier Sammelbeförderung nach § 3 Nummer 32 —> dann keine überhaupt keine Geltendmachung möglich!
-      - Veranlagungszeiträume 2021 bis 2026 andere Berechnung, siehe § 9 Abs. 1 S. 3 Nr. 4 S. 7
-        - Erste 20 km Pauschale i.H.v. 0,30 €
-        - Ab 21 km i.H.v. von 0,35 Euro (für 2021) bzw. von 0,38 Euro (für 2022 bis 2026) (”Fernpendlerpauschale”)
-    - Entfernung
-      - wird grundsätzlich nach kürzester Straßenverbindung zwischen Wohnung und erster Tätigkeitsstätte berechnet, Ausnahme: regelmäßig genutzte, offensichtlich verkehrsgünstigere Strecke
-      - Bei mehreren Wohnungen darf nur die längere Strecke zur ersten Tätigkeitsstätte angesetzt werden, wenn die betroffene Wohnung den Mittelpunkt der Lebensinteressen des Arbeitnehmers bildet (Hauptwohnung) und nicht nur gelegentlich aufgesucht wird
-    - Hat Arbeitnehmer keine erste Tätigkeitsstätte i.S.d. § 9 Abs. 4 (vgl. oben) ist für die Berechnung der typischerweise aufgesuchte Ort bzw. der dem zur Wohnung nächstgelegenen Zugang zum Tätigkeitsgebiet maßgebend (siehe Verweis in § 9 Abs. 1 S. 3 Nr. 4a S. 3)
-    - Kappung der Entfernungspauschale auf 4.500 € im Jahr, Ausnahme: insoweit KFZ genutzt wird Kappung erhöht
-    - Minderung der berechneten Pauschale insoweit § 8 Absatz 2 Satz 11 oder Absatz 3 steuerfreie Sachbezüge durch Arbeitgeber für Fahrten
-    - Pauschale hat abgeltende Wirkung. Ausnahmen:
-      - Aufwendungen für die Benutzung öffentlicher Verkehrsmittel können angesetzt werden, soweit sie den im Kalenderjahr insgesamt als Entfernungspauschale abziehbaren Betrag übersteigen
-      - Menschen mit erheblichen Behinderungen können STATT der Entfernungspauschalen die tatsächlichen Aufwendungen geltend machen
-  - Rechtsgrundlage: §§ 9 Abs. 1 S. 3 Nr. 4, 9 Abs. 2 EStG
-- Sonstige beruflich veranlasste Fahrten
-  - Voraussetzungen
-    - Entweder
-      - Berufliche veranlasste Fahrt
-      - Fahrt keine Fahrt zwischen Wohnung und erster Tätigkeitsstätte
-      - Fahrt keine Familienheimfahrt
 
-    - ODER
+§ 9 Abs. 1 S. 3 Nr. 4a EStG
+Aktuelle Rechtslage
+Aufwendungen des Arbeitnehmers für beruflich veranlasste Fahrten, die nicht Fahrten zwischen Wohnung und erster Tätigkeitsstätte im Sinne des Absatzes 4 sowie keine Familienheimfahrten sind. Anstelle der tatsächlichen Aufwendungen, die dem Arbeitnehmer durch die persönliche Benutzung eines Beförderungsmittels entstehen, können die Fahrtkosten mit den pauschalen Kilometersätzen angesetzt werden, die für das jeweils benutzte Beförderungsmittel (Fahrzeug) als höchste Wegstreckenentschädigung nach dem Bundesreisekostengesetz festgesetzt sind. Hat ein Arbeitnehmer keine erste Tätigkeitsstätte (§ 9 Absatz 4) und hat er nach den dienst- oder arbeitsrechtlichen Festlegungen sowie den diese ausfüllenden Absprachen und Weisungen zur Aufnahme seiner beruflichen Tätigkeit dauerhaft denselben Ort oder dasselbe weiträumige Tätigkeitsgebiet typischerweise arbeitstäglich aufzusuchen, gilt Absatz 1 Satz 3 Nummer 4 und Absatz 2 für die Fahrten von der Wohnung zu diesem Ort oder dem zur Wohnung nächstgelegenen Zugang zum Tätigkeitsgebiet entsprechend. Für die Fahrten innerhalb des weiträumigen Tätigkeitsgebietes gelten die Sätze 1 und 2 entsprechend.
 
-      - Arbeitnehmer hat keine erste Tätigkeitsstätte i.S.d. § 9 Abs. 4 und ist angewiesen dauerhaft dasselbe weiträumige Tätigkeitsgebiet typischerweise arbeitstäglich aufzusuchen (Siehe Verweis in § 9 Abs. 1 S. 3 Nr. 4a S. 3 u. S. 4)
-  - Folge
-    - Geltendmachung tatsächlicher Aufwendung für das Beförderungsmittel ODER
-    - Anwendung pauschaler Kilometersätze für persönliches Beförderungsmittel i.V.m. Bundesreisekostengesetz
-    - Für Fahrten innerhalb des weiträumigen Tätigkeitsgebiets gelten obenstehende Folgen entsprechend
-  - Rechtsgrundlage: § 9 Abs. 1 S. 3 Nr. 4a S. 3 und S. 4 EStG
-- Aufwendungen für Arbeitszimmer
-  - Voraussetzungen:
-    - Häusliches Arbeitszimmer
-    - Arbeitszimmer ist Mittelpunkt der betrieblichen bzw. beruflichen Betätigung
-  - Folge: Absetzbar sind:
-    - Aufwendungen für das häusliche Arbeitszimmer ODER Jahrespauschale i.H.v. 1260 € (ggf. pro rata)
-    - Kosten der Ausstattung für das häusliche Arbeitszimmer
-  - Rechtsgrundlage: § 9 Abs. 5 S. 1 EStG i.V.m. § 4 Abs. 5 Satz 1 Nr. 6b EStG
-- Home-Office-Pauschale
-  - Voraussetzungen (tagweise Betrachtung):
-    - Überwiegende Ausübung der betrieblichen oder beruflichen Tätigkeit in der häuslichen Wohnung
-      —> Ausnahme: Steht für die betriebliche oder berufliche Tätigkeit dauerhaft kein anderer Arbeitsplatz zur Verfügung, ist ein Abzug der Tagespauschale zulässig, auch wenn die Tätigkeit am selben Kalendertag auswärts ausgeübt wird.
-    - Kein Aufsuchen einer außerhalb der häuslichen Wohnung gelegene erste Tätigkeitsstätte
-      —> Ausnahme: Steht für die betriebliche oder berufliche Tätigkeit dauerhaft kein anderer Arbeitsplatz zur Verfügung, ist ein Abzug der Tagespauschale zulässig, auch wenn die Tätigkeit an der ersten Tätigkeitsstätte ausgeübt wird.
-    - Für die Wohnung KÖNNEN keine Unterkunftskosten im Rahmen der Nummer § 4 Abs. 5 S. 1 Nr. 6a (doppelte Haushaltsführung als Betriebsausgaben) oder des § 9 Absatz 1 Satz 3 Nummer 5 (doppelte Haushaltsführung und Familienheimfahrten als Werbungskosten) abgezogen werden
-    - Für die Wohnung WIRD kein Abzug nach Nummer § 4 Abs. 5 S. 1 Nr. 6b (Aufwendungen für Arbeitszimmer, siehe oben) vorgenommen
-  - Folge: Tagespauschale i.H.v. 6 €, gedeckelt auf 1260 € im Jahr
-  - Rechtsgrundlage: § 9 Abs. 5 S. 1 EStG i.V.m. § 4 Abs. 5 Satz 1 Nr. 6c EStG
+
+§ 9 Abs. 2 EStG
+Aktuelle Rechtslage
+Durch die Entfernungspauschalen sind sämtliche Aufwendungen abgegolten, die durch die Wege zwischen Wohnung und erster Tätigkeitsstätte im Sinne des Absatzes 4 und durch die Familienheimfahrten veranlasst sind. Aufwendungen für die Benutzung öffentlicher Verkehrsmittel können angesetzt werden, soweit sie den im Kalenderjahr insgesamt als Entfernungspauschale abziehbaren Betrag übersteigen. Menschen mit Behinderungen,
+1. deren Grad der Behinderung mindestens 70 beträgt,
+2. deren Grad der Behinderung weniger als 70, aber mindestens 50 beträgt und die in ihrer Bewegungsfähigkeit im Straßenverkehr erheblich beeinträchtigt sind,
+können anstelle der Entfernungspauschalen die tatsächlichen Aufwendungen für die Wege zwischen Wohnung und erster Tätigkeitsstätte und für Familienheimfahrten ansetzen. Die Voraussetzungen der Nummern 1 und 2 sind durch amtliche Unterlagen nachzuweisen.
+
+
+§ 9 Abs. 4 EStG
+Aktuelle Rechtslage
+Erste Tätigkeitsstätte ist die ortsfeste betriebliche Einrichtung des Arbeitgebers, eines verbundenen Unternehmens (§ 15 des Aktiengesetzes) oder eines vom Arbeitgeber bestimmten Dritten, der der Arbeitnehmer dauerhaft zugeordnet ist. Die Zuordnung im Sinne des Satzes 1 wird durch die dienst- oder arbeitsrechtlichen Festlegungen sowie die diese ausfüllenden Absprachen und Weisungen bestimmt. Von einer dauerhaften Zuordnung ist insbesondere auszugehen, wenn der Arbeitnehmer unbefristet, für die Dauer des Dienstverhältnisses oder über einen Zeitraum von 48 Monaten hinaus an einer solchen Tätigkeitsstätte tätig werden soll. Fehlt eine solche dienst- oder arbeitsrechtliche Festlegung auf eine Tätigkeitsstätte oder ist sie nicht eindeutig, ist erste Tätigkeitsstätte die betriebliche Einrichtung, an der der Arbeitnehmer dauerhaft
+1. typischerweise arbeitstäglich tätig werden soll oder
+2. je Arbeitswoche zwei volle Arbeitstage oder mindestens ein Drittel seiner vereinbarten regelmäßigen Arbeitszeit tätig werden soll.
+Je Dienstverhältnis hat der Arbeitnehmer höchstens eine erste Tätigkeitsstätte. Liegen die Voraussetzungen der Sätze 1 bis 4 für mehrere Tätigkeitsstätten vor, ist diejenige Tätigkeitsstätte erste Tätigkeitsstätte, die der Arbeitgeber bestimmt. Fehlt es an dieser Bestimmung oder ist sie nicht eindeutig, ist die der Wohnung örtlich am nächsten liegende Tätigkeitsstätte die erste Tätigkeitsstätte. Als erste Tätigkeitsstätte gilt auch eine Bildungseinrichtung, die außerhalb eines Dienstverhältnisses zum Zwecke eines Vollzeitstudiums oder einer vollzeitigen Bildungsmaßnahme aufgesucht wird; die Regelungen für Arbeitnehmer nach Absatz 1 Satz 3 Nummer 4 und 5 sowie Absatz 4a sind entsprechend anzuwenden.
+
+
+§ 9 Abs. 4a EStG
+Aktuelle Rechtslage
+
+Mehraufwendungen des Arbeitnehmers für die Verpflegung sind nur nach Maßgabe der folgenden Sätze als Werbungskosten abziehbar. Wird der Arbeitnehmer außerhalb seiner Wohnung und ersten Tätigkeitsstätte beruflich tätig (auswärtige berufliche Tätigkeit), ist zur Abgeltung der ihm tatsächlich entstandenen, beruflich veranlassten Mehraufwendungen eine Verpflegungspauschale anzusetzen. Diese beträgt
+
+1. 28 Euro für jeden Kalendertag, an dem der Arbeitnehmer 24 Stunden von seiner Wohnung und ersten Tätigkeitsstätte abwesend ist
+
+2. jeweils 14 Euro für den An- und Abreisetag, wenn der Arbeitnehmer an diesem, einem anschließenden oder vorhergehenden Tag außerhalb seiner Wohnung übernachtet,
+
+3. 14 Euro für den Kalendertag, an dem der Arbeitnehmer ohne Übernachtung außerhalb seiner Wohnung mehr als 8 Stunden von seiner Wohnung und der ersten Tätigkeitsstätte abwesend ist; beginnt die auswärtige berufliche Tätigkeit an einem Kalendertag und endet am nachfolgenden Kalendertag ohne Übernachtung, werden 14 Euro für den Kalendertag gewährt, an dem der Arbeitnehmer den überwiegenden Teil der insgesamt mehr als 8 Stunden von seiner Wohnung und der ersten Tätigkeitsstätte abwesend ist.
+
+Hat der Arbeitnehmer keine erste Tätigkeitsstätte, gelten die Sätze 2 und 3 entsprechend; Wohnung im Sinne der Sätze 2 und 3 ist der Hausstand, der den Mittelpunkt der Lebensinteressen des Arbeitnehmers bildet sowie eine Unterkunft am Ort der ersten Tätigkeitsstätte im Rahmen der doppelten Haushaltsführung. 5ei einer Tätigkeit im Ausland treten an die Stelle der Pauschbeträge nach Satz 3 länderweise unterschiedliche Pauschbeträge, die für die Fälle der Nummer 1 mit 120 sowie der Nummern 2 und 3 mit 80 Prozent der Auslandstagegelder nach dem Bundesreisekostengesetz vom Bundesministerium der Finanzen im Einvernehmen mit den obersten Finanzbehörden der Länder aufgerundet auf volle Euro festgesetzt werden; dabei bestimmt sich der Pauschbetrag nach dem Ort, den der Arbeitnehmer vor 24 Uhr Ortszeit zuletzt erreicht, oder, wenn dieser Ort im Inland liegt, nach dem letzten Tätigkeitsort im Ausland. Der Abzug der Verpflegungspauschalen ist auf die ersten drei Monate einer längerfristigen beruflichen Tätigkeit an derselben Tätigkeitsstätte beschränkt. Eine Unterbrechung der beruflichen Tätigkeit an derselben Tätigkeitsstätte führt zu einem Neubeginn, wenn sie mindestens vier Wochen dauert. Wird dem Arbeitnehmer anlässlich oder während einer Tätigkeit außerhalb seiner ersten Tätigkeitsstätte vom Arbeitgeber oder auf dessen Veranlassung von einem Dritten eine Mahlzeit zur Verfügung gestellt, sind die nach den Sätzen 3 und 5 ermittelten Verpflegungspauschalen zu kürzen:
+
+1. für Frühstück um 20 Prozent,
+
+2. für Mittag- und Abendessen um jeweils 40 Prozent,
+
+der nach Satz 3 Nummer 1 gegebenenfalls in Verbindung mit Satz 5 maßgebenden Verpflegungspauschale für einen vollen Kalendertag; die Kürzung darf die ermittelte Verpflegungspauschale nicht übersteigen. Satz 8 gilt auch, wenn Reisekostenvergütungen wegen der zur Verfügung gestellten Mahlzeiten einbehalten oder gekürzt werden oder die Mahlzeiten nach § 40 Absatz 2 Satz 1 Nummer 1a pauschal besteuert werden. Hat der Arbeitnehmer für die Mahlzeit ein Entgelt gezahlt, mindert dieser Betrag den Kürzungsbetrag nach Satz 8. Erhält der Arbeitnehmer steuerfreie Erstattungen für Verpflegung, ist ein Werbungskostenabzug insoweit ausgeschlossen. Die Verpflegungspauschalen nach den Sätzen 3 und 5, die Dreimonatsfrist nach den Sätzen 6 und 7 sowie die Kürzungsregelungen nach den Sätzen 8 bis 10 gelten entsprechend auch für den Abzug von Mehraufwendungen für Verpflegung, die bei einer beruflich veranlassten doppelten Haushaltsführung entstehen, soweit der Arbeitnehmer vom eigenen Hausstand im Sinne des § 9 Absatz 1 Satz 3 Nummer 5 abwesend ist; dabei ist für jeden Kalendertag innerhalb der Dreimonatsfrist, an dem gleichzeitig eine Tätigkeit im Sinne des Satzes 2 oder des Satzes 4 ausgeübt wird, nur der jeweils höchste in Betracht kommende Pauschbetrag abziehbar. Die Dauer einer Tätigkeit im Sinne des Satzes 2 an dem Tätigkeitsort, an dem die doppelte Haushaltsführung begründet wurde, ist auf die Dreimonatsfrist anzurechnen, wenn sie ihr unmittelbar vorausgegangen ist.
+
+
+§ 9 Abs. 5 EStG
+Aktuelle Rechtslage
+§ 4 Absatz 5 Satz 1 Nummer 1 bis 4, 6b bis 8a, 10, 12 und Absatz 6 gilt sinngemäß. Die §§ 4j, 4k, 6 Absatz 1 Nummer 1a und § 6e gelten entsprechend.
+
+
+§ 3 Nr. 15 EStG
+Aktuelle Rechtslage
+Zuschüsse des Arbeitgebers, die zusätzlich zum ohnehin geschuldeten Arbeitslohn zu den Aufwendungen des Arbeitnehmers für Fahrten mit öffentlichen Verkehrsmitteln im Linienverkehr (ohne Luftverkehr) zwischen Wohnung und erster Tätigkeitsstätte und nach § 9 Absatz 1 Satz 3 Nummer 4a Satz 3 sowie für Fahrten im öffentlichen Personennahverkehr gezahlt werden. Das Gleiche gilt für die unentgeltliche oder verbilligte Nutzung öffentlicher Verkehrsmittel im Linienverkehr (ohne Luftverkehr) für Fahrten zwischen Wohnung und erster Tätigkeitsstätte und nach § 9 Absatz 1 Satz 3 Nummer 4a Satz 3 sowie für Fahrten im öffentlichen Personennahverkehr, die der Arbeitnehmer auf Grund seines Dienstverhältnisses zusätzlich zum ohnehin geschuldeten Arbeitslohn in Anspruch nehmen kann. Die nach den Sätzen 1 und 2 steuerfreien Leistungen mindern den nach § 9 Absatz 1 Satz 3 Nummer 4 Satz 2 abziehbaren Betrag;
+
+
+§ 3 Nr. 32 EStG
+Aktuelle Rechtslage
+die unentgeltliche oder verbilligte Sammelbeförderung eines Arbeitnehmers zwischen Wohnung und erster Tätigkeitsstätte sowie bei Fahrten nach § 9 Absatz 1 Satz 3 Nummer 4a Satz 3 mit einem vom Arbeitgeber gestellten Beförderungsmittel, soweit die Sammelbeförderung für den betrieblichen Einsatz des Arbeitnehmers notwendig ist;
+
+
+§ 4 Abs. 5 S. 1 Nr. 6 EStG
+Aktuelle Rechtslage
+Aufwendungen für die Wege des Steuerpflichtigen zwischen Wohnung und Betriebsstätte und für Familienheimfahrten, soweit in den folgenden Sätzen nichts anderes bestimmt ist. Zur Abgeltung dieser Aufwendungen ist § 9 Absatz 1 Satz 3 Nummer 4 Satz 2 bis 6 und Nummer 5 Satz 5 bis 7 und Absatz 2 entsprechend anzuwenden. Bei der Nutzung eines Kraftfahrzeugs dürfen die Aufwendungen in Höhe des positiven Unterschiedsbetrags zwischen 0,03 Prozent des inländischen Listenpreises im Sinne des § 6 Absatz 1 Nummer 4 Satz 2 des Kraftfahrzeugs im Zeitpunkt der Erstzulassung je Kalendermonat für jeden Entfernungskilometer und dem sich nach § 9 Absatz 1 Satz 3 Nummer 4 Satz 2 bis 6 oder Absatz 2 ergebenden Betrag sowie Aufwendungen für Familienheimfahrten in Höhe des positiven Unterschiedsbetrags zwischen 0,002 Prozent des inländischen Listenpreises im Sinne des § 6 Absatz 1 Nummer 4 Satz 2 für jeden Entfernungskilometer und dem sich nach § 9 Absatz 1 Satz 3 Nummer 5 Satz 5 bis 7 oder Absatz 2 ergebenden Betrag den Gewinn nicht mindern; ermittelt der Steuerpflichtige die private Nutzung des Kraftfahrzeugs nach § 6 Absatz 1 Nummer 4 Satz 1 oder Satz 3, treten an die Stelle des mit 0,03 oder 0,002 Prozent des inländischen Listenpreises ermittelten Betrags für Fahrten zwischen Wohnung und Betriebsstätte und für Familienheimfahrten die auf diese Fahrten entfallenden tatsächlichen Aufwendungen; § 6 Absatz 1 Nummer 4 Satz 3 zweiter Halbsatz gilt sinngemäß. § 9 Absatz 1 Satz 3 Nummer 4 Satz 8 und Nummer 5 Satz 9 gilt entsprechend;
+
+
+§ 4 Abs. 5 S. 1 Nr. 6b EStG
+Aktuelle Rechtslage
+Aufwendungen für ein häusliches Arbeitszimmer sowie die Kosten der Ausstattung. Dies gilt nicht, wenn das Arbeitszimmer den Mittelpunkt der gesamten betrieblichen und beruflichen Betätigung bildet. Anstelle der Aufwendungen kann pauschal ein Betrag von 1 260 Euro (Jahrespauschale) für das Wirtschafts- oder Kalenderjahr abgezogen werden. Für jeden vollen Kalendermonat, in dem die Voraussetzungen nach Satz 2 nicht vorliegen, ermäßigt sich der Betrag von 1 260 Euro um ein Zwölftel;
+
+
+§ 4 Abs. 5 S. 1 Nr. 6c EStG
+Aktuelle Rechtslage
+für jeden Kalendertag, an dem die betriebliche oder berufliche Tätigkeit überwiegend in der häuslichen Wohnung ausgeübt und keine außerhalb der häuslichen Wohnung belegene erste Tätigkeitsstätte aufgesucht wird, kann für die gesamte betriebliche und berufliche Betätigung ein Betrag von 6 Euro (Tagespauschale), höchstens 1 260 Euro im Wirtschafts- oder Kalenderjahr, abgezogen werden. Steht für die betriebliche oder berufliche Tätigkeit dauerhaft kein anderer Arbeitsplatz zur Verfügung, ist ein Abzug der Tagespauschale zulässig, auch wenn die Tätigkeit am selben Kalendertag auswärts oder an der ersten Tätigkeitsstätte ausgeübt wird. Der Abzug der Tagespauschale ist nicht zulässig, soweit für die Wohnung Unterkunftskosten im Rahmen der Nummer 6a oder des § 9 Absatz 1 Satz 3 Nummer 5 abgezogen werden können oder soweit ein Abzug nach Nummer 6b vorgenommen wird;

--- a/resources/built_in_laws/arbeitstagepauschale_gueltig.txt
+++ b/resources/built_in_laws/arbeitstagepauschale_gueltig.txt
@@ -1,0 +1,56 @@
+### I. Gesetzlicher Status quo (Betrachtung nur für Arbeitnehmer)
+
+- Pendlerpauschale
+  - Voraussetzungen (tageweise Betrachtung):
+    - [Aufwendung für Weg zwischen Wohnung und erster Tätigkeitsstätte]
+    - Aufsuchen erster Tätigkeitsstätte ODER
+    - Arbeitnehmer hat keine erste Tätigkeitsstätte i.S.d. § 9 Abs. 4 und ist angewiesen dauerhaft denselben Ort oder dasselbe weiträumige Tätigkeitsgebiet typischerweise arbeitstäglich aufzusuchen (Siehe Verweis in § 9 Abs. 1 S. 3 Nr. 4a S. 3)
+  - Folge:
+    - Entfernungspauschale für jeden vollen Kilometer der Entfernung zwischen Wohnung und erster Tätigkeitsstätte i.H.v. 0,30 €
+      - Ausnahme: Gilt nicht für Flugstrecken und Strecken mit steuerfreier Sammelbeförderung nach § 3 Nummer 32 —> dann keine überhaupt keine Geltendmachung möglich!
+      - Veranlagungszeiträume 2021 bis 2026 andere Berechnung, siehe § 9 Abs. 1 S. 3 Nr. 4 S. 7
+        - Erste 20 km Pauschale i.H.v. 0,30 €
+        - Ab 21 km i.H.v. von 0,35 Euro (für 2021) bzw. von 0,38 Euro (für 2022 bis 2026) (”Fernpendlerpauschale”)
+    - Entfernung
+      - wird grundsätzlich nach kürzester Straßenverbindung zwischen Wohnung und erster Tätigkeitsstätte berechnet, Ausnahme: regelmäßig genutzte, offensichtlich verkehrsgünstigere Strecke
+      - Bei mehreren Wohnungen darf nur die längere Strecke zur ersten Tätigkeitsstätte angesetzt werden, wenn die betroffene Wohnung den Mittelpunkt der Lebensinteressen des Arbeitnehmers bildet (Hauptwohnung) und nicht nur gelegentlich aufgesucht wird
+    - Hat Arbeitnehmer keine erste Tätigkeitsstätte i.S.d. § 9 Abs. 4 (vgl. oben) ist für die Berechnung der typischerweise aufgesuchte Ort bzw. der dem zur Wohnung nächstgelegenen Zugang zum Tätigkeitsgebiet maßgebend (siehe Verweis in § 9 Abs. 1 S. 3 Nr. 4a S. 3)
+    - Kappung der Entfernungspauschale auf 4.500 € im Jahr, Ausnahme: insoweit KFZ genutzt wird Kappung erhöht
+    - Minderung der berechneten Pauschale insoweit § 8 Absatz 2 Satz 11 oder Absatz 3 steuerfreie Sachbezüge durch Arbeitgeber für Fahrten
+    - Pauschale hat abgeltende Wirkung. Ausnahmen:
+      - Aufwendungen für die Benutzung öffentlicher Verkehrsmittel können angesetzt werden, soweit sie den im Kalenderjahr insgesamt als Entfernungspauschale abziehbaren Betrag übersteigen
+      - Menschen mit erheblichen Behinderungen können STATT der Entfernungspauschalen die tatsächlichen Aufwendungen geltend machen
+  - Rechtsgrundlage: §§ 9 Abs. 1 S. 3 Nr. 4, 9 Abs. 2 EStG
+- Sonstige beruflich veranlasste Fahrten
+  - Voraussetzungen
+    - Entweder
+      - Berufliche veranlasste Fahrt
+      - Fahrt keine Fahrt zwischen Wohnung und erster Tätigkeitsstätte
+      - Fahrt keine Familienheimfahrt
+
+    - ODER
+
+      - Arbeitnehmer hat keine erste Tätigkeitsstätte i.S.d. § 9 Abs. 4 und ist angewiesen dauerhaft dasselbe weiträumige Tätigkeitsgebiet typischerweise arbeitstäglich aufzusuchen (Siehe Verweis in § 9 Abs. 1 S. 3 Nr. 4a S. 3 u. S. 4)
+  - Folge
+    - Geltendmachung tatsächlicher Aufwendung für das Beförderungsmittel ODER
+    - Anwendung pauschaler Kilometersätze für persönliches Beförderungsmittel i.V.m. Bundesreisekostengesetz
+    - Für Fahrten innerhalb des weiträumigen Tätigkeitsgebiets gelten obenstehende Folgen entsprechend
+  - Rechtsgrundlage: § 9 Abs. 1 S. 3 Nr. 4a S. 3 und S. 4 EStG
+- Aufwendungen für Arbeitszimmer
+  - Voraussetzungen:
+    - Häusliches Arbeitszimmer
+    - Arbeitszimmer ist Mittelpunkt der betrieblichen bzw. beruflichen Betätigung
+  - Folge: Absetzbar sind:
+    - Aufwendungen für das häusliche Arbeitszimmer ODER Jahrespauschale i.H.v. 1260 € (ggf. pro rata)
+    - Kosten der Ausstattung für das häusliche Arbeitszimmer
+  - Rechtsgrundlage: § 9 Abs. 5 S. 1 EStG i.V.m. § 4 Abs. 5 Satz 1 Nr. 6b EStG
+- Home-Office-Pauschale
+  - Voraussetzungen (tagweise Betrachtung):
+    - Überwiegende Ausübung der betrieblichen oder beruflichen Tätigkeit in der häuslichen Wohnung
+      —> Ausnahme: Steht für die betriebliche oder berufliche Tätigkeit dauerhaft kein anderer Arbeitsplatz zur Verfügung, ist ein Abzug der Tagespauschale zulässig, auch wenn die Tätigkeit am selben Kalendertag auswärts ausgeübt wird.
+    - Kein Aufsuchen einer außerhalb der häuslichen Wohnung gelegene erste Tätigkeitsstätte
+      —> Ausnahme: Steht für die betriebliche oder berufliche Tätigkeit dauerhaft kein anderer Arbeitsplatz zur Verfügung, ist ein Abzug der Tagespauschale zulässig, auch wenn die Tätigkeit an der ersten Tätigkeitsstätte ausgeübt wird.
+    - Für die Wohnung KÖNNEN keine Unterkunftskosten im Rahmen der Nummer § 4 Abs. 5 S. 1 Nr. 6a (doppelte Haushaltsführung als Betriebsausgaben) oder des § 9 Absatz 1 Satz 3 Nummer 5 (doppelte Haushaltsführung und Familienheimfahrten als Werbungskosten) abgezogen werden
+    - Für die Wohnung WIRD kein Abzug nach Nummer § 4 Abs. 5 S. 1 Nr. 6b (Aufwendungen für Arbeitszimmer, siehe oben) vorgenommen
+  - Folge: Tagespauschale i.H.v. 6 €, gedeckelt auf 1260 € im Jahr
+  - Rechtsgrundlage: § 9 Abs. 5 S. 1 EStG i.V.m. § 4 Abs. 5 Satz 1 Nr. 6c EStG

--- a/resources/built_in_laws/arbeitstagepauschale_vorschlag.txt
+++ b/resources/built_in_laws/arbeitstagepauschale_vorschlag.txt
@@ -1,154 +1,79 @@
-**Entwurf eines Gesetzes zur Einführung einer Arbeitstagepauschale**
-
-**(ArbeitstagepauschalenG)**
-
-
-
-**Vom 16. Oktober 2025**
+§ 9 Abs. 1 S. 3 Nr. 4 EStG
+Geplante Fassung
+Zur Abgeltung der arbeitstäglichen Aufwendungen eines Arbeitnehmers ist für jeden Tag, an dem der Arbeitnehmer eine berufliche Tätigkeit ausübt, ein Betrag von 8 Euro als Werbungskosten anzusetzen (Arbeitstagepauschale). Die Arbeitstagepauschale erfasst insbesondere Aufwendungen für Wege zwischen Wohnung und den regelmäßig arbeitstäglich aufgesuchten Arbeitsorten sowie Aufwendungen für die berufliche Nutzung der häuslichen Wohnung einschließlich eines häuslichen Arbeitszimmers. Steuerfreie Arbeitgeberleistungen, insbesondere nach § 3 Nummer 15 und Nummer 32, sind auf die Arbeitstagepauschale anzurechnen, soweit sie die arbeitstäglichen Aufwendungen abdecken. Für Tage einer auswärtigen beruflichen Tätigkeit nach Absatz 2a findet Satz 1 keine Anwendung.
 
 
-
-Der Bundestag hat mit Zustimmung des Bundesrates das folgende Gesetz beschlossen:
-
-
-
-Inhaltsübersicht
+§ 9 Abs. 1 S. 3 Nr. 4a EStG
+Geplante Fassung
+Überschreitet die Entfernung zwischen der Wohnung des Arbeitnehmers und dem von ihm regelmäßig arbeitstäglich aufgesuchten Arbeitsort oder, bei einem weiträumigen Tätigkeitsgebiet, dem der Wohnung nächstgelegenen Zugang zu diesem Gebiet 26 Kilometer, kann für jeden weiteren vollen Entfernungskilometer ein zusätzlicher Betrag von 0,30 Euro je Arbeitstag als Werbungskosten angesetzt werden. Für die Bestimmung der Entfernung gilt die kürzeste Straßenverbindung; eine regelmäßig benutzte, offensichtlich verkehrsgünstigere Strecke kann zugrunde gelegt werden. Die Zusatzpauschale ist verkehrsmittelunabhängig. Steuerfreie Arbeitgeberleistungen, insbesondere nach § 3 Nummer 15 und Nummer 32, sind auf die Zusatzpauschale anzurechnen, soweit sie die arbeitstäglichen Mobilitätsaufwendungen insoweit abdecken.
 
 
+§ 9 Abs. 2 EStG
+Geplante Fassung
+Durch die Pauschalen nach Absatz 1 Satz 3 Nummer 4 und 4a sind sämtliche arbeitstäglichen Aufwendungen des Arbeitnehmers abgegolten; der Ansatz tatsächlicher Aufwendungen ist insoweit ausgeschlossen. Absatz 2a bleibt unberührt.
 
-Artikel 1 Änderung des Einkommensteuergesetzes
 
-Artikel 2 Inkrafttreten
+§ 9 Abs. 2a EStG
+Geplante Fassung
+Für vorübergehende berufliche Tätigkeiten an einem anderen Ort als dem oder den regelmäßig arbeitstäglich aufgesuchten Arbeitsorten findet die Arbeitstagepauschale nach Absatz 1 Satz 3 Nummer 4 keine Anwendung. In diesen Fällen sind die tatsächlichen Aufwendungen für Fahrten, Übernachtungen und sonstige Reisenebenkosten als Werbungskosten anzusetzen; bei der Benutzung eines privaten Beförderungsmittels können die Fahrtkosten mit den pauschalen Kilometersätzen angesetzt werden, die als höchste Wegstreckenentschädigung nach dem Bundesreisekostengesetz festgesetzt sind.
 
 
 
-
-**Artikel 1**
-
-
-
-**Änderung des Einkommensteuergesetzes**
+§ 9 Abs. 4 EStG
+Geplante Fassung
+Regelmäßig arbeitstäglich aufgesuchter Arbeitsort ist der Ort oder sind die Orte, die der Arbeitnehmer nach den dienst- oder arbeitsrechtlichen Festlegungen sowie den diese ausfüllenden Absprachen und Weisungen zur Aufnahme seiner beruflichen Tätigkeit dauerhaft typischerweise arbeitstäglich aufsucht. Fehlt eine solche Festlegung oder ist sie nicht eindeutig, gilt als regelmäßig arbeitstäglich aufgesuchter Arbeitsort der Ort, an dem der Arbeitnehmer dauerhaft je Arbeitswoche zwei volle Arbeitstage oder mindestens ein Drittel seiner vereinbarten regelmäßigen Arbeitszeit tätig werden soll. Bei einem weiträumigen Tätigkeitsgebiet gilt als regelmäßig arbeitstäglich aufgesuchter Arbeitsort der der Wohnung des Arbeitnehmers nächstgelegene Zugang zu diesem Gebiet. Je Dienstverhältnis können mehrere regelmäßig arbeitstäglich aufgesuchte Arbeitsorte vorliegen.
 
 
+§ 9 Abs. 4a EStG
+Geplante Fassung
 
-Das Einkommensteuergesetz in der Fassung der Bekanntmachung vom 8. Oktober 2009 (BGBl. I S. 3366, 3862), das zuletzt durch Artikel 1 des Gesetzes vom 14. Juli 2025 (BGBl. 2025 I Nr. 161) geändert worden ist, wird wie folgt geändert:
-
-
-
-1. § 9 wird wie folgt geändert:
-
-
-
-  a) Absatz 1 Satz 3 wird wie folgt geändert:
-
-
-
-   aa) Nummer 4 wird wie folgt gefasst:
-
-
-„4. Zur Abgeltung der arbeitstäglichen Aufwendungen eines Arbeitnehmers ist für jeden Tag, an dem der Arbeitnehmer eine berufliche Tätigkeit ausübt, ein Betrag von 8 Euro als Werbungskosten anzusetzen (Arbeitstagepauschale). Die Arbeitstagepauschale erfasst insbesondere Aufwendungen für Wege zwischen Wohnung und den regelmäßig arbeitstäglich aufgesuchten Arbeitsorten sowie Aufwendungen für die berufliche Nutzung der häuslichen Wohnung einschließlich eines häuslichen Arbeitszimmers. Steuerfreie Arbeitgeberleistungen, insbesondere nach § 3 Nummer 15 und Nummer 32, sind auf die Arbeitstagepauschale anzurechnen, soweit sie die arbeitstäglichen Aufwendungen abdecken. Für Tage einer auswärtigen beruflichen Tätigkeit nach Absatz 2a findet Satz 1 keine Anwendung.“
-
-
-
-   bb) Nummer 4a wird wie folgt gefasst.
-
- „4a. Überschreitet die Entfernung zwischen der Wohnung des Arbeitnehmers und dem von ihm regelmäßig arbeitstäglich aufgesuchten Arbeitsort oder, bei einem weiträumigen Tätigkeitsgebiet, dem der Wohnung nächstgelegenen Zugang zu diesem Gebiet 26 Kilometer, kann für jeden weiteren vollen Entfernungskilometer ein zusätzlicher Betrag von 0,30 Euro je Arbeitstag als Werbungskosten angesetzt werden. Für die Bestimmung der Entfernung gilt die kürzeste Straßenverbindung; eine regelmäßig benutzte, offensichtlich verkehrsgünstigere Strecke kann zugrunde gelegt werden. Die Zusatzpauschale ist verkehrsmittelunabhängig. Steuerfreie Arbeitgeberleistungen, insbesondere nach § 3 Nummer 15 und Nummer 32, sind auf die Zusatzpauschale anzurechnen, soweit sie die arbeitstäglichen Mobilitätsaufwendungen insoweit abdecken.“
-
-
-
-  b) Absatz 2 wird wie folgt gefasst:
-
-
-
-„Durch die Pauschalen nach Absatz 1 Satz 3 Nummer 4 und 4a sind sämtliche arbeitstäglichen Aufwendungen des Arbeitnehmers abgegolten; der Ansatz tatsächlicher Aufwendungen ist insoweit ausgeschlossen. Absatz 2a bleibt unberührt.“
-
-
-
-  c) Nach Absatz 2 wird folgender Absatz 2a eingefügt:
-
-
-
-„Für vorübergehende berufliche Tätigkeiten an einem anderen Ort als dem oder den regelmäßig arbeitstäglich aufgesuchten Arbeitsorten findet die Arbeitstagepauschale nach Absatz 1 Satz 3 Nummer 4 keine Anwendung. In diesen Fällen sind die tatsächlichen Aufwendungen für Fahrten, Übernachtungen und sonstige Reisenebenkosten als Werbungskosten anzusetzen; bei der Benutzung eines privaten Beförderungsmittels können die Fahrtkosten mit den pauschalen Kilometersätzen angesetzt werden, die als höchste Wegstreckenentschädigung nach dem Bundesreisekostengesetz festgesetzt sind.“
-
-
-
-  d) Absatz 4 wird wie folgt gefasst:
-
-
-
- „Regelmäßig arbeitstäglich aufgesuchter Arbeitsort ist der Ort oder sind die Orte, die der Arbeitnehmer nach den dienst- oder arbeitsrechtlichen Festlegungen sowie den diese ausfüllenden Absprachen und Weisungen zur Aufnahme seiner beruflichen Tätigkeit dauerhaft typischerweise arbeitstäglich aufsucht. Fehlt eine solche Festlegung oder ist sie nicht eindeutig, gilt als regelmäßig arbeitstäglich aufgesuchter Arbeitsort der Ort, an dem der Arbeitnehmer dauerhaft je Arbeitswoche zwei volle Arbeitstage oder mindestens ein Drittel seiner vereinbarten regelmäßigen Arbeitszeit tätig werden soll. Bei einem weiträumigen Tätigkeitsgebiet gilt als regelmäßig arbeitstäglich aufgesuchter Arbeitsort der der Wohnung des Arbeitnehmers nächstgelegene Zugang zu diesem Gebiet. Je Dienstverhältnis können mehrere regelmäßig arbeitstäglich aufgesuchte Arbeitsorte vorliegen.“
-
-
-
-  e) Absatz 4a wird wie folgt gefasst:
-
-
-
-„Mehraufwendungen des Arbeitnehmers für die Verpflegung sind nur nach Maßgabe der folgenden Sätze als Werbungskosten abziehbar. Wird der Arbeitnehmer außerhalb seiner Wohnung und der regelmäßig arbeitstäglich aufgesuchten Arbeitsorte beruflich tätig (auswärtige berufliche Tätigkeit), ist zur Abgeltung der ihm tatsächlich entstandenen, beruflich veranlassten Mehraufwendungen eine Verpflegungspauschale anzusetzen. Diese beträgt
+Mehraufwendungen des Arbeitnehmers für die Verpflegung sind nur nach Maßgabe der folgenden Sätze als Werbungskosten abziehbar. Wird der Arbeitnehmer außerhalb seiner Wohnung und der regelmäßig arbeitstäglich aufgesuchten Arbeitsorte beruflich tätig (auswärtige berufliche Tätigkeit), ist zur Abgeltung der ihm tatsächlich entstandenen, beruflich veranlassten Mehraufwendungen eine Verpflegungspauschale anzusetzen. Diese beträgt
 
 1. 28 Euro für jeden Kalendertag, an dem der Arbeitnehmer 24 Stunden von seiner Wohnung und den regelmäßig arbeitstäglich aufgesuchten Arbeitsorten abwesend ist,
+
 2. jeweils 14 Euro für den An- und Abreisetag, wenn der Arbeitnehmer an diesem, einem anschließenden oder vorhergehenden Tag außerhalb seiner Wohnung übernachtet,
-3. 14 Euro für den Kalendertag, an dem der Arbeitnehmer ohne Übernachtung außerhalb seiner Wohnung mehr als 8 Stunden von seiner Wohnung und den regelmäßig arbeitstäglich aufgesuchten Arbeitsorten abwesend ist; beginnt die auswärtige berufliche Tätigkeit an einem Kalendertag und endet am nachfolgenden Kalendertag ohne Übernachtung, werden 14 Euro für den Kalendertag gewährt, an dem der Arbeitnehmer den überwiegenden Teil der insgesamt mehr als 8 Stunden von seiner Wohnung und den regelmäßig arbeitstäglich aufgesuchten Arbeitsorten abwesend ist.
+
+3. 14 Euro für den Kalendertag, an dem der Arbeitnehmer ohne Übernachtung außerhalb seiner Wohnung mehr als 8 Stunden von seiner Wohnung und den regelmäßig arbeitstäglich aufgesuchten Arbeitsorten abwesend ist; beginnt die auswärtige berufliche Tätigkeit an einem Kalendertag und endet am nachfolgenden Kalendertag ohne Übernachtung, werden 14 Euro für den Kalendertag gewährt, an dem der Arbeitnehmer den überwiegenden Teil der insgesamt mehr als 8 Stunden von seiner Wohnung und den regelmäßig arbeitstäglich aufgesuchten Arbeitsorten abwesend ist. 
 
 Hat der Arbeitnehmer keinen regelmäßig arbeitstäglich aufgesuchten Arbeitsort, gelten die Sätze 2 und 3 entsprechend; Wohnung im Sinne der Sätze 2 und 3 ist der Hausstand, der den Mittelpunkt der Lebensinteressen des Arbeitnehmers bildet sowie eine Unterkunft am Ort der beruflichen Tätigkeit im Rahmen der doppelten Haushaltsführung. Bei einer Tätigkeit im Ausland treten an die Stelle der Pauschbeträge nach Satz 3 länderweise unterschiedliche Pauschbeträge, die für die Fälle der Nummer 1 mit 120 sowie der Nummern 2 und 3 mit 80 Prozent der Auslandstagegelder nach dem Bundesreisekostengesetz vom Bundesministerium der Finanzen im Einvernehmen mit den obersten Finanzbehörden der Länder aufgerundet auf volle Euro festgesetzt werden; dabei bestimmt sich der Pauschbetrag nach dem Ort, den der Arbeitnehmer vor 24 Uhr Ortszeit zuletzt erreicht, oder, wenn dieser Ort im Inland liegt, nach dem letzten Tätigkeitsort im Ausland. Der Abzug der Verpflegungspauschalen ist auf die ersten drei Monate einer längerfristigen beruflichen Tätigkeit an derselben Tätigkeitsstätte beschränkt. Eine Unterbrechung der beruflichen Tätigkeit an derselben Tätigkeitsstätte führt zu einem Neubeginn, wenn sie mindestens vier Wochen dauert. Wird dem Arbeitnehmer anlässlich oder während einer Tätigkeit außerhalb der regelmäßig arbeitstäglich aufgesuchten Arbeitsorte vom Arbeitgeber oder auf dessen Veranlassung von einem Dritten eine Mahlzeit zur Verfügung gestellt, sind die nach den Sätzen 3 und 5 ermittelten Verpflegungspauschalen zu kürzen:
 
 1. für Frühstück um 20 Prozent,
+
 2. für Mittag- und Abendessen um jeweils 40 Prozent,
 
-der nach Satz 3 Nummer 1 gegebenenfalls in Verbindung mit Satz 5 maßgebenden Verpflegungspauschale für einen vollen Kalendertag; die Kürzung darf die ermittelte Verpflegungspauschale nicht übersteigen. Satz 8 gilt auch, wenn Reisekostenvergütungen wegen der zur Verfügung gestellten Mahlzeiten einbehalten oder gekürzt werden oder die Mahlzeiten nach § 40 Absatz 2 Satz 1 Nummer 1a pauschal besteuert werden. Hat der Arbeitnehmer für die Mahlzeit ein Entgelt gezahlt, mindert dieser Betrag den Kürzungsbetrag nach Satz 8. Erhält der Arbeitnehmer steuerfreie Erstattungen für Verpflegung, ist ein Werbungskostenabzug insoweit ausgeschlossen. Die Verpflegungspauschalen nach den Sätzen 3 und 5, die Dreimonatsfrist nach den Sätzen 6 und 7 sowie die Kürzungsregelungen nach den Sätzen 8 bis 10 gelten entsprechend auch für den Abzug von Mehraufwendungen für Verpflegung, die bei einer beruflich veranlassten doppelten Haushaltsführung entstehen, soweit der Arbeitnehmer vom eigenen Hausstand im Sinne des § 9 Absatz 1 Satz 3 Nummer 5 abwesend ist; dabei ist für jeden Kalendertag innerhalb der Dreimonatsfrist, an dem gleichzeitig eine Tätigkeit im Sinne des Satzes 2 oder des Satzes 4 ausgeübt wird, nur der jeweils höchste in Betracht kommende Pauschbetrag abziehbar. Die Dauer einer Tätigkeit im Sinne des Satzes 2 an dem Tätigkeitsort, an dem die doppelte Haushaltsführung begründet wurde, ist auf die Dreimonatsfrist anzurechnen, wenn sie ihr unmittelbar vorausgegangen ist.“
+der nach Satz 3 Nummer 1 gegebenenfalls in Verbindung mit Satz 5 maßgebenden Verpflegungspauschale für einen vollen Kalendertag; die Kürzung darf die ermittelte Verpflegungspauschale nicht übersteigen. Satz 8 gilt auch, wenn Reisekostenvergütungen wegen der zur Verfügung gestellten Mahlzeiten einbehalten oder gekürzt werden oder die Mahlzeiten nach § 40 Absatz 2 Satz 1 Nummer 1a pauschal besteuert werden. Hat der Arbeitnehmer für die Mahlzeit ein Entgelt gezahlt, mindert dieser Betrag den Kürzungsbetrag nach Satz 8. Erhält der Arbeitnehmer steuerfreie Erstattungen für Verpflegung, ist ein Werbungskostenabzug insoweit ausgeschlossen. Die Verpflegungspauschalen nach den Sätzen 3 und 5, die Dreimonatsfrist nach den Sätzen 6 und 7 sowie die Kürzungsregelungen nach den Sätzen 8 bis 10 gelten entsprechend auch für den Abzug von Mehraufwendungen für Verpflegung, die bei einer beruflich veranlassten doppelten Haushaltsführung entstehen, soweit der Arbeitnehmer vom eigenen Hausstand im Sinne des § 9 Absatz 1 Satz 3 Nummer 5 abwesend ist; dabei ist für jeden Kalendertag innerhalb der Dreimonatsfrist, an dem gleichzeitig eine Tätigkeit im Sinne des Satzes 2 oder des Satzes 4 ausgeübt wird, nur der jeweils höchste in Betracht kommende Pauschbetrag abziehbar. Die Dauer einer Tätigkeit im Sinne des Satzes 2 an dem Tätigkeitsort, an dem die doppelte Haushaltsführung begründet wurde, ist auf die Dreimonatsfrist anzurechnen, wenn sie ihr unmittelbar vorausgegangen ist.
+
+
+§ 9 Abs. 5 EStG
+
+Geplante Fassung
+§ 4 Absatz 5 Satz 1 Nummer 1 bis 4, 7 bis 8a, 10, 12 und Absatz 6 gilt sinngemäß. Die §§ 4j, 4k, 6 Absatz 1 Nummer 1a und § 6e gelten entsprechend.
 
 
 
-  f) Absatz 5 wird wie folgt gefasst:
+§ 3 Nr. 15 EStG
+
+Geplante Fassung
+Zuschüsse des Arbeitgebers, die zusätzlich zum ohnehin geschuldeten Arbeitslohn zu den Aufwendungen des Arbeitnehmers für Fahrten mit öffentlichen Verkehrsmitteln im Linienverkehr (ohne Luftverkehr) zwischen Wohnung und regelmäßig arbeitstäglich aufgesuchtem Arbeitsort sowie für Fahrten im öffentlichen Personennahverkehr gezahlt werden. Das Gleiche gilt für die unentgeltliche oder verbilligte Nutzung öffentlicher Verkehrsmittel im Linienverkehr (ohne Luftverkehr) für Fahrten zwischen Wohnung und regelmäßig arbeitstäglich aufgesuchtem Arbeitsort sowie für Fahrten im öffentlichen Personennahverkehr, die der Arbeitnehmer auf Grund seines Dienstverhältnisses zusätzlich zum ohnehin geschuldeten Arbeitslohn in Anspruch nehmen kann. Die nach den Sätzen 1 und 2 steuerfreien Leistungen mindern den nach § 9 Absatz 1 Satz 3 Nummer 4 und Nummer 4b abziehbaren Betrag;
 
 
-
-„§ 4 Absatz 5 Satz 1 Nummer 1 bis 4, 7 bis 8a, 10, 12 und Absatz 6 gilt sinngemäß. Die §§ 4j, 4k, 6 Absatz 1 Nummer 1a und § 6e gelten entsprechend.“
-
-
-
-2. § 3 wird wie folgt geändert:
+§ 3 Nr. 32 EStG
+Geplante Fassung
+die unentgeltliche oder verbilligte Sammelbeförderung eines Arbeitnehmers zwischen Wohnung und regelmäßig arbeitstäglich aufgesuchtem Arbeitsort sowie bei Fahrten im Sinne des § 9 Absatz 2a mit einem vom Arbeitgeber gestellten Beförderungsmittel, soweit die Sammelbeförderung für den betrieblichen Einsatz des Arbeitnehmers notwendig ist;
 
 
-
-  a) Nummer 15 wird wie folgt gefasst:
-
-
-
-„Zuschüsse des Arbeitgebers, die zusätzlich zum ohnehin geschuldeten Arbeitslohn zu den Aufwendungen des Arbeitnehmers für Fahrten mit öffentlichen Verkehrsmitteln im Linienverkehr (ohne Luftverkehr) zwischen Wohnung und regelmäßig arbeitstäglich aufgesuchtem Arbeitsort sowie für Fahrten im öffentlichen Personennahverkehr gezahlt werden. Das Gleiche gilt für die unentgeltliche oder verbilligte Nutzung öffentlicher Verkehrsmittel im Linienverkehr (ohne Luftverkehr) für Fahrten zwischen Wohnung und regelmäßig arbeitstäglich aufgesuchtem Arbeitsort sowie für Fahrten im öffentlichen Personennahverkehr, die der Arbeitnehmer auf Grund seines Dienstverhältnisses zusätzlich zum ohnehin geschuldeten Arbeitslohn in Anspruch nehmen kann. Die nach den Sätzen 1 und 2 steuerfreien Leistungen mindern den nach § 9 Absatz 1 Satz 3 Nummer 4 und Nummer 4b abziehbaren Betrag;“
+§ 4 Abs. 5 S. 1 Nr. 6 EStG
+Geplante Fassung
+Aufwendungen für die Wege des Steuerpflichtigen zwischen Wohnung und Betriebsstätte und für Familienheimfahrten, soweit in den folgenden Sätzen nichts anderes bestimmt ist. Zur Abgeltung dieser Aufwendungen ist § 9 Absatz 1 Satz 3 Nummer 4 und Absatz 2 entsprechend anzuwenden; für Familienheimfahrten gilt § 9 Absatz 1 Satz 3 Nummer 5 Satz 5 bis 7 und Absatz 2 entsprechend; § 9 Absatz 1 Satz 3 Nummer 4a findet keine Anwendung. Bei der Nutzung eines Kraftfahrzeugs dürfen die Aufwendungen in Höhe des positiven Unterschiedsbetrags zwischen 0,03 Prozent des inländischen Listenpreises im Sinne des § 6 Absatz 1 Nummer 4 Satz 2 des Kraftfahrzeugs im Zeitpunkt der Erstzulassung je Kalendermonat für jeden Entfernungskilometer und dem sich nach § 9 Absatz 1 Satz 3 Nummer 4 oder Absatz 2 ergebenden Betrag sowie Aufwendungen für Familienheimfahrten in Höhe des positiven Unterschiedsbetrags zwischen 0,002 Prozent des inländischen Listenpreises im Sinne des § 6 Absatz 1 Nummer 4 Satz 2 für jeden Entfernungskilometer und dem sich nach § 9 Absatz 1 Satz 3 Nummer 5 Satz 5 bis 7 oder Absatz 2 ergebenden Betrag den Gewinn nicht mindern; ermittelt der Steuerpflichtige die private Nutzung des Kraftfahrzeugs nach § 6 Absatz 1 Nummer 4 Satz 1 oder Satz 3, treten an die Stelle des mit 0,03 oder 0,002 Prozent des inländischen Listenpreises ermittelten Betrags für Fahrten zwischen Wohnung und Betriebsstätte und für Familienheimfahrten die auf diese Fahrten entfallenden tatsächlichen Aufwendungen; § 6 Absatz 1 Nummer 4 Satz 3 zweiter Halbsatz gilt sinngemäß.
 
 
-
-  b) Nummer 32 wird wie folgt gefasst:
-
-
-
- „die unentgeltliche oder verbilligte Sammelbeförderung eines Arbeitnehmers zwischen Wohnung und regelmäßig arbeitstäglich aufgesuchtem Arbeitsort sowie bei Fahrten im Sinne des § 9 Absatz 2a mit einem vom Arbeitgeber gestellten Beförderungsmittel, soweit die Sammelbeförderung für den betrieblichen Einsatz des Arbeitnehmers notwendig ist;“
+§ 4 Abs. 5 S. 1 Nr. 6b EStG
+Geplante Fassung
+Aufwendungen für ein häusliches Arbeitszimmer sowie die Kosten der Ausstattung. Dies gilt nicht, wenn das Arbeitszimmer den Mittelpunkt der gesamten betrieblichen und beruflichen Betätigung bildet.
 
 
+§ 4 Abs. 5 S. 1 Nr. 6c EStG
 
-3. § 4 Abs. 5 S. 1 wird wie folgt geändert:
+Geplante Fassung
+(aufgehoben)
 
-a) Nummer 6 wird wie folgt gefasst:
-
-„Aufwendungen für die Wege des Steuerpflichtigen zwischen Wohnung und Betriebsstätte und für Familienheimfahrten, soweit in den folgenden Sätzen nichts anderes bestimmt ist. Zur Abgeltung dieser Aufwendungen ist § 9 Absatz 1 Satz 3 Nummer 4 und Absatz 2 entsprechend anzuwenden; für Familienheimfahrten gilt § 9 Absatz 1 Satz 3 Nummer 5 Satz 5 bis 7 und Absatz 2 entsprechend; § 9 Absatz 1 Satz 3 Nummer 4a findet keine Anwendung. Bei der Nutzung eines Kraftfahrzeugs dürfen die Aufwendungen in Höhe des positiven Unterschiedsbetrags zwischen 0,03 Prozent des inländischen Listenpreises im Sinne des § 6 Absatz 1 Nummer 4 Satz 2 des Kraftfahrzeugs im Zeitpunkt der Erstzulassung je Kalendermonat für jeden Entfernungskilometer und dem sich nach § 9 Absatz 1 Satz 3 Nummer 4 oder Absatz 2 ergebenden Betrag sowie Aufwendungen für Familienheimfahrten in Höhe des positiven Unterschiedsbetrags zwischen 0,002 Prozent des inländischen Listenpreises im Sinne des § 6 Absatz 1 Nummer 4 Satz 2 für jeden Entfernungskilometer und dem sich nach § 9 Absatz 1 Satz 3 Nummer 5 Satz 5 bis 7 oder Absatz 2 ergebenden Betrag den Gewinn nicht mindern; ermittelt der Steuerpflichtige die private Nutzung des Kraftfahrzeugs nach § 6 Absatz 1 Nummer 4 Satz 1 oder Satz 3, treten an die Stelle des mit 0,03 oder 0,002 Prozent des inländischen Listenpreises ermittelten Betrags für Fahrten zwischen Wohnung und Betriebsstätte und für Familienheimfahrten die auf diese Fahrten entfallenden tatsächlichen Aufwendungen; § 6 Absatz 1 Nummer 4 Satz 3 zweiter Halbsatz gilt sinngemäß.“
-
-  	b) Nummer 6b wird wie folgt gefasst:
-
- „Aufwendungen für ein häusliches Arbeitszimmer sowie die Kosten der Ausstattung. Dies gilt nicht, wenn das Arbeitszimmer den Mittelpunkt der gesamten betrieblichen und beruflichen Betätigung bildet.“
-
-  	c) Nummer 6c wird aufgehoben.
-
-
-
-
-
-**Artikel 2**
-
-
-
-**Inkrafttreten**
-
-
-
-Dieses Gesetz tritt am Tag nach der Verkündung in Kraft.

--- a/resources/built_in_laws/arbeitstagepauschale_vorschlag.txt
+++ b/resources/built_in_laws/arbeitstagepauschale_vorschlag.txt
@@ -1,0 +1,154 @@
+**Entwurf eines Gesetzes zur Einführung einer Arbeitstagepauschale**
+
+**(ArbeitstagepauschalenG)**
+
+
+
+**Vom 16. Oktober 2025**
+
+
+
+Der Bundestag hat mit Zustimmung des Bundesrates das folgende Gesetz beschlossen:
+
+
+
+Inhaltsübersicht
+
+
+
+Artikel 1 Änderung des Einkommensteuergesetzes
+
+Artikel 2 Inkrafttreten
+
+
+
+
+**Artikel 1**
+
+
+
+**Änderung des Einkommensteuergesetzes**
+
+
+
+Das Einkommensteuergesetz in der Fassung der Bekanntmachung vom 8. Oktober 2009 (BGBl. I S. 3366, 3862), das zuletzt durch Artikel 1 des Gesetzes vom 14. Juli 2025 (BGBl. 2025 I Nr. 161) geändert worden ist, wird wie folgt geändert:
+
+
+
+1. § 9 wird wie folgt geändert:
+
+
+
+  a) Absatz 1 Satz 3 wird wie folgt geändert:
+
+
+
+   aa) Nummer 4 wird wie folgt gefasst:
+
+
+„4. Zur Abgeltung der arbeitstäglichen Aufwendungen eines Arbeitnehmers ist für jeden Tag, an dem der Arbeitnehmer eine berufliche Tätigkeit ausübt, ein Betrag von 8 Euro als Werbungskosten anzusetzen (Arbeitstagepauschale). Die Arbeitstagepauschale erfasst insbesondere Aufwendungen für Wege zwischen Wohnung und den regelmäßig arbeitstäglich aufgesuchten Arbeitsorten sowie Aufwendungen für die berufliche Nutzung der häuslichen Wohnung einschließlich eines häuslichen Arbeitszimmers. Steuerfreie Arbeitgeberleistungen, insbesondere nach § 3 Nummer 15 und Nummer 32, sind auf die Arbeitstagepauschale anzurechnen, soweit sie die arbeitstäglichen Aufwendungen abdecken. Für Tage einer auswärtigen beruflichen Tätigkeit nach Absatz 2a findet Satz 1 keine Anwendung.“
+
+
+
+   bb) Nummer 4a wird wie folgt gefasst.
+
+ „4a. Überschreitet die Entfernung zwischen der Wohnung des Arbeitnehmers und dem von ihm regelmäßig arbeitstäglich aufgesuchten Arbeitsort oder, bei einem weiträumigen Tätigkeitsgebiet, dem der Wohnung nächstgelegenen Zugang zu diesem Gebiet 26 Kilometer, kann für jeden weiteren vollen Entfernungskilometer ein zusätzlicher Betrag von 0,30 Euro je Arbeitstag als Werbungskosten angesetzt werden. Für die Bestimmung der Entfernung gilt die kürzeste Straßenverbindung; eine regelmäßig benutzte, offensichtlich verkehrsgünstigere Strecke kann zugrunde gelegt werden. Die Zusatzpauschale ist verkehrsmittelunabhängig. Steuerfreie Arbeitgeberleistungen, insbesondere nach § 3 Nummer 15 und Nummer 32, sind auf die Zusatzpauschale anzurechnen, soweit sie die arbeitstäglichen Mobilitätsaufwendungen insoweit abdecken.“
+
+
+
+  b) Absatz 2 wird wie folgt gefasst:
+
+
+
+„Durch die Pauschalen nach Absatz 1 Satz 3 Nummer 4 und 4a sind sämtliche arbeitstäglichen Aufwendungen des Arbeitnehmers abgegolten; der Ansatz tatsächlicher Aufwendungen ist insoweit ausgeschlossen. Absatz 2a bleibt unberührt.“
+
+
+
+  c) Nach Absatz 2 wird folgender Absatz 2a eingefügt:
+
+
+
+„Für vorübergehende berufliche Tätigkeiten an einem anderen Ort als dem oder den regelmäßig arbeitstäglich aufgesuchten Arbeitsorten findet die Arbeitstagepauschale nach Absatz 1 Satz 3 Nummer 4 keine Anwendung. In diesen Fällen sind die tatsächlichen Aufwendungen für Fahrten, Übernachtungen und sonstige Reisenebenkosten als Werbungskosten anzusetzen; bei der Benutzung eines privaten Beförderungsmittels können die Fahrtkosten mit den pauschalen Kilometersätzen angesetzt werden, die als höchste Wegstreckenentschädigung nach dem Bundesreisekostengesetz festgesetzt sind.“
+
+
+
+  d) Absatz 4 wird wie folgt gefasst:
+
+
+
+ „Regelmäßig arbeitstäglich aufgesuchter Arbeitsort ist der Ort oder sind die Orte, die der Arbeitnehmer nach den dienst- oder arbeitsrechtlichen Festlegungen sowie den diese ausfüllenden Absprachen und Weisungen zur Aufnahme seiner beruflichen Tätigkeit dauerhaft typischerweise arbeitstäglich aufsucht. Fehlt eine solche Festlegung oder ist sie nicht eindeutig, gilt als regelmäßig arbeitstäglich aufgesuchter Arbeitsort der Ort, an dem der Arbeitnehmer dauerhaft je Arbeitswoche zwei volle Arbeitstage oder mindestens ein Drittel seiner vereinbarten regelmäßigen Arbeitszeit tätig werden soll. Bei einem weiträumigen Tätigkeitsgebiet gilt als regelmäßig arbeitstäglich aufgesuchter Arbeitsort der der Wohnung des Arbeitnehmers nächstgelegene Zugang zu diesem Gebiet. Je Dienstverhältnis können mehrere regelmäßig arbeitstäglich aufgesuchte Arbeitsorte vorliegen.“
+
+
+
+  e) Absatz 4a wird wie folgt gefasst:
+
+
+
+„Mehraufwendungen des Arbeitnehmers für die Verpflegung sind nur nach Maßgabe der folgenden Sätze als Werbungskosten abziehbar. Wird der Arbeitnehmer außerhalb seiner Wohnung und der regelmäßig arbeitstäglich aufgesuchten Arbeitsorte beruflich tätig (auswärtige berufliche Tätigkeit), ist zur Abgeltung der ihm tatsächlich entstandenen, beruflich veranlassten Mehraufwendungen eine Verpflegungspauschale anzusetzen. Diese beträgt
+
+1. 28 Euro für jeden Kalendertag, an dem der Arbeitnehmer 24 Stunden von seiner Wohnung und den regelmäßig arbeitstäglich aufgesuchten Arbeitsorten abwesend ist,
+2. jeweils 14 Euro für den An- und Abreisetag, wenn der Arbeitnehmer an diesem, einem anschließenden oder vorhergehenden Tag außerhalb seiner Wohnung übernachtet,
+3. 14 Euro für den Kalendertag, an dem der Arbeitnehmer ohne Übernachtung außerhalb seiner Wohnung mehr als 8 Stunden von seiner Wohnung und den regelmäßig arbeitstäglich aufgesuchten Arbeitsorten abwesend ist; beginnt die auswärtige berufliche Tätigkeit an einem Kalendertag und endet am nachfolgenden Kalendertag ohne Übernachtung, werden 14 Euro für den Kalendertag gewährt, an dem der Arbeitnehmer den überwiegenden Teil der insgesamt mehr als 8 Stunden von seiner Wohnung und den regelmäßig arbeitstäglich aufgesuchten Arbeitsorten abwesend ist.
+
+Hat der Arbeitnehmer keinen regelmäßig arbeitstäglich aufgesuchten Arbeitsort, gelten die Sätze 2 und 3 entsprechend; Wohnung im Sinne der Sätze 2 und 3 ist der Hausstand, der den Mittelpunkt der Lebensinteressen des Arbeitnehmers bildet sowie eine Unterkunft am Ort der beruflichen Tätigkeit im Rahmen der doppelten Haushaltsführung. Bei einer Tätigkeit im Ausland treten an die Stelle der Pauschbeträge nach Satz 3 länderweise unterschiedliche Pauschbeträge, die für die Fälle der Nummer 1 mit 120 sowie der Nummern 2 und 3 mit 80 Prozent der Auslandstagegelder nach dem Bundesreisekostengesetz vom Bundesministerium der Finanzen im Einvernehmen mit den obersten Finanzbehörden der Länder aufgerundet auf volle Euro festgesetzt werden; dabei bestimmt sich der Pauschbetrag nach dem Ort, den der Arbeitnehmer vor 24 Uhr Ortszeit zuletzt erreicht, oder, wenn dieser Ort im Inland liegt, nach dem letzten Tätigkeitsort im Ausland. Der Abzug der Verpflegungspauschalen ist auf die ersten drei Monate einer längerfristigen beruflichen Tätigkeit an derselben Tätigkeitsstätte beschränkt. Eine Unterbrechung der beruflichen Tätigkeit an derselben Tätigkeitsstätte führt zu einem Neubeginn, wenn sie mindestens vier Wochen dauert. Wird dem Arbeitnehmer anlässlich oder während einer Tätigkeit außerhalb der regelmäßig arbeitstäglich aufgesuchten Arbeitsorte vom Arbeitgeber oder auf dessen Veranlassung von einem Dritten eine Mahlzeit zur Verfügung gestellt, sind die nach den Sätzen 3 und 5 ermittelten Verpflegungspauschalen zu kürzen:
+
+1. für Frühstück um 20 Prozent,
+2. für Mittag- und Abendessen um jeweils 40 Prozent,
+
+der nach Satz 3 Nummer 1 gegebenenfalls in Verbindung mit Satz 5 maßgebenden Verpflegungspauschale für einen vollen Kalendertag; die Kürzung darf die ermittelte Verpflegungspauschale nicht übersteigen. Satz 8 gilt auch, wenn Reisekostenvergütungen wegen der zur Verfügung gestellten Mahlzeiten einbehalten oder gekürzt werden oder die Mahlzeiten nach § 40 Absatz 2 Satz 1 Nummer 1a pauschal besteuert werden. Hat der Arbeitnehmer für die Mahlzeit ein Entgelt gezahlt, mindert dieser Betrag den Kürzungsbetrag nach Satz 8. Erhält der Arbeitnehmer steuerfreie Erstattungen für Verpflegung, ist ein Werbungskostenabzug insoweit ausgeschlossen. Die Verpflegungspauschalen nach den Sätzen 3 und 5, die Dreimonatsfrist nach den Sätzen 6 und 7 sowie die Kürzungsregelungen nach den Sätzen 8 bis 10 gelten entsprechend auch für den Abzug von Mehraufwendungen für Verpflegung, die bei einer beruflich veranlassten doppelten Haushaltsführung entstehen, soweit der Arbeitnehmer vom eigenen Hausstand im Sinne des § 9 Absatz 1 Satz 3 Nummer 5 abwesend ist; dabei ist für jeden Kalendertag innerhalb der Dreimonatsfrist, an dem gleichzeitig eine Tätigkeit im Sinne des Satzes 2 oder des Satzes 4 ausgeübt wird, nur der jeweils höchste in Betracht kommende Pauschbetrag abziehbar. Die Dauer einer Tätigkeit im Sinne des Satzes 2 an dem Tätigkeitsort, an dem die doppelte Haushaltsführung begründet wurde, ist auf die Dreimonatsfrist anzurechnen, wenn sie ihr unmittelbar vorausgegangen ist.“
+
+
+
+  f) Absatz 5 wird wie folgt gefasst:
+
+
+
+„§ 4 Absatz 5 Satz 1 Nummer 1 bis 4, 7 bis 8a, 10, 12 und Absatz 6 gilt sinngemäß. Die §§ 4j, 4k, 6 Absatz 1 Nummer 1a und § 6e gelten entsprechend.“
+
+
+
+2. § 3 wird wie folgt geändert:
+
+
+
+  a) Nummer 15 wird wie folgt gefasst:
+
+
+
+„Zuschüsse des Arbeitgebers, die zusätzlich zum ohnehin geschuldeten Arbeitslohn zu den Aufwendungen des Arbeitnehmers für Fahrten mit öffentlichen Verkehrsmitteln im Linienverkehr (ohne Luftverkehr) zwischen Wohnung und regelmäßig arbeitstäglich aufgesuchtem Arbeitsort sowie für Fahrten im öffentlichen Personennahverkehr gezahlt werden. Das Gleiche gilt für die unentgeltliche oder verbilligte Nutzung öffentlicher Verkehrsmittel im Linienverkehr (ohne Luftverkehr) für Fahrten zwischen Wohnung und regelmäßig arbeitstäglich aufgesuchtem Arbeitsort sowie für Fahrten im öffentlichen Personennahverkehr, die der Arbeitnehmer auf Grund seines Dienstverhältnisses zusätzlich zum ohnehin geschuldeten Arbeitslohn in Anspruch nehmen kann. Die nach den Sätzen 1 und 2 steuerfreien Leistungen mindern den nach § 9 Absatz 1 Satz 3 Nummer 4 und Nummer 4b abziehbaren Betrag;“
+
+
+
+  b) Nummer 32 wird wie folgt gefasst:
+
+
+
+ „die unentgeltliche oder verbilligte Sammelbeförderung eines Arbeitnehmers zwischen Wohnung und regelmäßig arbeitstäglich aufgesuchtem Arbeitsort sowie bei Fahrten im Sinne des § 9 Absatz 2a mit einem vom Arbeitgeber gestellten Beförderungsmittel, soweit die Sammelbeförderung für den betrieblichen Einsatz des Arbeitnehmers notwendig ist;“
+
+
+
+3. § 4 Abs. 5 S. 1 wird wie folgt geändert:
+
+a) Nummer 6 wird wie folgt gefasst:
+
+„Aufwendungen für die Wege des Steuerpflichtigen zwischen Wohnung und Betriebsstätte und für Familienheimfahrten, soweit in den folgenden Sätzen nichts anderes bestimmt ist. Zur Abgeltung dieser Aufwendungen ist § 9 Absatz 1 Satz 3 Nummer 4 und Absatz 2 entsprechend anzuwenden; für Familienheimfahrten gilt § 9 Absatz 1 Satz 3 Nummer 5 Satz 5 bis 7 und Absatz 2 entsprechend; § 9 Absatz 1 Satz 3 Nummer 4a findet keine Anwendung. Bei der Nutzung eines Kraftfahrzeugs dürfen die Aufwendungen in Höhe des positiven Unterschiedsbetrags zwischen 0,03 Prozent des inländischen Listenpreises im Sinne des § 6 Absatz 1 Nummer 4 Satz 2 des Kraftfahrzeugs im Zeitpunkt der Erstzulassung je Kalendermonat für jeden Entfernungskilometer und dem sich nach § 9 Absatz 1 Satz 3 Nummer 4 oder Absatz 2 ergebenden Betrag sowie Aufwendungen für Familienheimfahrten in Höhe des positiven Unterschiedsbetrags zwischen 0,002 Prozent des inländischen Listenpreises im Sinne des § 6 Absatz 1 Nummer 4 Satz 2 für jeden Entfernungskilometer und dem sich nach § 9 Absatz 1 Satz 3 Nummer 5 Satz 5 bis 7 oder Absatz 2 ergebenden Betrag den Gewinn nicht mindern; ermittelt der Steuerpflichtige die private Nutzung des Kraftfahrzeugs nach § 6 Absatz 1 Nummer 4 Satz 1 oder Satz 3, treten an die Stelle des mit 0,03 oder 0,002 Prozent des inländischen Listenpreises ermittelten Betrags für Fahrten zwischen Wohnung und Betriebsstätte und für Familienheimfahrten die auf diese Fahrten entfallenden tatsächlichen Aufwendungen; § 6 Absatz 1 Nummer 4 Satz 3 zweiter Halbsatz gilt sinngemäß.“
+
+  	b) Nummer 6b wird wie folgt gefasst:
+
+ „Aufwendungen für ein häusliches Arbeitszimmer sowie die Kosten der Ausstattung. Dies gilt nicht, wenn das Arbeitszimmer den Mittelpunkt der gesamten betrieblichen und beruflichen Betätigung bildet.“
+
+  	c) Nummer 6c wird aufgehoben.
+
+
+
+
+
+**Artikel 2**
+
+
+
+**Inkrafttreten**
+
+
+
+Dieses Gesetz tritt am Tag nach der Verkündung in Kraft.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,6 +50,29 @@ def isolated_db(tmp_path, monkeypatch):
 
     monkeypatch.setattr(db, "upsert_session", _upsert_session_with_owner)
 
+    real_insert_law = db.insert_law
+
+    def _insert_law_with_owner(
+        file_name,
+        law_text,
+        owner_user_id=None,
+        is_builtin=False,
+    ):
+        if (
+            owner_user_id is None
+            and not is_builtin
+            and db.get_user_by_id(TEST_USER_ID) is not None
+        ):
+            owner_user_id = TEST_USER_ID
+        return real_insert_law(
+            file_name,
+            law_text,
+            owner_user_id=owner_user_id,
+            is_builtin=is_builtin,
+        )
+
+    monkeypatch.setattr(db, "insert_law", _insert_law_with_owner)
+
     # Authenticate every request as the seeded test user by default.
     app.dependency_overrides[auth_core.get_current_user] = override_current_user
     yield

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -6,6 +6,7 @@ genuine cookie-based login and ownership checks.
 """
 
 import re
+import sqlite3
 
 import pytest
 from fastapi.testclient import TestClient
@@ -200,17 +201,15 @@ def test_regulation_summary_succeeds_for_owned_session(client, monkeypatch):
 
 def test_uploaded_laws_are_private_but_builtin_laws_are_shared(client):
     _login(client, TEST_USER_EMAIL, TEST_USER_PASSWORD)
-    db.insert_law("builtin-law.txt", "shared fixture")
+    db.insert_law("builtin-law.txt", "shared fixture", is_builtin=True)
 
     upload = client.post(
         "/regulations/upload",
         files={"file": ("private-law.txt", b"user a law", "text/plain")},
     )
     assert upload.status_code == 200
-    assert set(client.get("/regulations").json()["files"]) == {
-        "builtin-law.txt",
-        "private-law.txt",
-    }
+    user_a_files = set(client.get("/regulations").json()["files"])
+    assert {"builtin-law.txt", "private-law.txt"}.issubset(user_a_files)
 
     client.post(
         "/auth/users",
@@ -219,7 +218,9 @@ def test_uploaded_laws_are_private_but_builtin_laws_are_shared(client):
     client.post("/auth/logout")
     _login(client, "law-other@example.com", "otherpass")
 
-    assert client.get("/regulations").json()["files"] == ["builtin-law.txt"]
+    user_b_files = set(client.get("/regulations").json()["files"])
+    assert "builtin-law.txt" in user_b_files
+    assert "private-law.txt" not in user_b_files
 
     own_session = client.post("/sessions", json={"llm_model": "test-model"})
     assert own_session.status_code == 200
@@ -244,3 +245,42 @@ def test_uploaded_laws_are_private_but_builtin_laws_are_shared(client):
         files={"file": ("builtin-law.txt", b"shadow builtin", "text/plain")},
     )
     assert builtin_conflict.status_code == 409
+
+
+def test_legacy_ownerless_laws_are_hidden_but_resource_builtins_are_shared(
+    tmp_path,
+    monkeypatch,
+):
+    db_path = tmp_path / "legacy-laws.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        CREATE TABLE laws (
+            document_id INTEGER PRIMARY KEY,
+            file_name TEXT NOT NULL,
+            law_text TEXT NOT NULL,
+            text_length INTEGER NOT NULL,
+            uploaded_at TEXT NOT NULL DEFAULT current_timestamp,
+            owner_user_id INTEGER,
+            is_builtin INTEGER NOT NULL DEFAULT 1
+        )
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO laws (file_name, law_text, text_length, owner_user_id, is_builtin)
+        VALUES ('legacy-upload.txt', 'alter Upload', 12, NULL, 1)
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    monkeypatch.setattr(config.settings, "db_path", db_path)
+    db.init_db()
+
+    visible = set(db.list_law_file_names(owner_user_id=1))
+    assert "legacy-upload.txt" not in visible
+    assert {
+        "arbeitstagepauschale_gueltig.txt",
+        "arbeitstagepauschale_vorschlag.txt",
+    }.issubset(visible)

--- a/tests/test_sessions_status.py
+++ b/tests/test_sessions_status.py
@@ -102,6 +102,66 @@ def test_session_status_exposes_latest_failed_step_message(test_client):
     assert payload["last_failed_message"] is None
 
 
+def test_session_status_reports_failed_norm_addressee_despite_newer_sibling_retries(
+    test_client,
+):
+    session_id, _ = db.upsert_session("STATUS-FAILED-SIBLING-RETRY", "test-model")
+    db.update_session_summary("STATUS-FAILED-SIBLING-RETRY", "Titel", "Zusammenfassung")
+    db.insert_regulation(session_id, "§ 1", "Beschreibung")
+    db.insert_process(
+        session_id,
+        "Prozess A",
+        "Beschreibung Prozess",
+        norm_addressee="administration",
+    )
+    db.insert_llm_answer(
+        session_id=session_id,
+        prompt_id="case_group_development",
+        model="test-model",
+        answer_text="{}",
+        answer_state=db.LLM_ANSWER_STATE_INVALID,
+        state_reason=(
+            "session_update_failed: case group development: expected top-level key "
+            "'prozesse' in LLM response"
+        ),
+        norm_addressee="citizens",
+    )
+    db.insert_llm_answer(
+        session_id=session_id,
+        prompt_id="case_group_development",
+        model="test-model",
+        answer_text="{}",
+        answer_state=db.LLM_ANSWER_STATE_PENDING,
+        state_reason="waiting_for_paired_retry",
+        norm_addressee="administration",
+    )
+    db.insert_llm_answer(
+        session_id=session_id,
+        prompt_id="case_group_development",
+        model="test-model",
+        answer_text="{}",
+        answer_state=db.LLM_ANSWER_STATE_PENDING,
+        state_reason="waiting_for_paired_retry",
+        norm_addressee="business",
+    )
+
+    resp = test_client.get(
+        "/sessions/status", params={"app_session_id": "STATUS-FAILED-SIBLING-RETRY"}
+    )
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["processes_ready"] is True
+    assert payload["case_groups_ready"] is False
+    assert payload["last_failed_step"] == "case_groups"
+    assert payload["last_failed_label"] == "Fallgruppen entwickeln"
+    assert (
+        "Die Antwort für Bürgerinnen und Bürger konnte nicht verarbeitet werden"
+        in payload["last_failed_message"]
+    )
+    assert "expected top-level key 'prozesse'" in payload["last_failed_message"]
+
+
 def test_session_status_treats_empty_process_answer_as_completed_no_op(test_client):
     session_id, _ = db.upsert_session("STATUS-EMPTY-PROCESSES", "test-model")
     db.update_session_summary("STATUS-EMPTY-PROCESSES", "Titel", "Zusammenfassung")


### PR DESCRIPTION
## Summary

Follow-up fixes after merging the containerisation/auth branch into `develop`.

- fixes uploaded law visibility so user uploads stay private and only explicit built-in law pairs are shared
- seeds bundled example law files from `resources/built_in_laws` in both local and Docker runs
- clears stale frontend session/law selections when the backend no longer owns or exposes them
- restores reliable run-all UI state: authenticated SSE, visible failure messages, cancellable active workflow runs, and hidden law upload controls while Step 1 is running
- removes SQLite WAL mode while keeping `busy_timeout`
- normalizes LLM monitor timestamps so persisted and live calls sort consistently
- updates Next / eslint-config-next to `15.5.20`

## Testing

- `npm --prefix frontend test -- --runInBand`
- `npm --prefix frontend run lint -- --max-warnings=0`
- `npm --prefix frontend run build`
- `.venv/bin/python -m pytest`

## Manual check:
- Docker build/run
- login as admin/user
- verify only bundled law pairs plus the current user’s uploads are visible
- start `CCC starten` / run-all and confirm the law upload boxes disappear while `Abbrechen` is shown
- confirm LLM console/run-all failures are visible in the main UI/session menu