### PR TITLE
preserve explicit zero values in backend parsing and print tables in tiles

### DIFF
--- a/backend/core/db.py
+++ b/backend/core/db.py
@@ -2492,7 +2492,11 @@ def get_latest_session() -> dict | None:
     return dict(row)
 
 
-def list_sessions(limit: int = 50, owner_user_id: int | None = None) -> List[dict]:
+def list_sessions(
+    limit: int = 50,
+    owner_user_id: int | None = None,
+    offset: int = 0,
+) -> List[dict]:
     conn = get_conn()
     cur = conn.cursor()
     where = ""
@@ -2500,7 +2504,7 @@ def list_sessions(limit: int = 50, owner_user_id: int | None = None) -> List[dic
     if owner_user_id is not None:
         where = "WHERE s.owner_user_id = ?"
         params.append(int(owner_user_id))
-    params.append(limit)
+    params.extend([limit, offset])
     cur.execute(
         f"""
         SELECT
@@ -2512,7 +2516,7 @@ def list_sessions(limit: int = 50, owner_user_id: int | None = None) -> List[dic
         FROM sessions AS s
         {where}
         ORDER BY s.created_at DESC, s.session_id DESC
-        LIMIT ?
+        LIMIT ? OFFSET ?
         """,
         tuple(params),
     )

--- a/backend/core/parsing.py
+++ b/backend/core/parsing.py
@@ -22,7 +22,7 @@ def parse_optional_number(value: object) -> float | None:
     if value is None:
         return None
     if isinstance(value, bool):
-        return float(int(value))
+        return None
     if isinstance(value, (int, float)):
         return float(value)
     if isinstance(value, str):

--- a/backend/routers/effort.py
+++ b/backend/routers/effort.py
@@ -337,11 +337,12 @@ def _parse_personnel_effort_entries(
             raw_item.get("qualifikation") or raw_item.get("qualification") or ""
         ).strip()
         raw_source = str(raw_item.get("lohnquelle") or "").strip()
-        duration = parse_optional_number(
-            raw_item.get("zeitaufwand_in_min")
-            or raw_item.get("zeitaufwand")
-            or raw_item.get("time_required_in_min")
+        duration_raw, _duration_alias = _value_from_keys(
+            raw_item,
+            "zeitaufwand_in_min",
+            ("zeitaufwand", "time_required_in_min"),
         )
+        duration = parse_optional_number(duration_raw)
         if not raw_qualification:
             # Fully empty placeholder rows (prompt template) are skipped; a row that
             # carries a `lohnquelle` or a time but no `qualifikation` is rejected, so
@@ -453,26 +454,38 @@ def _parse_citizens_effort_entry(entry: dict, step_id: int) -> dict | None:
                     f"unexpected roles array '{key}' for step_id {step_id}"
                 ),
             )
-    time_current = parse_optional_number(
-        entry.get("zeitaufwand_in_min_current")
-        or entry.get("zeitaufwand_in_min_gueltig")
-        or entry.get("time_required_in_min_current")
-        or entry.get("time_required_in_min_gueltig")
+    time_current_raw, _time_current_alias = _value_from_keys(
+        entry,
+        "zeitaufwand_in_min_gueltig",
+        (
+            "zeitaufwand_in_min_current",
+            "time_required_in_min_gueltig",
+            "time_required_in_min_current",
+        ),
     )
-    time_proposed = parse_optional_number(
-        entry.get("zeitaufwand_in_min_proposed")
-        or entry.get("zeitaufwand_in_min_vorschlag")
-        or entry.get("time_required_in_min_proposed")
-        or entry.get("time_required_in_min_vorschlag")
+    time_proposed_raw, _time_proposed_alias = _value_from_keys(
+        entry,
+        "zeitaufwand_in_min_vorschlag",
+        (
+            "zeitaufwand_in_min_proposed",
+            "time_required_in_min_vorschlag",
+            "time_required_in_min_proposed",
+        ),
     )
-    expenses_current = parse_optional_number(
-        entry.get("sachaufwand_current")
-        or entry.get("sachaufwand_gueltig")
+    expenses_current_raw, _expenses_current_alias = _value_from_keys(
+        entry,
+        "sachaufwand_gueltig",
+        ("sachaufwand_current",),
     )
-    expenses_proposed = parse_optional_number(
-        entry.get("sachaufwand_proposed")
-        or entry.get("sachaufwand_vorschlag")
+    expenses_proposed_raw, _expenses_proposed_alias = _value_from_keys(
+        entry,
+        "sachaufwand_vorschlag",
+        ("sachaufwand_proposed",),
     )
+    time_current = parse_optional_number(time_current_raw)
+    time_proposed = parse_optional_number(time_proposed_raw)
+    expenses_current = parse_optional_number(expenses_current_raw)
+    expenses_proposed = parse_optional_number(expenses_proposed_raw)
 
     if (
         time_current is None

--- a/backend/routers/sessions.py
+++ b/backend/routers/sessions.py
@@ -128,6 +128,7 @@ class SessionSummary(BaseModel):
 
 class SessionListResponse(BaseModel):
     sessions: list[SessionSummary]
+    has_more: bool = False
 
 
 class SessionStatusResponse(BaseModel):
@@ -2262,10 +2263,15 @@ async def upsert_session(
 @router.get("", response_model=SessionListResponse)
 async def list_sessions(
     limit: int = Query(default=50, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
     user: AuthUser = Depends(get_current_user),
 ) -> SessionListResponse:
-    sessions = db.list_sessions(limit=limit, owner_user_id=user.user_id)
-    return SessionListResponse(sessions=sessions)
+    rows = db.list_sessions(
+        limit=limit + 1,
+        owner_user_id=user.user_id,
+        offset=offset,
+    )
+    return SessionListResponse(sessions=rows[:limit], has_more=len(rows) > limit)
 
 
 @router.get(

--- a/frontend/src/components/SessionMenu.tsx
+++ b/frontend/src/components/SessionMenu.tsx
@@ -115,6 +115,7 @@ const menuCancellingButtonClass =
 const menuDisabledButtonClass =
   `${menuButtonBaseClass} cursor-not-allowed border border-slate-100 bg-slate-100 text-slate-400`;
 const menuExportButtonClass = `${menuSecondaryButtonClass} disabled:cursor-not-allowed disabled:bg-slate-100 disabled:text-slate-400`;
+const SESSION_PAGE_SIZE = 50;
 
 function isTransientWorkflowStatus(status: string | null): boolean {
   if (!status) {
@@ -153,6 +154,10 @@ export default function SessionMenu({ variant = "default" }: SessionMenuProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [sessions, setSessions] = useState<SessionSummary[]>([]);
   const [selectedSession, setSelectedSession] = useState("");
+  const [isSessionPickerOpen, setIsSessionPickerOpen] = useState(false);
+  const [hasMoreSessions, setHasMoreSessions] = useState(false);
+  const [isLoadingSessions, setIsLoadingSessions] = useState(false);
+  const [isLoadingMoreSessions, setIsLoadingMoreSessions] = useState(false);
   const [isLoadingSession, setIsLoadingSession] = useState(false);
   const [status, setStatus] = useState<string | null>(null);
   const [isUndoing, setIsUndoing] = useState(false);
@@ -252,14 +257,21 @@ export default function SessionMenu({ variant = "default" }: SessionMenuProps) {
     let cancelled = false;
     const loadSessions = async () => {
       try {
-        const payload = await apiClient.listSessions(50);
+        setIsLoadingSessions(true);
+        const payload = await apiClient.listSessions(SESSION_PAGE_SIZE, 0);
         if (!cancelled) {
           setSessions(payload.sessions);
+          setHasMoreSessions(Boolean(payload.has_more));
         }
       } catch (error) {
         logClientError("SessionMenu.loadSessions", error);
         if (!cancelled) {
           setSessions([]);
+          setHasMoreSessions(false);
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoadingSessions(false);
         }
       }
     };
@@ -272,6 +284,9 @@ export default function SessionMenu({ variant = "default" }: SessionMenuProps) {
 
   useEffect(() => {
     setSelectedSession(isOpen ? state.appSessionId : "");
+    if (!isOpen) {
+      setIsSessionPickerOpen(false);
+    }
   }, [isOpen, state.appSessionId]);
 
   useEffect(() => {
@@ -309,6 +324,15 @@ export default function SessionMenu({ variant = "default" }: SessionMenuProps) {
       };
     });
   }, [sessions]);
+
+  const selectedSessionLabel = useMemo(() => {
+    return (
+      formattedSessions.find((session) => session.app_session_id === selectedSession)
+        ?.label ||
+      selectedSession ||
+      "Session auswählen"
+    );
+  }, [formattedSessions, selectedSession]);
 
   const getSessionModel = (appSessionId: string): string | null =>
     sessions.find((session) => session.app_session_id === appSessionId)?.llm_model || null;
@@ -438,7 +462,34 @@ export default function SessionMenu({ variant = "default" }: SessionMenuProps) {
 
   const handleSessionSelect = (targetSession: string) => {
     setSelectedSession(targetSession);
+    setIsSessionPickerOpen(false);
     void handleLoadSession(targetSession);
+  };
+
+  const handleLoadMoreSessions = async () => {
+    if (isLoadingMoreSessions || !hasMoreSessions) {
+      return;
+    }
+    try {
+      setIsLoadingMoreSessions(true);
+      const payload = await apiClient.listSessions(
+        SESSION_PAGE_SIZE,
+        sessions.length
+      );
+      setSessions((current) => {
+        const seen = new Set(current.map((session) => session.app_session_id));
+        return [
+          ...current,
+          ...payload.sessions.filter((session) => !seen.has(session.app_session_id)),
+        ];
+      });
+      setHasMoreSessions(Boolean(payload.has_more));
+    } catch (error) {
+      logClientError("SessionMenu.loadMoreSessions", error);
+      setStatus("Weitere Sessions konnten nicht geladen werden.");
+    } finally {
+      setIsLoadingMoreSessions(false);
+    }
   };
 
   const handleUndoLastStep = async () => {
@@ -1067,20 +1118,79 @@ export default function SessionMenu({ variant = "default" }: SessionMenuProps) {
         >
           Neue Session starten
         </button>
-        <select
-          value={selectedSession}
-          onChange={(event) => handleSessionSelect(event.target.value)}
-          disabled={isLoadingSession}
-          className="w-full rounded-xl border border-slate-200 px-3 py-2 text-xs font-semibold text-slate-700 disabled:cursor-wait disabled:bg-slate-100 disabled:text-slate-400"
-          aria-label="Session wechseln"
-        >
-          <option value="">Session auswählen</option>
-          {formattedSessions.map((session) => (
-            <option key={session.app_session_id} value={session.app_session_id}>
-              {session.label}
-            </option>
-          ))}
-        </select>
+        <div className="relative">
+          <button
+            type="button"
+            onClick={() => setIsSessionPickerOpen((open) => !open)}
+            disabled={isLoadingSession}
+            className="flex w-full items-center justify-between gap-2 rounded-xl border border-slate-200 px-3 py-2 text-left text-xs font-semibold text-slate-700 transition hover:bg-slate-50 disabled:cursor-wait disabled:bg-slate-100 disabled:text-slate-400"
+            aria-haspopup="listbox"
+            aria-expanded={isSessionPickerOpen}
+            aria-label="Session wechseln"
+          >
+            <span className="min-w-0 truncate">{selectedSessionLabel}</span>
+            <span className="shrink-0 text-slate-500" aria-hidden="true">
+              {isSessionPickerOpen ? "⌃" : "⌄"}
+            </span>
+          </button>
+          {isSessionPickerOpen && (
+            <div
+              role="listbox"
+              aria-label="Verfügbare Sessions"
+              className="mt-2 max-h-[280px] overflow-y-auto rounded-xl border border-slate-200 bg-white p-1 shadow-lg"
+            >
+              <div className="space-y-0.5">
+                {isLoadingSessions ? (
+                  <div className="px-3 py-2 text-xs font-semibold text-slate-400">
+                    Sessions werden geladen...
+                  </div>
+                ) : formattedSessions.length === 0 ? (
+                  <div className="px-3 py-2 text-xs font-semibold text-slate-400">
+                    Keine Sessions gefunden.
+                  </div>
+                ) : (
+                  formattedSessions.map((session) => {
+                    const isSelected = session.app_session_id === selectedSession;
+                    return (
+                      <button
+                        key={session.app_session_id}
+                        type="button"
+                        role="option"
+                        aria-selected={isSelected}
+                        onClick={() => handleSessionSelect(session.app_session_id)}
+                        disabled={isLoadingSession}
+                        className={`flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-[11px] font-semibold transition ${
+                          isSelected
+                            ? "bg-slate-100 text-slate-900"
+                            : "text-slate-700 hover:bg-slate-50"
+                        } disabled:cursor-wait disabled:text-slate-400`}
+                      >
+                        <span className="w-4 shrink-0 text-center text-slate-500">
+                          {isSelected ? "✓" : ""}
+                        </span>
+                        <span className="min-w-0 truncate">{session.label}</span>
+                      </button>
+                    );
+                  })
+                )}
+              </div>
+              {hasMoreSessions && (
+                <div className="sticky bottom-0 mt-1 bg-white pt-1">
+                  <button
+                    type="button"
+                    onClick={handleLoadMoreSessions}
+                    disabled={isLoadingMoreSessions}
+                    className="w-full rounded-lg border border-slate-200 bg-slate-50 px-2 py-1.5 text-xs font-semibold text-slate-700 transition hover:bg-slate-100 disabled:cursor-wait disabled:text-slate-400"
+                  >
+                    {isLoadingMoreSessions
+                      ? "Weitere Sessions werden geladen..."
+                      : "Weitere Sessions laden"}
+                  </button>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
       </div>
       <div className="mt-4 space-y-2 border-t border-slate-100 pt-3">
         <div className={menuSectionLabelClass}>

--- a/frontend/src/components/__tests__/SessionMenu.test.tsx
+++ b/frontend/src/components/__tests__/SessionMenu.test.tsx
@@ -212,6 +212,11 @@ describe("SessionMenu", () => {
     return user;
   }
 
+  async function chooseSession(user: ReturnType<typeof userEvent.setup>, sessionId: string) {
+    await user.click(screen.getByRole("button", { name: "Session wechseln" }));
+    await user.click(screen.getByRole("option", { name: new RegExp(sessionId) }));
+  }
+
   it("rebuilds the selected norm addressee after loading another session", async () => {
     mockGetSessionStatus.mockImplementation((appSessionId: string) =>
       Promise.resolve(
@@ -243,7 +248,7 @@ describe("SessionMenu", () => {
     const user = await openMenu();
 
     await waitFor(() => expect(mockListSessions).toHaveBeenCalled());
-    await user.selectOptions(screen.getByRole("combobox"), "XYZ789");
+    await chooseSession(user, "XYZ789");
 
     await waitFor(() =>
       expect(mockRebuildTiles).toHaveBeenCalledWith("XYZ789", "business")
@@ -558,10 +563,11 @@ describe("SessionMenu", () => {
     const user = await openMenu();
 
     await waitFor(() => expect(mockListSessions).toHaveBeenCalled());
-    const select = screen.getByRole("combobox");
-    expect(select).toHaveValue("ABC123");
+    expect(screen.getByRole("button", { name: "Session wechseln" })).toHaveTextContent(
+      "ABC123"
+    );
 
-    await user.selectOptions(select, "XYZ789");
+    await chooseSession(user, "XYZ789");
 
     await waitFor(() =>
       expect(mockGetSessionStatus).toHaveBeenCalledWith("XYZ789")
@@ -576,7 +582,48 @@ describe("SessionMenu", () => {
 
     await user.click(screen.getByTitle("Session Aktionen"));
     await screen.findByText("Session Aktionen");
-    expect(screen.getByRole("combobox")).toHaveValue("ABC123");
+    expect(screen.getByRole("button", { name: "Session wechseln" })).toHaveTextContent(
+      "ABC123"
+    );
+  });
+
+  it("loads additional sessions from the picker", async () => {
+    mockListSessions
+      .mockResolvedValueOnce({
+        sessions: [
+          {
+            app_session_id: "ABC123",
+            created_at: "2026-04-14T08:00:00Z",
+            llm_model: "gpt-5.4",
+            used_llm_models: "gpt-5.4",
+          },
+        ],
+        has_more: true,
+      })
+      .mockResolvedValueOnce({
+        sessions: [
+          {
+            app_session_id: "OLDER1",
+            created_at: "2026-04-13T08:00:00Z",
+            llm_model: "gemini-3.5-flash",
+            used_llm_models: "gemini-3.5-flash",
+          },
+        ],
+        has_more: false,
+      });
+    const user = await openMenu();
+
+    await user.click(screen.getByRole("button", { name: "Session wechseln" }));
+    await user.click(
+      await screen.findByRole("button", { name: "Weitere Sessions laden" })
+    );
+
+    expect(mockListSessions).toHaveBeenNthCalledWith(1, 50, 0);
+    expect(mockListSessions).toHaveBeenNthCalledWith(2, 50, 1);
+    expect(await screen.findByRole("option", { name: /OLDER1/ })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Weitere Sessions laden" })
+    ).not.toBeInTheDocument();
   });
 
   it("does not commit a session switch when rebuilding tiles fails", async () => {
@@ -611,7 +658,7 @@ describe("SessionMenu", () => {
     const user = await openMenu();
 
     await waitFor(() => expect(mockListSessions).toHaveBeenCalled());
-    await user.selectOptions(screen.getByRole("combobox"), "XYZ789");
+    await chooseSession(user, "XYZ789");
 
     await waitFor(() =>
       expect(mockRebuildTiles).toHaveBeenCalledWith("XYZ789", "business")
@@ -620,7 +667,9 @@ describe("SessionMenu", () => {
     expect(applySessionStatus).not.toHaveBeenCalledWith(
       expect.objectContaining({ total_cost_ready: true })
     );
-    expect(screen.getByRole("combobox")).toHaveValue("ABC123");
+    expect(screen.getByRole("button", { name: "Session wechseln" })).toHaveTextContent(
+      "ABC123"
+    );
     expect(
       await screen.findByText("Session konnte nicht geladen werden.")
     ).toBeInTheDocument();

--- a/frontend/src/components/__tests__/tileMetrics.test.ts
+++ b/frontend/src/components/__tests__/tileMetrics.test.ts
@@ -335,11 +335,14 @@ describe("tileMetrics", () => {
     });
 
     const table = buildTileMetricTable(tile);
-    expect(table?.rows.map((row) => row.label)).toEqual([
-      "Länder - gD",
-      "Bund - hD",
-      "Kosten/Jahr",
-    ]);
+    expect(table).toMatchObject({
+      variant: "table",
+      rows: [
+        { label: "Länder - gD" },
+        { label: "Bund - hD" },
+        { label: "Kosten/Jahr" },
+      ],
+    });
   });
 
   it("prefers personnel_rows over stale slot time on the step metric table", () => {
@@ -356,6 +359,7 @@ describe("tileMetrics", () => {
     });
 
     const table = buildTileMetricTable(tile, "business");
+    expect(table).toMatchObject({ variant: "table" });
     expect(table?.rows.map((row) => row.label)).toEqual(["R - Mittel"]);
     expect(table?.rows[0].current).toContain("12");
     expect(table?.rows[0].current).not.toContain("999");

--- a/frontend/src/components/tileMetrics.ts
+++ b/frontend/src/components/tileMetrics.ts
@@ -601,7 +601,7 @@ export function buildTileMetricTable(
     if (usePersonnel) {
       // Meta is authoritative here; do not merge the free-text fallback.
       const orderedRows = orderRows(rows, order);
-      return orderedRows.length > 0 ? { rows: orderedRows } : null;
+      return orderedRows.length > 0 ? buildTableMetricTable(orderedRows) : null;
     }
     const fallbackRows = parseLegacyStepText(tile.text || "").rows;
     const mergedRows = orderRows(mergeRows(rows, fallbackRows), order);

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -395,8 +395,12 @@ export const apiClient = {
     return response.json();
   },
 
-  async listSessions(limit = 50): Promise<SessionsResponse> {
-    const response = await fetch(`${API_BASE_URL}/sessions?limit=${limit}`, {
+  async listSessions(limit = 50, offset = 0): Promise<SessionsResponse> {
+    const params = new URLSearchParams({
+      limit: String(limit),
+      offset: String(offset),
+    });
+    const response = await fetch(`${API_BASE_URL}/sessions?${params.toString()}`, {
       credentials: "include",
     });
     if (!response.ok) {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -68,6 +68,7 @@ export interface SessionSummary {
 
 export interface SessionsResponse {
   sessions: SessionSummary[];
+  has_more?: boolean;
 }
 
 export interface SessionStatus {

--- a/tests/test_deep_research_cases.py
+++ b/tests/test_deep_research_cases.py
@@ -85,6 +85,36 @@ def test_parse_deep_research_case_metrics_keeps_legacy_nested_payload():
     assert parsed[0].case_group_id == 81
 
 
+def test_parse_deep_research_case_metrics_preserves_zero_and_ignores_booleans():
+    payload = """
+    {
+      "fallgruppen": [
+        {
+          "normadressat": "citizens",
+          "fallgruppen_id": 81,
+          "anzahl_betroffene_gueltig": 0,
+          "haeufigkeit_pro_jahr_gueltig": false,
+          "anzahl_betroffene_vorschlag": "0,0",
+          "haeufigkeit_pro_jahr_vorschlag": true,
+          "fallzahl_gueltig": "0",
+          "fallzahl_vorschlag": false
+        }
+      ]
+    }
+    """
+
+    _data, parsed = parse_deep_research_case_metrics(payload)
+
+    assert len(parsed) == 1
+    entry = parsed[0]
+    assert entry.addressees_current == 0.0
+    assert entry.annual_frequency_current is None
+    assert entry.addressees_proposed == 0.0
+    assert entry.annual_frequency_proposed is None
+    assert entry.metadata["fallzahl_gueltig"] == 0.0
+    assert entry.metadata["fallzahl_vorschlag"] is None
+
+
 def test_apply_deep_research_flat_payload_uses_db_process_assignment(test_client):
     session_id, _ = db.upsert_session("DR-FLAT", "test-model")
     process_id = db.insert_process(session_id, "Prozess A", "Beschreibung")

--- a/tests/test_sessions_validation.py
+++ b/tests/test_sessions_validation.py
@@ -50,12 +50,33 @@ def test_list_sessions_response_shape(test_client):
     resp = test_client.get("/sessions")
     assert resp.status_code == 200
     payload = resp.json()
-    assert set(payload.keys()) == {"sessions"}
+    assert set(payload.keys()) == {"sessions", "has_more"}
     assert isinstance(payload["sessions"], list)
+    assert isinstance(payload["has_more"], bool)
     assert payload["sessions"]
     first = payload["sessions"][0]
     assert {"app_session_id", "created_at", "llm_model", "used_llm_models"}.issubset(
         first.keys()
+    )
+
+
+def test_list_sessions_supports_offset_pagination(test_client):
+    test_client.post("/sessions", json={"app_session_id": "PAGE01", "llm_model": "gpt-5"})
+    test_client.post("/sessions", json={"app_session_id": "PAGE02", "llm_model": "gpt-5"})
+
+    first_page = test_client.get("/sessions", params={"limit": 1, "offset": 0})
+    assert first_page.status_code == 200
+    first_payload = first_page.json()
+    assert first_payload["has_more"] is True
+    assert len(first_payload["sessions"]) == 1
+
+    second_page = test_client.get("/sessions", params={"limit": 1, "offset": 1})
+    assert second_page.status_code == 200
+    second_payload = second_page.json()
+    assert len(second_payload["sessions"]) == 1
+    assert (
+        second_payload["sessions"][0]["app_session_id"]
+        != first_payload["sessions"][0]["app_session_id"]
     )
 
 

--- a/tests/test_workflow_parser_edges.py
+++ b/tests/test_workflow_parser_edges.py
@@ -3,11 +3,19 @@ from fastapi import HTTPException
 
 from backend.core import db
 from backend.core.norm_addressees import ADMINISTRATION, CITIZENS
+from backend.core.parsing import parse_optional_number
 from backend.core.prompts import PromptId
 from backend.routers import case_groups as case_groups_router
 from backend.routers import effort as effort_router
 from backend.routers import process_steps as process_steps_router
 from backend.routers import processes as processes_router
+
+
+def test_parse_optional_number_rejects_booleans_but_keeps_numeric_one():
+    assert parse_optional_number(False) is None
+    assert parse_optional_number(True) is None
+    assert parse_optional_number(1) == 1.0
+    assert parse_optional_number("1") == 1.0
 
 
 def _seed_process_context(app_session_id: str = "PARSER-PROCESSES") -> tuple[int, int, dict]:
@@ -557,6 +565,34 @@ def test_effort_parser_logs_alias_fallbacks(monkeypatch):
     assert "effort_legacy_english_alias" in fallback_kinds
 
 
+def test_cases_parser_preserves_explicit_zero_case_values():
+    payload = """
+    {
+      "normadressat": "citizens",
+      "fallgruppen": [
+        {
+          "fallgruppen_id": 101,
+          "anzahl_betroffene_gueltig": 0,
+          "haeufigkeit_pro_jahr_gueltig": "0",
+          "anzahl_betroffene_vorschlag": "0.0",
+          "haeufigkeit_pro_jahr_vorschlag": "0,0"
+        }
+      ]
+    }
+    """
+
+    parsed, fallback_kinds = effort_router._parse_cases_payload(payload, CITIZENS)
+
+    assert fallback_kinds == set()
+    assert len(parsed) == 1
+    assert parsed[0]["case_group_id"] == 101
+    assert parsed[0]["addressees_current"] == 0.0
+    assert parsed[0]["annual_frequency_current"] == 0.0
+    assert parsed[0]["addressees_proposed"] == 0.0
+    assert parsed[0]["annual_frequency_proposed"] == 0.0
+    assert parsed[0]["case_metric_research_json"] is None
+
+
 def test_effort_parser_rejects_invalid_cases_json_payload():
     session_id, case_group_id, step_id, context = _seed_effort_context(
         "PARSER-EFFORT-BAD-CASES"
@@ -876,6 +912,141 @@ def test_effort_parser_keeps_row_personnel_effort_model():
     assert parsed_effort[0]["time_required_current"]["b"] == 10
     assert parsed_effort[0]["time_required_proposed"]["c"] == 8
     assert parsed_effort[0]["hourly_rates_current"]["a"] is not None
+
+
+def test_effort_parser_preserves_zero_personnel_duration_rows():
+    payload = """
+    {
+      "normadressat": "administration",
+      "fallgruppen": [
+        {
+          "fallgruppen_id": 10,
+          "taetigkeiten": [
+            {
+              "taetigkeiten_id": 100,
+              "personalaufwand_gueltig": [
+                {
+                  "qualifikation": "einfacher_und_mittlerer_dienst",
+                  "lohnquelle": "bund",
+                  "zeitaufwand_in_min": 0
+                }
+              ],
+              "personalaufwand_vorschlag": [
+                {
+                  "qualifikation": "gehobener_dienst",
+                  "lohnquelle": "bund",
+                  "time_required_in_min": "0,0"
+                }
+              ],
+              "sachaufwand_gueltig": 0,
+              "sachaufwand_vorschlag": "0.0"
+            }
+          ]
+        }
+      ]
+    }
+    """
+
+    parsed, fallback_kinds = effort_router._parse_effort_payload(
+        payload,
+        ADMINISTRATION,
+    )
+
+    assert fallback_kinds == set()
+    assert len(parsed) == 1
+    assert parsed[0]["time_required_current"]["a"] == 0.0
+    assert parsed[0]["time_required_proposed"]["b"] == 0.0
+    assert parsed[0]["expenses_current"] == 0.0
+    assert parsed[0]["expenses_proposed"] == 0.0
+    assert [
+        (row["period"], row["qualification"], row["time_required_in_min"])
+        for row in parsed[0]["personnel_effort_rows"]
+    ] == [
+        ("current", "einfacher_und_mittlerer_dienst", 0.0),
+        ("proposed", "gehobener_dienst", 0.0),
+    ]
+
+
+def test_effort_parser_preserves_zero_citizen_effort_values():
+    payload = """
+    {
+      "normadressat": "citizens",
+      "fallgruppen": [
+        {
+          "fallgruppen_id": 10,
+          "taetigkeiten": [
+            {
+              "taetigkeiten_id": 100,
+              "zeitaufwand_in_min_gueltig": 0,
+              "zeitaufwand_in_min_vorschlag": "0,0",
+              "sachaufwand_gueltig": "0",
+              "sachaufwand_vorschlag": "0.0"
+            }
+          ]
+        }
+      ]
+    }
+    """
+
+    parsed, fallback_kinds = effort_router._parse_effort_payload(payload, CITIZENS)
+
+    assert fallback_kinds == set()
+    assert len(parsed) == 1
+    assert parsed[0]["step_id"] == 100
+    assert parsed[0]["hourly_rates_current"] == {
+        "a": None,
+        "b": None,
+        "c": None,
+        "d": None,
+    }
+    assert parsed[0]["hourly_rates_proposed"] == {
+        "a": None,
+        "b": None,
+        "c": None,
+        "d": None,
+    }
+    assert parsed[0]["time_required_current"] == {
+        "a": 0.0,
+        "b": None,
+        "c": None,
+        "d": None,
+    }
+    assert parsed[0]["time_required_proposed"] == {
+        "a": 0.0,
+        "b": None,
+        "c": None,
+        "d": None,
+    }
+    assert parsed[0]["expenses_current"] == 0.0
+    assert parsed[0]["expenses_proposed"] == 0.0
+    assert parsed[0]["execution_per_case"] is None
+
+
+def test_effort_parser_keeps_blank_citizen_effort_values_missing():
+    payload = """
+    {
+      "normadressat": "citizens",
+      "fallgruppen": [
+        {
+          "fallgruppen_id": 10,
+          "taetigkeiten": [
+            {
+              "taetigkeiten_id": 100,
+              "zeitaufwand_in_min_gueltig": "",
+              "zeitaufwand_in_min_vorschlag": " ",
+              "sachaufwand_gueltig": "",
+              "sachaufwand_vorschlag": ""
+            }
+          ]
+        }
+      ]
+    }
+    """
+
+    parsed, fallback_kinds = effort_router._parse_effort_payload(payload, CITIZENS)
+
+    assert fallback_kinds == set()
+    assert parsed == []
 
 
 def test_process_step_parser_rejects_duplicate_case_group_id():


### PR DESCRIPTION
## Summary

This PR tightens the Step 5/6 prompt-output contract and fixes two follow-up issues found while testing generated effort data and session handling. It fixes issues #74 and #73.

## Changes

- Improves the Step 5/6 and Deep Research prompt/schema flow:
  - uses flat `fallgruppen` output structures where the backend already owns process assignment
  - clarifies prompt wording around required IDs and output shape
  - keeps Deep Research metrics compatible with the flat structure

- Preserves explicit zero values during backend parsing:
  - treats `0`, `0.0`, and `"0"` as deliberate values rather than missing data
  - rejects boolean `true`/`false` as numeric effort/case values
  - adds regression coverage for effort and Deep Research parsing

- Improves session selection:
  - replaces the fixed short session list with a paginated picker
  - adds “Weitere Sessions laden” so older sessions remain reachable without overloading the modal

- Fixes expanded step-tile tables for row-based personnel effort:
  - row-based `personnel_rows` metrics now return the standard table shape
  - expanded Verwaltung/Wirtschaft step tiles now show wage-source rows correctly
  - adds regression coverage for the table variant

## Testing

- Backend parser/session tests updated and run
- Frontend session picker tests updated and run
- Focused tile metric regression added for row-based personnel tables

## Reviewer Hints

1. Start a new session and confirm Deep Research is enabled by default only when a Gemini key is available.
2. Run a session through Step 6 and Step 7 with normal/non-DR mode and check that explicit `0` values stay visible as `0`, not `-` or missing.
3. Expand business/admin step tiles after Step 6 and confirm row-based wage-source tables render, including rows like `G - Ø`, `Bund - gD`, `Länder - hD`.
4. Check citizen step tiles still render their time/sach cost rows normally.
5. Open the session menu with more than 50 sessions and confirm “Weitere Sessions laden” appears and loads older sessions without changing the compact layout.
6. Switch sessions from the expanded picker and confirm the selected session loads correctly.
7. Spot-check a Deep Research run/export if relevant: flat `fallgruppen` output should still parse, and DR metrics should not fail because the old nested `prozesse` key is missing.

Main regression risk: Step 6 parsing/display, especially zeros vs missing values and row-based personnel tables.
